### PR TITLE
Integer overflow error in PianorollEncoderDecoder after conversion from NoteSequence

### DIFF
--- a/note_seq/pianoroll_lib.py
+++ b/note_seq/pianoroll_lib.py
@@ -198,7 +198,7 @@ class PianorollSequence(events_lib.EventSequence):
         piano_roll[note_start_offset - 1, note_pitch_offset] = 0
       piano_roll[note_start_offset:note_end_offset, note_pitch_offset] = 1
 
-    events = [tuple(np.where(frame)[0]) for frame in piano_roll]
+    events = [tuple(map(int,np.where(frame)[0])) for frame in piano_roll]
 
     return events
 


### PR DESCRIPTION
Currently, when converting a NoteSequence to a PianoRollSequencel, the converter only outputs note pitch's as np.int64, which seems to be inconsistent with most generation methods for both, which store this as an int. In particular though, this causes problems when using the PianorollEncoderDecoder's classes events_to_label and class_index_to_event methods as they have overflow errors for pitches above 84. A minor edit to the output fixes this of _from_quantized_sequence fixes this.