### PR TITLE
Rename bazel_skylib default branch to main.

### DIFF
--- a/note_seq/alignment/WORKSPACE
+++ b/note_seq/alignment/WORKSPACE
@@ -46,8 +46,8 @@ http_archive(
 
 http_archive(
     name = "bazel_skylib",
-    strip_prefix = "bazel-skylib-master",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/master.zip"],
+    strip_prefix = "bazel-skylib-main",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/main.zip"],
 )
 
 


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-skylib/branches and
https://github.com/bazelbuild/bazel-skylib/issues/281.