### PR TITLE
Add pdoc autogenerated docs

### DIFF
--- a/docs/abc_parser.html
+++ b/docs/abc_parser.html
@@ -1,0 +1,2489 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.abc_parser API documentation</title>
+<meta name="description" content="Parser for ABC files …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.abc_parser</code></h1>
+</header>
+<section id="section-intro">
+<p>Parser for ABC files.</p>
+<p><a href="http://abcnotation.com/wiki/abc:standard:v2.1">http://abcnotation.com/wiki/abc:standard:v2.1</a></p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Parser for ABC files.
+
+http://abcnotation.com/wiki/abc:standard:v2.1
+&#34;&#34;&#34;
+
+import fractions
+import re
+
+from absl import logging
+from note_seq import constants
+from note_seq.protobuf import music_pb2
+
+
+Fraction = fractions.Fraction
+
+
+class ABCParseError(Exception):
+  &#34;&#34;&#34;Exception thrown when ABC contents cannot be parsed.&#34;&#34;&#34;
+  pass
+
+
+class MultiVoiceError(ABCParseError):
+  &#34;&#34;&#34;Exception when a multi-voice directive is encountered.&#34;&#34;&#34;
+
+
+class RepeatParseError(ABCParseError):
+  &#34;&#34;&#34;Exception when a repeat directive could not be parsed.&#34;&#34;&#34;
+
+
+class VariantEndingError(ABCParseError):
+  &#34;&#34;&#34;Variant endings are not yet supported.&#34;&#34;&#34;
+
+
+class PartError(ABCParseError):
+  &#34;&#34;&#34;ABC Parts are not yet supported.&#34;&#34;&#34;
+
+
+class InvalidCharacterError(ABCParseError):
+  &#34;&#34;&#34;Invalid character.&#34;&#34;&#34;
+
+
+class ChordError(ABCParseError):
+  &#34;&#34;&#34;Chords are not supported.&#34;&#34;&#34;
+
+
+class DuplicateReferenceNumberError(ABCParseError):
+  &#34;&#34;&#34;Found duplicate reference numbers.&#34;&#34;&#34;
+
+
+class TupletError(ABCParseError):
+  &#34;&#34;&#34;Tuplets are not supported.&#34;&#34;&#34;
+
+
+def parse_abc_tunebook_file(filename):
+  &#34;&#34;&#34;Parse an ABC Tunebook file.
+
+  Args:
+    filename: File path to an ABC tunebook.
+
+  Returns:
+    tunes: A dictionary of reference number to NoteSequence of parsed ABC tunes.
+    exceptions: A list of exceptions for tunes that could not be parsed.
+
+  Raises:
+    DuplicateReferenceNumberError: If the same reference number appears more
+        than once in the tunebook.
+  &#34;&#34;&#34;
+  # &#39;r&#39; mode will decode the file as utf-8 in py3.
+  return parse_abc_tunebook(open(filename, &#39;r&#39;).read())
+
+
+def parse_abc_tunebook(tunebook):
+  &#34;&#34;&#34;Parse an ABC Tunebook string.
+
+  Args:
+    tunebook: The ABC tunebook as a string.
+
+  Returns:
+    tunes: A dictionary of reference number to NoteSequence of parsed ABC tunes.
+    exceptions: A list of exceptions for tunes that could not be parsed.
+
+  Raises:
+    DuplicateReferenceNumberError: If the same reference number appears more
+        than once in the tunebook.
+  &#34;&#34;&#34;
+  # Split tunebook into sections based on empty lines.
+  sections = []
+  current_lines = []
+  for line in tunebook.splitlines():
+    line = line.strip()
+    if not line:
+      if current_lines:
+        sections.append(current_lines)
+        current_lines = []
+    else:
+      current_lines.append(line)
+  if current_lines:
+    sections.append(current_lines)
+
+  # If there are multiple sections, the first one may be a header.
+  # The first section is a header if it does not contain an X information field.
+  header = []
+  if len(sections) &gt; 1 and not any(
+      line.startswith(&#39;X:&#39;) for line in sections[0]):
+    header = sections.pop(0)
+
+  tunes = {}
+  exceptions = []
+
+  for tune in sections:
+    try:
+      # The header sets default values for each tune, so prepend it to every
+      # tune that is being parsed.
+      abc_tune = ABCTune(header + tune)
+    except ABCParseError as e:
+      exceptions.append(e)
+    else:
+      ns = abc_tune.note_sequence
+      if ns.reference_number in tunes:
+        raise DuplicateReferenceNumberError(
+            &#39;ABC Reference number {} appears more than once in this &#39;
+            &#39;tunebook&#39;.format(ns.reference_number))
+      tunes[ns.reference_number] = ns
+
+  return tunes, exceptions
+
+
+class ABCTune(object):
+  &#34;&#34;&#34;Class for parsing an individual ABC tune.&#34;&#34;&#34;
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+  DECORATION_TO_VELOCITY = {
+      &#39;!pppp!&#39;: 30,
+      &#39;!ppp!&#39;: 30,
+      &#39;!pp!&#39;: 45,
+      &#39;!p!&#39;: 60,
+      &#39;!mp!&#39;: 75,
+      &#39;!mf!&#39;: 90,
+      &#39;!f!&#39;: 105,
+      &#39;!ff!&#39;: 120,
+      &#39;!fff!&#39;: 127,
+      &#39;!ffff!&#39;: 127,
+  }
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#pitch
+  ABC_NOTE_TO_MIDI = {
+      &#39;C&#39;: 60,
+      &#39;D&#39;: 62,
+      &#39;E&#39;: 64,
+      &#39;F&#39;: 65,
+      &#39;G&#39;: 67,
+      &#39;A&#39;: 69,
+      &#39;B&#39;: 71,
+      &#39;c&#39;: 72,
+      &#39;d&#39;: 74,
+      &#39;e&#39;: 76,
+      &#39;f&#39;: 77,
+      &#39;g&#39;: 79,
+      &#39;a&#39;: 81,
+      &#39;b&#39;: 83,
+  }
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  SIG_TO_KEYS = {
+      7: [&#39;C#&#39;, &#39;A#m&#39;, &#39;G#Mix&#39;, &#39;D#Dor&#39;, &#39;E#Phr&#39;, &#39;F#Lyd&#39;, &#39;B#Loc&#39;],
+      6: [&#39;F#&#39;, &#39;D#m&#39;, &#39;C#Mix&#39;, &#39;G#Dor&#39;, &#39;A#Phr&#39;, &#39;BLyd&#39;, &#39;E#Loc&#39;],
+      5: [&#39;B&#39;, &#39;G#m&#39;, &#39;F#Mix&#39;, &#39;C#Dor&#39;, &#39;D#Phr&#39;, &#39;ELyd&#39;, &#39;A#Loc&#39;],
+      4: [&#39;E&#39;, &#39;C#m&#39;, &#39;BMix&#39;, &#39;F#Dor&#39;, &#39;G#Phr&#39;, &#39;ALyd&#39;, &#39;D#Loc&#39;],
+      3: [&#39;A&#39;, &#39;F#m&#39;, &#39;EMix&#39;, &#39;BDor&#39;, &#39;C#Phr&#39;, &#39;DLyd&#39;, &#39;G#Loc&#39;],
+      2: [&#39;D&#39;, &#39;Bm&#39;, &#39;AMix&#39;, &#39;EDor&#39;, &#39;F#Phr&#39;, &#39;GLyd&#39;, &#39;C#Loc&#39;],
+      1: [&#39;G&#39;, &#39;Em&#39;, &#39;DMix&#39;, &#39;ADor&#39;, &#39;BPhr&#39;, &#39;CLyd&#39;, &#39;F#Loc&#39;],
+      0: [&#39;C&#39;, &#39;Am&#39;, &#39;GMix&#39;, &#39;DDor&#39;, &#39;EPhr&#39;, &#39;FLyd&#39;, &#39;BLoc&#39;],
+      -1: [&#39;F&#39;, &#39;Dm&#39;, &#39;CMix&#39;, &#39;GDor&#39;, &#39;APhr&#39;, &#39;BbLyd&#39;, &#39;ELoc&#39;],
+      -2: [&#39;Bb&#39;, &#39;Gm&#39;, &#39;FMix&#39;, &#39;CDor&#39;, &#39;DPhr&#39;, &#39;EbLyd&#39;, &#39;ALoc&#39;],
+      -3: [&#39;Eb&#39;, &#39;Cm&#39;, &#39;BbMix&#39;, &#39;FDor&#39;, &#39;GPhr&#39;, &#39;AbLyd&#39;, &#39;DLoc&#39;],
+      -4: [&#39;Ab&#39;, &#39;Fm&#39;, &#39;EbMix&#39;, &#39;BbDor&#39;, &#39;CPhr&#39;, &#39;DbLyd&#39;, &#39;GLoc&#39;],
+      -5: [&#39;Db&#39;, &#39;Bbm&#39;, &#39;AbMix&#39;, &#39;EbDor&#39;, &#39;FPhr&#39;, &#39;GbLyd&#39;, &#39;CLoc&#39;],
+      -6: [&#39;Gb&#39;, &#39;Ebm&#39;, &#39;DbMix&#39;, &#39;AbDor&#39;, &#39;BbPhr&#39;, &#39;CbLyd&#39;, &#39;FLoc&#39;],
+      -7: [&#39;Cb&#39;, &#39;Abm&#39;, &#39;GbMix&#39;, &#39;DbDor&#39;, &#39;EbPhr&#39;, &#39;FbLyd&#39;, &#39;BbLoc&#39;],
+  }
+
+  KEY_TO_SIG = {}
+  for sig, keys in SIG_TO_KEYS.items():
+    for key in keys:
+      KEY_TO_SIG[key.lower()] = sig
+
+  KEY_TO_PROTO_KEY = {
+      &#39;c&#39;: music_pb2.NoteSequence.KeySignature.C,
+      &#39;c#&#39;: music_pb2.NoteSequence.KeySignature.C_SHARP,
+      &#39;db&#39;: music_pb2.NoteSequence.KeySignature.D_FLAT,
+      &#39;d&#39;: music_pb2.NoteSequence.KeySignature.D,
+      &#39;d#&#39;: music_pb2.NoteSequence.KeySignature.D_SHARP,
+      &#39;eb&#39;: music_pb2.NoteSequence.KeySignature.E_FLAT,
+      &#39;e&#39;: music_pb2.NoteSequence.KeySignature.E,
+      &#39;f&#39;: music_pb2.NoteSequence.KeySignature.F,
+      &#39;f#&#39;: music_pb2.NoteSequence.KeySignature.F_SHARP,
+      &#39;gb&#39;: music_pb2.NoteSequence.KeySignature.G_FLAT,
+      &#39;g&#39;: music_pb2.NoteSequence.KeySignature.G,
+      &#39;g#&#39;: music_pb2.NoteSequence.KeySignature.G_SHARP,
+      &#39;ab&#39;: music_pb2.NoteSequence.KeySignature.A_FLAT,
+      &#39;a&#39;: music_pb2.NoteSequence.KeySignature.A,
+      &#39;a#&#39;: music_pb2.NoteSequence.KeySignature.A_SHARP,
+      &#39;bb&#39;: music_pb2.NoteSequence.KeySignature.B_FLAT,
+      &#39;b&#39;: music_pb2.NoteSequence.KeySignature.B,
+  }
+
+  SHARPS_ORDER = &#39;FCGDAEB&#39;
+  FLATS_ORDER = &#39;BEADGCF&#39;
+
+  INFORMATION_FIELD_PATTERN = re.compile(r&#39;([A-Za-z]):\s*(.*)&#39;)
+
+  def __init__(self, tune_lines):
+    self._ns = music_pb2.NoteSequence()
+    # Standard ABC fields.
+    self._ns.source_info.source_type = (
+        music_pb2.NoteSequence.SourceInfo.SCORE_BASED)
+    self._ns.source_info.encoding_type = (
+        music_pb2.NoteSequence.SourceInfo.ABC)
+    self._ns.source_info.parser = (
+        music_pb2.NoteSequence.SourceInfo.MAGENTA_ABC)
+    self._ns.ticks_per_quarter = constants.STANDARD_PPQ
+
+    self._current_time = 0
+    self._accidentals = ABCTune._sig_to_accidentals(0)
+    self._bar_accidentals = {}
+    self._current_unit_note_length = None
+    self._current_expected_repeats = None
+
+    # Default dynamic should be !mf! as per:
+    # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+    self._current_velocity = ABCTune.DECORATION_TO_VELOCITY[&#39;!mf!&#39;]
+
+    self._in_header = True
+    self._header_tempo_unit = None
+    self._header_tempo_rate = None
+    for line in tune_lines:
+      line = re.sub(&#39;%.*$&#39;, &#39;&#39;, line)  # Strip comments.
+      line = line.strip()  # Strip whitespace.
+      if not line:
+        continue
+
+      # If the lines begins with a letter and a colon, it&#39;s an information
+      # field. Extract it.
+      info_field_match = ABCTune.INFORMATION_FIELD_PATTERN.match(line)
+      if info_field_match:
+        self._parse_information_field(
+            info_field_match.group(1), info_field_match.group(2))
+      else:
+        if self._in_header:
+          self._set_values_from_header()
+          self._in_header = False
+        self._parse_music_code(line)
+    if self._in_header:
+      self._set_values_from_header()
+
+    self._finalize()
+
+    if self._ns.notes:
+      self._ns.total_time = self._ns.notes[-1].end_time
+
+  @property
+  def note_sequence(self):
+    return self._ns
+
+  @staticmethod
+  def _sig_to_accidentals(sig):
+    accidentals = {pitch: 0 for pitch in &#39;ABCDEFG&#39;}
+    if sig &gt; 0:
+      for i in range(sig):
+        accidentals[ABCTune.SHARPS_ORDER[i]] = 1
+    elif sig &lt; 0:
+      for i in range(abs(sig)):
+        accidentals[ABCTune.FLATS_ORDER[i]] = -1
+    return accidentals
+
+  @property
+  def _qpm(self):
+    &#34;&#34;&#34;Returns the current QPM.&#34;&#34;&#34;
+    if self._ns.tempos:
+      return self._ns.tempos[-1].qpm
+    else:
+      # No QPM has been specified, so will use the default one.
+      return constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  def _set_values_from_header(self):
+    # Set unit note length. May depend on the current meter, so this has to be
+    # calculated at the end of the header.
+    self._set_unit_note_length_from_header()
+
+    # Set the tempo if it was specified in the header. May depend on current
+    # unit note length, so has to be calculated after that is set.
+    # _header_tempo_unit may be legitimately None, so check _header_tempo_rate.
+    if self._header_tempo_rate:
+      self._add_tempo(self._header_tempo_unit, self._header_tempo_rate)
+
+  def _set_unit_note_length_from_header(self):
+    &#34;&#34;&#34;Sets the current unit note length.
+
+    Should be called immediately after parsing the header.
+
+    Raises:
+      ABCParseError: If multiple time signatures were set in the header.
+    &#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length
+
+    if self._current_unit_note_length:
+      # If it has been set explicitly, leave it as is.
+      pass
+    elif not self._ns.time_signatures:
+      # For free meter, the default unit note length is 1/8.
+      self._current_unit_note_length = Fraction(1, 8)
+    else:
+      # Otherwise, base it on the current meter.
+      if len(self._ns.time_signatures) != 1:
+        raise ABCParseError(&#39;Multiple time signatures set in header.&#39;)
+      current_ts = self._ns.time_signatures[0]
+      ratio = current_ts.numerator / current_ts.denominator
+      if ratio &lt; 0.75:
+        self._current_unit_note_length = Fraction(1, 16)
+      else:
+        self._current_unit_note_length = Fraction(1, 8)
+
+  def _add_tempo(self, tempo_unit, tempo_rate):
+    if tempo_unit is None:
+      tempo_unit = self._current_unit_note_length
+
+    tempo = self._ns.tempos.add()
+    tempo.time = self._current_time
+    tempo.qpm = float((tempo_unit / Fraction(1, 4)) * tempo_rate)
+
+  def _add_section(self, time):
+    &#34;&#34;&#34;Adds a new section to the NoteSequence.
+
+    If the most recently added section is for the same time, a new section will
+    not be created.
+
+    Args:
+      time: The time at which to create the new section.
+
+    Returns:
+      The id of the newly created section, or None if no new section was
+      created.
+    &#34;&#34;&#34;
+    if not self._ns.section_annotations and time &gt; 0:
+      # We&#39;re in a piece with sections, need to add a section marker at the
+      # beginning of the piece if there isn&#39;t one there already.
+      sa = self._ns.section_annotations.add()
+      sa.time = 0
+      sa.section_id = 0
+
+    if self._ns.section_annotations:
+      if self._ns.section_annotations[-1].time == time:
+        logging.debug(&#39;Ignoring duplicate section at time %f&#39;, time)
+        return None
+      new_id = self._ns.section_annotations[-1].section_id + 1
+    else:
+      new_id = 0
+
+    sa = self._ns.section_annotations.add()
+    sa.time = time
+    sa.section_id = new_id
+    return new_id
+
+  def _finalize(self):
+    &#34;&#34;&#34;Do final cleanup. To be called at the end of the tune.&#34;&#34;&#34;
+    self._finalize_repeats()
+    self._finalize_sections()
+
+  def _finalize_repeats(self):
+    &#34;&#34;&#34;Handle any pending repeats.&#34;&#34;&#34;
+    # If we&#39;re still expecting a repeat at the end of the tune, that&#39;s an error
+    # in the file.
+    if self._current_expected_repeats:
+      raise RepeatParseError(
+          &#39;Expected a repeat at the end of the file, but did not get one.&#39;)
+
+  def _finalize_sections(self):
+    &#34;&#34;&#34;Handle any pending sections.&#34;&#34;&#34;
+    # If a new section was started at the very end of the piece, delete it
+    # because it will contain no notes and is meaningless.
+    # This happens if the last line in the piece ends with a :| symbol. A new
+    # section is set up to handle upcoming notes, but then the end of the piece
+    # is reached.
+    if (self._ns.section_annotations and
+        self._ns.section_annotations[-1].time == self._ns.notes[-1].end_time):
+      del self._ns.section_annotations[-1]
+
+    # Make sure the final section annotation is referenced in a section group.
+    # If it hasn&#39;t been referenced yet, it just needs to be played once.
+    # This checks that the final section_annotation is referenced in the final
+    # section_group.
+    # At this point, all of our section_groups have only 1 section, so this
+    # logic will need to be updated when we support parts and start creating
+    # more complex section_groups.
+    if (self._ns.section_annotations and self._ns.section_groups and
+        self._ns.section_groups[-1].sections[0].section_id !=
+        self._ns.section_annotations[-1].section_id):
+      sg = self._ns.section_groups.add()
+      sg.sections.add(
+          section_id=self._ns.section_annotations[-1].section_id)
+      sg.num_times = 1
+
+  def _apply_broken_rhythm(self, broken_rhythm):
+    &#34;&#34;&#34;Applies a broken rhythm symbol to the two most recently added notes.&#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
+
+    if len(self._ns.notes) &lt; 2:
+      raise ABCParseError(
+          &#39;Cannot apply a broken rhythm with fewer than 2 notes&#39;)
+
+    note1 = self._ns.notes[-2]
+    note2 = self._ns.notes[-1]
+    note1_len = note1.end_time - note1.start_time
+    note2_len = note2.end_time - note2.start_time
+    if note1_len != note2_len:
+      raise ABCParseError(
+          &#39;Cannot apply broken rhythm to two notes of different lengths&#39;)
+
+    time_adj = note1_len / (2 ** len(broken_rhythm))
+    if broken_rhythm[0] == &#39;&lt;&#39;:
+      note1.end_time -= time_adj
+      note2.start_time -= time_adj
+    elif broken_rhythm[0] == &#39;&gt;&#39;:
+      note1.end_time += time_adj
+      note2.start_time += time_adj
+    else:
+      raise ABCParseError(&#39;Could not parse broken rhythm token: {}&#39;.format(
+          broken_rhythm))
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#pitch
+  NOTE_PATTERN = re.compile(
+      r&#39;(__|_|=|\^|\^\^)?([A-Ga-g])([\&#39;,]*)(\d*/*\d*)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
+  CHORD_PATTERN = re.compile(r&#39;\[(&#39; + NOTE_PATTERN.pattern + r&#39;)+\]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
+  BROKEN_RHYTHM_PATTERN = re.compile(r&#39;(&lt;+|&gt;+)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#use_of_fields_within_the_tune_body
+  INLINE_INFORMATION_FIELD_PATTERN = re.compile(r&#39;\[([A-Za-z]):\s*([^\]]+)\]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#repeat_bar_symbols
+
+  # Pattern for matching variant endings with an associated bar symbol.
+  BAR_AND_VARIANT_ENDINGS_PATTERN = re.compile(r&#39;(:*)[\[\]|]+\s*([0-9,-]+)&#39;)
+  # Pattern for matching repeat symbols with an associated bar symbol.
+  BAR_AND_REPEAT_SYMBOLS_PATTERN = re.compile(r&#39;(:*)([\[\]|]+)(:*)&#39;)
+  # Pattern for matching repeat symbols without an associated bar symbol.
+  REPEAT_SYMBOLS_PATTERN = re.compile(r&#39;(:+)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+  # http://abcnotation.com/wiki/abc:standard:v2.1#annotations
+  TEXT_ANNOTATION_PATTERN = re.compile(r&#39;&#34;([^&#34;]*)&#34;&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+  DECORATION_PATTERN = re.compile(r&#39;[.~HLMOPSTuv]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+  # Either an opening parenthesis (not followed by a digit, since that indicates
+  # a tuplet) or a closing parenthesis.
+  SLUR_PATTERN = re.compile(r&#39;\((?!\d)|\)&#39;)
+  TIE_PATTERN = re.compile(r&#39;-&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#duplets_triplets_quadruplets_etc
+  TUPLET_PATTERN = re.compile(r&#39;\(\d&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#typesetting_line-breaks
+  LINE_CONTINUATION_PATTERN = re.compile(r&#39;\\$&#39;)
+
+  def _parse_music_code(self, line):
+    &#34;&#34;&#34;Parse the music code within an ABC file.&#34;&#34;&#34;
+
+    # http://abcnotation.com/wiki/abc:standard:v2.1#the_tune_body
+    pos = 0
+    broken_rhythm = None
+    while pos &lt; len(line):
+      match = None
+      for regex in [
+          ABCTune.NOTE_PATTERN,
+          ABCTune.CHORD_PATTERN,
+          ABCTune.BROKEN_RHYTHM_PATTERN,
+          ABCTune.INLINE_INFORMATION_FIELD_PATTERN,
+          ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN,
+          ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN,
+          ABCTune.REPEAT_SYMBOLS_PATTERN,
+          ABCTune.TEXT_ANNOTATION_PATTERN,
+          ABCTune.DECORATION_PATTERN,
+          ABCTune.SLUR_PATTERN,
+          ABCTune.TIE_PATTERN,
+          ABCTune.TUPLET_PATTERN,
+          ABCTune.LINE_CONTINUATION_PATTERN]:
+        match = regex.match(line, pos)
+        if match:
+          break
+
+      if not match:
+        if not line[pos].isspace():
+          raise InvalidCharacterError(
+              &#39;Unexpected character: [{}]&#39;.format(line[pos].encode(&#39;utf-8&#39;)))
+        pos += 1
+        continue
+
+      pos = match.end()
+      if match.re == ABCTune.NOTE_PATTERN:
+        note = self._ns.notes.add()
+        note.velocity = self._current_velocity
+        note.start_time = self._current_time
+
+        note.pitch = ABCTune.ABC_NOTE_TO_MIDI[match.group(2)]
+        note_name = match.group(2).upper()
+
+        # Accidentals
+        if match.group(1):
+          pitch_change = 0
+          for accidental in match.group(1).split():
+            if accidental == &#39;^&#39;:
+              pitch_change += 1
+            elif accidental == &#39;_&#39;:
+              pitch_change -= 1
+            elif accidental == &#39;=&#39;:
+              pass
+            else:
+              raise ABCParseError(
+                  &#39;Invalid accidental: {}&#39;.format(accidental))
+          note.pitch += pitch_change
+          self._bar_accidentals[note_name] = pitch_change
+        elif note_name in self._bar_accidentals:
+          note.pitch += self._bar_accidentals[note_name]
+        else:
+          # No accidentals, so modify according to current key.
+          note.pitch += self._accidentals[note_name]
+
+        # Octaves
+        if match.group(3):
+          for octave in match.group(3):
+            if octave == &#39;\&#39;&#39;:
+              note.pitch += 12
+            elif octave == &#39;,&#39;:
+              note.pitch -= 12
+            else:
+              raise ABCParseError(&#39;Invalid octave: {}&#39;.format(octave))
+
+        if (note.pitch &lt; constants.MIN_MIDI_PITCH or
+            note.pitch &gt; constants.MAX_MIDI_PITCH):
+          raise ABCParseError(&#39;pitch {} is invalid&#39;.format(note.pitch))
+
+        # Note length
+        length = self._current_unit_note_length
+        # http://abcnotation.com/wiki/abc:standard:v2.1#note_lengths
+        if match.group(4):
+          slash_count = match.group(4).count(&#39;/&#39;)
+          if slash_count == len(match.group(4)):
+            # Handle A// shorthand case.
+            length /= 2 ** slash_count
+          elif match.group(4).startswith(&#39;/&#39;):
+            length /= int(match.group(4)[1:])
+          elif slash_count == 1:
+            fraction = match.group(4).split(&#39;/&#39;, 1)
+            # If no denominator is specified (e.g., &#34;3/&#34;), default to 2.
+            if not fraction[1]:
+              fraction[1] = 2
+            length *= Fraction(int(fraction[0]), int(fraction[1]))
+          elif slash_count == 0:
+            length *= int(match.group(4))
+          else:
+            raise ABCParseError(
+                &#39;Could not parse note length: {}&#39;.format(match.group(4)))
+
+        # Advance clock based on note length.
+        self._current_time += (1 / (self._qpm / 60)) * (length / Fraction(1, 4))
+
+        note.end_time = self._current_time
+
+        if broken_rhythm:
+          self._apply_broken_rhythm(broken_rhythm)
+          broken_rhythm = None
+      elif match.re == ABCTune.CHORD_PATTERN:
+        raise ChordError(&#39;Chords are not supported.&#39;)
+      elif match.re == ABCTune.BROKEN_RHYTHM_PATTERN:
+        if broken_rhythm:
+          raise ABCParseError(
+              &#39;Cannot specify a broken rhythm twice in a row.&#39;)
+        broken_rhythm = match.group(1)
+      elif match.re == ABCTune.INLINE_INFORMATION_FIELD_PATTERN:
+        self._parse_information_field(match.group(1), match.group(2))
+      elif match.re == ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN:
+        raise VariantEndingError(
+            &#39;Variant ending {} is not supported.&#39;.format(match.group(0)))
+      elif (match.re == ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN or
+            match.re == ABCTune.REPEAT_SYMBOLS_PATTERN):
+        if match.re == ABCTune.REPEAT_SYMBOLS_PATTERN:
+          colon_count = len(match.group(1))
+          if colon_count % 2 != 0:
+            raise RepeatParseError(
+                &#39;Colon-only repeats must be divisible by 2: {}&#39;.format(
+                    match.group(1)))
+          backward_repeats = forward_repeats = int((colon_count / 2) + 1)
+        elif match.re == ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN:
+          # We&#39;re in a new bar, so clear the bar-wise accidentals.
+          self._bar_accidentals.clear()
+
+          is_repeat = &#39;:&#39; in match.group(1) or match.group(3)
+          if not is_repeat:
+            if len(match.group(2)) &gt;= 2:
+              # This is a double bar that isn&#39;t a repeat.
+              if not self._current_expected_repeats and self._current_time &gt; 0:
+                # There was no previous forward repeat symbol.
+                # Add a new section so that if there is a backward repeat later
+                # on, it will repeat to this bar.
+                new_section_id = self._add_section(self._current_time)
+                if new_section_id is not None:
+                  sg = self._ns.section_groups.add()
+                  sg.sections.add(
+                      section_id=self._ns.section_annotations[-2].section_id)
+                  sg.num_times = 1
+
+            # If this isn&#39;t a repeat, no additional work to do.
+            continue
+
+          # Count colons on either side.
+          if match.group(1):
+            backward_repeats = len(match.group(1)) + 1
+          else:
+            backward_repeats = None
+
+          if match.group(3):
+            forward_repeats = len(match.group(3)) + 1
+          else:
+            forward_repeats = None
+        else:
+          raise ABCParseError(&#39;Unexpected regex. Should not happen.&#39;)
+
+        if (self._current_expected_repeats and
+            backward_repeats != self._current_expected_repeats):
+          raise RepeatParseError(
+              &#39;Mismatched forward/backward repeat symbols. &#39;
+              &#39;Expected {} but got {}.&#39;.format(
+                  self._current_expected_repeats, backward_repeats))
+
+        # A repeat implies the start of a new section, so make one.
+        new_section_id = self._add_section(self._current_time)
+
+        if backward_repeats:
+          if self._current_time == 0:
+            raise RepeatParseError(
+                &#39;Cannot have a backward repeat at time 0&#39;)
+          sg = self._ns.section_groups.add()
+          sg.sections.add(
+              section_id=self._ns.section_annotations[-2].section_id)
+          sg.num_times = backward_repeats
+        elif self._current_time &gt; 0 and new_section_id is not None:
+          # There were not backward repeats, but we still want to play the
+          # previous section once.
+          # If new_section_id is None (implying that a section at the current
+          # time was created elsewhere), this is not needed because it should
+          # have been done when the section was created.
+          sg = self._ns.section_groups.add()
+          sg.sections.add(
+              section_id=self._ns.section_annotations[-2].section_id)
+          sg.num_times = 1
+
+        self._current_expected_repeats = forward_repeats
+      elif match.re == ABCTune.TEXT_ANNOTATION_PATTERN:
+        # Text annotation
+        # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+        # http://abcnotation.com/wiki/abc:standard:v2.1#annotations
+        annotation = match.group(1)
+        ta = self._ns.text_annotations.add()
+        ta.time = self._current_time
+        ta.text = annotation
+        if annotation and annotation[0] in ABCTune.ABC_NOTE_TO_MIDI:
+          # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+          ta.annotation_type = (
+              music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL)
+        else:
+          ta.annotation_type = (
+              music_pb2.NoteSequence.TextAnnotation.UNKNOWN)
+      elif match.re == ABCTune.DECORATION_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+        # We don&#39;t currently do anything with decorations.
+        pass
+      elif match.re == ABCTune.SLUR_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+        # We don&#39;t currently do anything with slurs.
+        pass
+      elif match.re == ABCTune.TIE_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+        # We don&#39;t currently do anything with ties.
+        # TODO(fjord): Ideally, we would extend the duration of the previous
+        # note to include the duration of the next note.
+        pass
+      elif match.re == ABCTune.TUPLET_PATTERN:
+        raise TupletError(&#39;Tuplets are not supported.&#39;)
+      elif match.re == ABCTune.LINE_CONTINUATION_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#typesetting_line-breaks
+        # Line continuations are only for typesetting, so we can ignore them.
+        pass
+      else:
+        raise ABCParseError(&#39;Unknown regex match!&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  KEY_PATTERN = re.compile(
+      r&#39;([A-G])\s*([#b]?)\s*&#39;
+      r&#39;((?:(?:maj|ion|min|aeo|mix|dor|phr|lyd|loc|m)[^ ]*)?)&#39;,
+      re.IGNORECASE)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  KEY_ACCIDENTALS_PATTERN = re.compile(r&#39;(__|_|=|\^|\^\^)?([A-Ga-g])&#39;)
+
+  @staticmethod
+  def parse_key(key):
+    &#34;&#34;&#34;Parse an ABC key string.&#34;&#34;&#34;
+
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    key_match = ABCTune.KEY_PATTERN.match(key)
+    if not key_match:
+      raise ABCParseError(&#39;Could not parse key: {}&#39;.format(key))
+
+    key_components = list(key_match.groups())
+
+    # Shorten the mode to be at most 3 letters long.
+    mode = key_components[2][:3].lower()
+
+    # &#34;Minor&#34; and &#34;Aeolian&#34; are special cases that are abbreviated to &#39;m&#39;.
+    # &#34;Major&#34; and &#34;Ionian&#34; are special cases that are abbreviated to &#39;&#39;.
+    if mode in (&#39;min&#39;, &#39;aeo&#39;):
+      mode = &#39;m&#39;
+    elif mode in (&#39;maj&#39;, &#39;ion&#39;):
+      mode = &#39;&#39;
+
+    sig = ABCTune.KEY_TO_SIG[&#39;&#39;.join(key_components[0:2] + [mode]).lower()]
+
+    proto_key = ABCTune.KEY_TO_PROTO_KEY[&#39;&#39;.join(key_components[0:2]).lower()]
+
+    if mode == &#39;&#39;:  # pylint: disable=g-explicit-bool-comparison
+      proto_mode = music_pb2.NoteSequence.KeySignature.MAJOR
+    elif mode == &#39;m&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.MINOR
+    elif mode == &#39;mix&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.MIXOLYDIAN
+    elif mode == &#39;dor&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.DORIAN
+    elif mode == &#39;phr&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.PHRYGIAN
+    elif mode == &#39;lyd&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.LYDIAN
+    elif mode == &#39;loc&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.LOCRIAN
+    else:
+      raise ABCParseError(&#39;Unknown mode: {}&#39;.format(mode))
+
+    # Match the rest of the string for possible modifications.
+    pos = key_match.end()
+    exppos = key[pos:].find(&#39;exp&#39;)
+    if exppos != -1:
+      # Only explicit accidentals will be used.
+      accidentals = ABCTune._sig_to_accidentals(0)
+      pos += exppos + 3
+    else:
+      accidentals = ABCTune._sig_to_accidentals(sig)
+
+    while pos &lt; len(key):
+      note_match = ABCTune.KEY_ACCIDENTALS_PATTERN.match(key, pos)
+      if note_match:
+        pos += len(note_match.group(0))
+
+        note = note_match.group(2).upper()
+        if note_match.group(1):
+          if note_match.group(1) == &#39;^&#39;:
+            accidentals[note] = 1
+          elif note_match.group(1) == &#39;_&#39;:
+            accidentals[note] = -1
+          elif note_match.group(1) == &#39;=&#39;:
+            accidentals[note] = 0
+          else:
+            raise ABCParseError(
+                &#39;Invalid accidental: {}&#39;.format(note_match.group(1)))
+      else:
+        pos += 1
+
+    return accidentals, proto_key, proto_mode
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#outdated_information_field_syntax
+  # This syntax is deprecated but must still be supported.
+  TEMPO_DEPRECATED_PATTERN = re.compile(r&#39;C?\s*=?\s*(\d+)$&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+  TEMPO_PATTERN = re.compile(r&#39;(?:&#34;[^&#34;]*&#34;)?\s*((?:\d+/\d+\s*)+)\s*=\s*(\d+)&#39;)
+  TEMPO_PATTERN_STRING_ONLY = re.compile(r&#39;&#34;([^&#34;]*)&#34;$&#39;)
+
+  def _parse_information_field(self, field_name, field_content):
+    &#34;&#34;&#34;Parses information field.&#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#information_fields
+    if field_name == &#39;A&#39;:
+      pass
+    elif field_name == &#39;B&#39;:
+      pass
+    elif field_name == &#39;C&#39;:
+      # Composer
+      # http://abcnotation.com/wiki/abc:standard:v2.1#ccomposer
+      self._ns.sequence_metadata.composers.append(field_content)
+
+      # The first composer will be set as the primary artist.
+      if not self._ns.sequence_metadata.artist:
+        self._ns.sequence_metadata.artist = field_content
+    elif field_name == &#39;D&#39;:
+      pass
+    elif field_name == &#39;F&#39;:
+      pass
+    elif field_name == &#39;G&#39;:
+      pass
+    elif field_name == &#39;H&#39;:
+      pass
+    elif field_name == &#39;I&#39;:
+      pass
+    elif field_name == &#39;K&#39;:
+      # Key
+      # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+      accidentals, proto_key, proto_mode = ABCTune.parse_key(field_content)
+      self._accidentals = accidentals
+      ks = self._ns.key_signatures.add()
+      ks.key = proto_key
+      ks.mode = proto_mode
+      ks.time = self._current_time
+    elif field_name == &#39;L&#39;:
+      # Unit note length
+      # http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length
+      length = field_content.split(&#39;/&#39;, 1)
+
+      # Handle the case of L:1 being equivalent to L:1/1
+      if len(length) &lt; 2:
+        length.append(&#39;1&#39;)
+
+      try:
+        numerator = int(length[0])
+        denominator = int(length[1])
+      except ValueError as e:
+        raise ABCParseError(
+            e, &#39;Could not parse unit note length: {}&#39;.format(field_content))
+
+      self._current_unit_note_length = Fraction(numerator, denominator)
+    elif field_name == &#39;M&#39;:
+      # Meter
+      # http://abcnotation.com/wiki/abc:standard:v2.1#mmeter
+      if field_content.upper() == &#39;C&#39;:
+        ts = self._ns.time_signatures.add()
+        ts.numerator = 4
+        ts.denominator = 4
+        ts.time = self._current_time
+      elif field_content.upper() == &#39;C|&#39;:
+        ts = self._ns.time_signatures.add()
+        ts.numerator = 2
+        ts.denominator = 2
+        ts.time = self._current_time
+      elif field_content.lower() == &#39;none&#39;:
+        pass
+      else:
+        timesig = field_content.split(&#39;/&#39;, 1)
+        if len(timesig) != 2:
+          raise ABCParseError(&#39;Could not parse meter: {}&#39;.format(field_content))
+
+        ts = self._ns.time_signatures.add()
+        ts.time = self._current_time
+        try:
+          ts.numerator = int(timesig[0])
+          ts.denominator = int(timesig[1])
+        except ValueError as e:
+          raise ABCParseError(
+              e, &#39;Could not parse meter: {}&#39;.format(field_content))
+    elif field_name == &#39;m&#39;:
+      pass
+    elif field_name == &#39;N&#39;:
+      pass
+    elif field_name == &#39;O&#39;:
+      pass
+    elif field_name == &#39;P&#39;:
+      # TODO(fjord): implement part parsing.
+      raise PartError(&#39;ABC parts are not yet supported.&#39;)
+    elif field_name == &#39;Q&#39;:
+      # Tempo
+      # http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+
+      tempo_match = ABCTune.TEMPO_PATTERN.match(field_content)
+      deprecated_tempo_match = ABCTune.TEMPO_DEPRECATED_PATTERN.match(
+          field_content)
+      tempo_string_only_match = ABCTune.TEMPO_PATTERN_STRING_ONLY.match(
+          field_content)
+      if tempo_match:
+        tempo_rate = int(tempo_match.group(2))
+        tempo_unit = Fraction(0)
+        for beat in tempo_match.group(1).split():
+          tempo_unit += Fraction(beat)
+      elif deprecated_tempo_match:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#outdated_information_field_syntax
+        # In the deprecated syntax, the tempo is interpreted based on the unit
+        # note length, which is potentially dependent on the current meter.
+        # Set tempo_unit to None for now, and the current unit note length will
+        # be filled in later.
+        tempo_unit = None
+        tempo_rate = int(deprecated_tempo_match.group(1))
+      elif tempo_string_only_match:
+        logging.warning(&#39;Ignoring string-only tempo marking: %s&#39;, field_content)
+        return
+      else:
+        raise ABCParseError(&#39;Could not parse tempo: {}&#39;.format(field_content))
+
+      if self._in_header:
+        # If we&#39;re in the header, save these until we&#39;ve finished parsing the
+        # header. The deprecated syntax relies on the unit note length and
+        # meter, which may not be set yet. At the end of the header, we&#39;ll fill
+        # in the necessary information and add these.
+        self._header_tempo_unit = tempo_unit
+        self._header_tempo_rate = tempo_rate
+      else:
+        self._add_tempo(tempo_unit, tempo_rate)
+    elif field_name == &#39;R&#39;:
+      pass
+    elif field_name == &#39;r&#39;:
+      pass
+    elif field_name == &#39;S&#39;:
+      pass
+    elif field_name == &#39;s&#39;:
+      pass
+    elif field_name == &#39;T&#39;:
+      # Title
+      # http://abcnotation.com/wiki/abc:standard:v2.1#ttune_title
+
+      if not self._in_header:
+        # TODO(fjord): Non-header titles are used to name parts of tunes, but
+        # NoteSequence doesn&#39;t currently have any place to put that information.
+        logging.warning(&#39;Ignoring non-header title: %s&#39;, field_content)
+        return
+
+      # If there are multiple titles, separate them with semicolons.
+      if self._ns.sequence_metadata.title:
+        self._ns.sequence_metadata.title += &#39;; &#39; + field_content
+      else:
+        self._ns.sequence_metadata.title = field_content
+    elif field_name == &#39;U&#39;:
+      pass
+    elif field_name == &#39;V&#39;:
+      raise MultiVoiceError(&#39;Multi-voice files are not currently supported.&#39;)
+    elif field_name == &#39;W&#39;:
+      pass
+    elif field_name == &#39;w&#39;:
+      pass
+    elif field_name == &#39;X&#39;:
+      # Reference number
+      # http://abcnotation.com/wiki/abc:standard:v2.1#xreference_number
+      self._ns.reference_number = int(field_content)
+    elif field_name == &#39;Z&#39;:
+      pass
+    else:
+      logging.warning(
+          &#39;Unknown field name %s with content %s&#39;, field_name, field_content)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.abc_parser.parse_abc_tunebook"><code class="name flex">
+<span>def <span class="ident">parse_abc_tunebook</span></span>(<span>tunebook)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Parse an ABC Tunebook string.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>tunebook</code></strong></dt>
+<dd>The ABC tunebook as a string.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>tunes</code></dt>
+<dd>A dictionary of reference number to NoteSequence of parsed ABC tunes.</dd>
+<dt><code>exceptions</code></dt>
+<dd>A list of exceptions for tunes that could not be parsed.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.abc_parser.DuplicateReferenceNumberError" href="#note_seq.abc_parser.DuplicateReferenceNumberError">DuplicateReferenceNumberError</a></code></dt>
+<dd>If the same reference number appears more
+than once in the tunebook.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def parse_abc_tunebook(tunebook):
+  &#34;&#34;&#34;Parse an ABC Tunebook string.
+
+  Args:
+    tunebook: The ABC tunebook as a string.
+
+  Returns:
+    tunes: A dictionary of reference number to NoteSequence of parsed ABC tunes.
+    exceptions: A list of exceptions for tunes that could not be parsed.
+
+  Raises:
+    DuplicateReferenceNumberError: If the same reference number appears more
+        than once in the tunebook.
+  &#34;&#34;&#34;
+  # Split tunebook into sections based on empty lines.
+  sections = []
+  current_lines = []
+  for line in tunebook.splitlines():
+    line = line.strip()
+    if not line:
+      if current_lines:
+        sections.append(current_lines)
+        current_lines = []
+    else:
+      current_lines.append(line)
+  if current_lines:
+    sections.append(current_lines)
+
+  # If there are multiple sections, the first one may be a header.
+  # The first section is a header if it does not contain an X information field.
+  header = []
+  if len(sections) &gt; 1 and not any(
+      line.startswith(&#39;X:&#39;) for line in sections[0]):
+    header = sections.pop(0)
+
+  tunes = {}
+  exceptions = []
+
+  for tune in sections:
+    try:
+      # The header sets default values for each tune, so prepend it to every
+      # tune that is being parsed.
+      abc_tune = ABCTune(header + tune)
+    except ABCParseError as e:
+      exceptions.append(e)
+    else:
+      ns = abc_tune.note_sequence
+      if ns.reference_number in tunes:
+        raise DuplicateReferenceNumberError(
+            &#39;ABC Reference number {} appears more than once in this &#39;
+            &#39;tunebook&#39;.format(ns.reference_number))
+      tunes[ns.reference_number] = ns
+
+  return tunes, exceptions</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser.parse_abc_tunebook_file"><code class="name flex">
+<span>def <span class="ident">parse_abc_tunebook_file</span></span>(<span>filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Parse an ABC Tunebook file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>filename</code></strong></dt>
+<dd>File path to an ABC tunebook.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>tunes</code></dt>
+<dd>A dictionary of reference number to NoteSequence of parsed ABC tunes.</dd>
+<dt><code>exceptions</code></dt>
+<dd>A list of exceptions for tunes that could not be parsed.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.abc_parser.DuplicateReferenceNumberError" href="#note_seq.abc_parser.DuplicateReferenceNumberError">DuplicateReferenceNumberError</a></code></dt>
+<dd>If the same reference number appears more
+than once in the tunebook.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def parse_abc_tunebook_file(filename):
+  &#34;&#34;&#34;Parse an ABC Tunebook file.
+
+  Args:
+    filename: File path to an ABC tunebook.
+
+  Returns:
+    tunes: A dictionary of reference number to NoteSequence of parsed ABC tunes.
+    exceptions: A list of exceptions for tunes that could not be parsed.
+
+  Raises:
+    DuplicateReferenceNumberError: If the same reference number appears more
+        than once in the tunebook.
+  &#34;&#34;&#34;
+  # &#39;r&#39; mode will decode the file as utf-8 in py3.
+  return parse_abc_tunebook(open(filename, &#39;r&#39;).read())</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.abc_parser.ABCParseError"><code class="flex name class">
+<span>class <span class="ident">ABCParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when ABC contents cannot be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ABCParseError(Exception):
+  &#34;&#34;&#34;Exception thrown when ABC contents cannot be parsed.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ChordError" href="#note_seq.abc_parser.ChordError">ChordError</a></li>
+<li><a title="note_seq.abc_parser.DuplicateReferenceNumberError" href="#note_seq.abc_parser.DuplicateReferenceNumberError">DuplicateReferenceNumberError</a></li>
+<li><a title="note_seq.abc_parser.InvalidCharacterError" href="#note_seq.abc_parser.InvalidCharacterError">InvalidCharacterError</a></li>
+<li><a title="note_seq.abc_parser.MultiVoiceError" href="#note_seq.abc_parser.MultiVoiceError">MultiVoiceError</a></li>
+<li><a title="note_seq.abc_parser.PartError" href="#note_seq.abc_parser.PartError">PartError</a></li>
+<li><a title="note_seq.abc_parser.RepeatParseError" href="#note_seq.abc_parser.RepeatParseError">RepeatParseError</a></li>
+<li><a title="note_seq.abc_parser.TupletError" href="#note_seq.abc_parser.TupletError">TupletError</a></li>
+<li><a title="note_seq.abc_parser.VariantEndingError" href="#note_seq.abc_parser.VariantEndingError">VariantEndingError</a></li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune"><code class="flex name class">
+<span>class <span class="ident">ABCTune</span></span>
+<span>(</span><span>tune_lines)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Class for parsing an individual ABC tune.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ABCTune(object):
+  &#34;&#34;&#34;Class for parsing an individual ABC tune.&#34;&#34;&#34;
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+  DECORATION_TO_VELOCITY = {
+      &#39;!pppp!&#39;: 30,
+      &#39;!ppp!&#39;: 30,
+      &#39;!pp!&#39;: 45,
+      &#39;!p!&#39;: 60,
+      &#39;!mp!&#39;: 75,
+      &#39;!mf!&#39;: 90,
+      &#39;!f!&#39;: 105,
+      &#39;!ff!&#39;: 120,
+      &#39;!fff!&#39;: 127,
+      &#39;!ffff!&#39;: 127,
+  }
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#pitch
+  ABC_NOTE_TO_MIDI = {
+      &#39;C&#39;: 60,
+      &#39;D&#39;: 62,
+      &#39;E&#39;: 64,
+      &#39;F&#39;: 65,
+      &#39;G&#39;: 67,
+      &#39;A&#39;: 69,
+      &#39;B&#39;: 71,
+      &#39;c&#39;: 72,
+      &#39;d&#39;: 74,
+      &#39;e&#39;: 76,
+      &#39;f&#39;: 77,
+      &#39;g&#39;: 79,
+      &#39;a&#39;: 81,
+      &#39;b&#39;: 83,
+  }
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  SIG_TO_KEYS = {
+      7: [&#39;C#&#39;, &#39;A#m&#39;, &#39;G#Mix&#39;, &#39;D#Dor&#39;, &#39;E#Phr&#39;, &#39;F#Lyd&#39;, &#39;B#Loc&#39;],
+      6: [&#39;F#&#39;, &#39;D#m&#39;, &#39;C#Mix&#39;, &#39;G#Dor&#39;, &#39;A#Phr&#39;, &#39;BLyd&#39;, &#39;E#Loc&#39;],
+      5: [&#39;B&#39;, &#39;G#m&#39;, &#39;F#Mix&#39;, &#39;C#Dor&#39;, &#39;D#Phr&#39;, &#39;ELyd&#39;, &#39;A#Loc&#39;],
+      4: [&#39;E&#39;, &#39;C#m&#39;, &#39;BMix&#39;, &#39;F#Dor&#39;, &#39;G#Phr&#39;, &#39;ALyd&#39;, &#39;D#Loc&#39;],
+      3: [&#39;A&#39;, &#39;F#m&#39;, &#39;EMix&#39;, &#39;BDor&#39;, &#39;C#Phr&#39;, &#39;DLyd&#39;, &#39;G#Loc&#39;],
+      2: [&#39;D&#39;, &#39;Bm&#39;, &#39;AMix&#39;, &#39;EDor&#39;, &#39;F#Phr&#39;, &#39;GLyd&#39;, &#39;C#Loc&#39;],
+      1: [&#39;G&#39;, &#39;Em&#39;, &#39;DMix&#39;, &#39;ADor&#39;, &#39;BPhr&#39;, &#39;CLyd&#39;, &#39;F#Loc&#39;],
+      0: [&#39;C&#39;, &#39;Am&#39;, &#39;GMix&#39;, &#39;DDor&#39;, &#39;EPhr&#39;, &#39;FLyd&#39;, &#39;BLoc&#39;],
+      -1: [&#39;F&#39;, &#39;Dm&#39;, &#39;CMix&#39;, &#39;GDor&#39;, &#39;APhr&#39;, &#39;BbLyd&#39;, &#39;ELoc&#39;],
+      -2: [&#39;Bb&#39;, &#39;Gm&#39;, &#39;FMix&#39;, &#39;CDor&#39;, &#39;DPhr&#39;, &#39;EbLyd&#39;, &#39;ALoc&#39;],
+      -3: [&#39;Eb&#39;, &#39;Cm&#39;, &#39;BbMix&#39;, &#39;FDor&#39;, &#39;GPhr&#39;, &#39;AbLyd&#39;, &#39;DLoc&#39;],
+      -4: [&#39;Ab&#39;, &#39;Fm&#39;, &#39;EbMix&#39;, &#39;BbDor&#39;, &#39;CPhr&#39;, &#39;DbLyd&#39;, &#39;GLoc&#39;],
+      -5: [&#39;Db&#39;, &#39;Bbm&#39;, &#39;AbMix&#39;, &#39;EbDor&#39;, &#39;FPhr&#39;, &#39;GbLyd&#39;, &#39;CLoc&#39;],
+      -6: [&#39;Gb&#39;, &#39;Ebm&#39;, &#39;DbMix&#39;, &#39;AbDor&#39;, &#39;BbPhr&#39;, &#39;CbLyd&#39;, &#39;FLoc&#39;],
+      -7: [&#39;Cb&#39;, &#39;Abm&#39;, &#39;GbMix&#39;, &#39;DbDor&#39;, &#39;EbPhr&#39;, &#39;FbLyd&#39;, &#39;BbLoc&#39;],
+  }
+
+  KEY_TO_SIG = {}
+  for sig, keys in SIG_TO_KEYS.items():
+    for key in keys:
+      KEY_TO_SIG[key.lower()] = sig
+
+  KEY_TO_PROTO_KEY = {
+      &#39;c&#39;: music_pb2.NoteSequence.KeySignature.C,
+      &#39;c#&#39;: music_pb2.NoteSequence.KeySignature.C_SHARP,
+      &#39;db&#39;: music_pb2.NoteSequence.KeySignature.D_FLAT,
+      &#39;d&#39;: music_pb2.NoteSequence.KeySignature.D,
+      &#39;d#&#39;: music_pb2.NoteSequence.KeySignature.D_SHARP,
+      &#39;eb&#39;: music_pb2.NoteSequence.KeySignature.E_FLAT,
+      &#39;e&#39;: music_pb2.NoteSequence.KeySignature.E,
+      &#39;f&#39;: music_pb2.NoteSequence.KeySignature.F,
+      &#39;f#&#39;: music_pb2.NoteSequence.KeySignature.F_SHARP,
+      &#39;gb&#39;: music_pb2.NoteSequence.KeySignature.G_FLAT,
+      &#39;g&#39;: music_pb2.NoteSequence.KeySignature.G,
+      &#39;g#&#39;: music_pb2.NoteSequence.KeySignature.G_SHARP,
+      &#39;ab&#39;: music_pb2.NoteSequence.KeySignature.A_FLAT,
+      &#39;a&#39;: music_pb2.NoteSequence.KeySignature.A,
+      &#39;a#&#39;: music_pb2.NoteSequence.KeySignature.A_SHARP,
+      &#39;bb&#39;: music_pb2.NoteSequence.KeySignature.B_FLAT,
+      &#39;b&#39;: music_pb2.NoteSequence.KeySignature.B,
+  }
+
+  SHARPS_ORDER = &#39;FCGDAEB&#39;
+  FLATS_ORDER = &#39;BEADGCF&#39;
+
+  INFORMATION_FIELD_PATTERN = re.compile(r&#39;([A-Za-z]):\s*(.*)&#39;)
+
+  def __init__(self, tune_lines):
+    self._ns = music_pb2.NoteSequence()
+    # Standard ABC fields.
+    self._ns.source_info.source_type = (
+        music_pb2.NoteSequence.SourceInfo.SCORE_BASED)
+    self._ns.source_info.encoding_type = (
+        music_pb2.NoteSequence.SourceInfo.ABC)
+    self._ns.source_info.parser = (
+        music_pb2.NoteSequence.SourceInfo.MAGENTA_ABC)
+    self._ns.ticks_per_quarter = constants.STANDARD_PPQ
+
+    self._current_time = 0
+    self._accidentals = ABCTune._sig_to_accidentals(0)
+    self._bar_accidentals = {}
+    self._current_unit_note_length = None
+    self._current_expected_repeats = None
+
+    # Default dynamic should be !mf! as per:
+    # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+    self._current_velocity = ABCTune.DECORATION_TO_VELOCITY[&#39;!mf!&#39;]
+
+    self._in_header = True
+    self._header_tempo_unit = None
+    self._header_tempo_rate = None
+    for line in tune_lines:
+      line = re.sub(&#39;%.*$&#39;, &#39;&#39;, line)  # Strip comments.
+      line = line.strip()  # Strip whitespace.
+      if not line:
+        continue
+
+      # If the lines begins with a letter and a colon, it&#39;s an information
+      # field. Extract it.
+      info_field_match = ABCTune.INFORMATION_FIELD_PATTERN.match(line)
+      if info_field_match:
+        self._parse_information_field(
+            info_field_match.group(1), info_field_match.group(2))
+      else:
+        if self._in_header:
+          self._set_values_from_header()
+          self._in_header = False
+        self._parse_music_code(line)
+    if self._in_header:
+      self._set_values_from_header()
+
+    self._finalize()
+
+    if self._ns.notes:
+      self._ns.total_time = self._ns.notes[-1].end_time
+
+  @property
+  def note_sequence(self):
+    return self._ns
+
+  @staticmethod
+  def _sig_to_accidentals(sig):
+    accidentals = {pitch: 0 for pitch in &#39;ABCDEFG&#39;}
+    if sig &gt; 0:
+      for i in range(sig):
+        accidentals[ABCTune.SHARPS_ORDER[i]] = 1
+    elif sig &lt; 0:
+      for i in range(abs(sig)):
+        accidentals[ABCTune.FLATS_ORDER[i]] = -1
+    return accidentals
+
+  @property
+  def _qpm(self):
+    &#34;&#34;&#34;Returns the current QPM.&#34;&#34;&#34;
+    if self._ns.tempos:
+      return self._ns.tempos[-1].qpm
+    else:
+      # No QPM has been specified, so will use the default one.
+      return constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  def _set_values_from_header(self):
+    # Set unit note length. May depend on the current meter, so this has to be
+    # calculated at the end of the header.
+    self._set_unit_note_length_from_header()
+
+    # Set the tempo if it was specified in the header. May depend on current
+    # unit note length, so has to be calculated after that is set.
+    # _header_tempo_unit may be legitimately None, so check _header_tempo_rate.
+    if self._header_tempo_rate:
+      self._add_tempo(self._header_tempo_unit, self._header_tempo_rate)
+
+  def _set_unit_note_length_from_header(self):
+    &#34;&#34;&#34;Sets the current unit note length.
+
+    Should be called immediately after parsing the header.
+
+    Raises:
+      ABCParseError: If multiple time signatures were set in the header.
+    &#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length
+
+    if self._current_unit_note_length:
+      # If it has been set explicitly, leave it as is.
+      pass
+    elif not self._ns.time_signatures:
+      # For free meter, the default unit note length is 1/8.
+      self._current_unit_note_length = Fraction(1, 8)
+    else:
+      # Otherwise, base it on the current meter.
+      if len(self._ns.time_signatures) != 1:
+        raise ABCParseError(&#39;Multiple time signatures set in header.&#39;)
+      current_ts = self._ns.time_signatures[0]
+      ratio = current_ts.numerator / current_ts.denominator
+      if ratio &lt; 0.75:
+        self._current_unit_note_length = Fraction(1, 16)
+      else:
+        self._current_unit_note_length = Fraction(1, 8)
+
+  def _add_tempo(self, tempo_unit, tempo_rate):
+    if tempo_unit is None:
+      tempo_unit = self._current_unit_note_length
+
+    tempo = self._ns.tempos.add()
+    tempo.time = self._current_time
+    tempo.qpm = float((tempo_unit / Fraction(1, 4)) * tempo_rate)
+
+  def _add_section(self, time):
+    &#34;&#34;&#34;Adds a new section to the NoteSequence.
+
+    If the most recently added section is for the same time, a new section will
+    not be created.
+
+    Args:
+      time: The time at which to create the new section.
+
+    Returns:
+      The id of the newly created section, or None if no new section was
+      created.
+    &#34;&#34;&#34;
+    if not self._ns.section_annotations and time &gt; 0:
+      # We&#39;re in a piece with sections, need to add a section marker at the
+      # beginning of the piece if there isn&#39;t one there already.
+      sa = self._ns.section_annotations.add()
+      sa.time = 0
+      sa.section_id = 0
+
+    if self._ns.section_annotations:
+      if self._ns.section_annotations[-1].time == time:
+        logging.debug(&#39;Ignoring duplicate section at time %f&#39;, time)
+        return None
+      new_id = self._ns.section_annotations[-1].section_id + 1
+    else:
+      new_id = 0
+
+    sa = self._ns.section_annotations.add()
+    sa.time = time
+    sa.section_id = new_id
+    return new_id
+
+  def _finalize(self):
+    &#34;&#34;&#34;Do final cleanup. To be called at the end of the tune.&#34;&#34;&#34;
+    self._finalize_repeats()
+    self._finalize_sections()
+
+  def _finalize_repeats(self):
+    &#34;&#34;&#34;Handle any pending repeats.&#34;&#34;&#34;
+    # If we&#39;re still expecting a repeat at the end of the tune, that&#39;s an error
+    # in the file.
+    if self._current_expected_repeats:
+      raise RepeatParseError(
+          &#39;Expected a repeat at the end of the file, but did not get one.&#39;)
+
+  def _finalize_sections(self):
+    &#34;&#34;&#34;Handle any pending sections.&#34;&#34;&#34;
+    # If a new section was started at the very end of the piece, delete it
+    # because it will contain no notes and is meaningless.
+    # This happens if the last line in the piece ends with a :| symbol. A new
+    # section is set up to handle upcoming notes, but then the end of the piece
+    # is reached.
+    if (self._ns.section_annotations and
+        self._ns.section_annotations[-1].time == self._ns.notes[-1].end_time):
+      del self._ns.section_annotations[-1]
+
+    # Make sure the final section annotation is referenced in a section group.
+    # If it hasn&#39;t been referenced yet, it just needs to be played once.
+    # This checks that the final section_annotation is referenced in the final
+    # section_group.
+    # At this point, all of our section_groups have only 1 section, so this
+    # logic will need to be updated when we support parts and start creating
+    # more complex section_groups.
+    if (self._ns.section_annotations and self._ns.section_groups and
+        self._ns.section_groups[-1].sections[0].section_id !=
+        self._ns.section_annotations[-1].section_id):
+      sg = self._ns.section_groups.add()
+      sg.sections.add(
+          section_id=self._ns.section_annotations[-1].section_id)
+      sg.num_times = 1
+
+  def _apply_broken_rhythm(self, broken_rhythm):
+    &#34;&#34;&#34;Applies a broken rhythm symbol to the two most recently added notes.&#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
+
+    if len(self._ns.notes) &lt; 2:
+      raise ABCParseError(
+          &#39;Cannot apply a broken rhythm with fewer than 2 notes&#39;)
+
+    note1 = self._ns.notes[-2]
+    note2 = self._ns.notes[-1]
+    note1_len = note1.end_time - note1.start_time
+    note2_len = note2.end_time - note2.start_time
+    if note1_len != note2_len:
+      raise ABCParseError(
+          &#39;Cannot apply broken rhythm to two notes of different lengths&#39;)
+
+    time_adj = note1_len / (2 ** len(broken_rhythm))
+    if broken_rhythm[0] == &#39;&lt;&#39;:
+      note1.end_time -= time_adj
+      note2.start_time -= time_adj
+    elif broken_rhythm[0] == &#39;&gt;&#39;:
+      note1.end_time += time_adj
+      note2.start_time += time_adj
+    else:
+      raise ABCParseError(&#39;Could not parse broken rhythm token: {}&#39;.format(
+          broken_rhythm))
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#pitch
+  NOTE_PATTERN = re.compile(
+      r&#39;(__|_|=|\^|\^\^)?([A-Ga-g])([\&#39;,]*)(\d*/*\d*)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
+  CHORD_PATTERN = re.compile(r&#39;\[(&#39; + NOTE_PATTERN.pattern + r&#39;)+\]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
+  BROKEN_RHYTHM_PATTERN = re.compile(r&#39;(&lt;+|&gt;+)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#use_of_fields_within_the_tune_body
+  INLINE_INFORMATION_FIELD_PATTERN = re.compile(r&#39;\[([A-Za-z]):\s*([^\]]+)\]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#repeat_bar_symbols
+
+  # Pattern for matching variant endings with an associated bar symbol.
+  BAR_AND_VARIANT_ENDINGS_PATTERN = re.compile(r&#39;(:*)[\[\]|]+\s*([0-9,-]+)&#39;)
+  # Pattern for matching repeat symbols with an associated bar symbol.
+  BAR_AND_REPEAT_SYMBOLS_PATTERN = re.compile(r&#39;(:*)([\[\]|]+)(:*)&#39;)
+  # Pattern for matching repeat symbols without an associated bar symbol.
+  REPEAT_SYMBOLS_PATTERN = re.compile(r&#39;(:+)&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+  # http://abcnotation.com/wiki/abc:standard:v2.1#annotations
+  TEXT_ANNOTATION_PATTERN = re.compile(r&#39;&#34;([^&#34;]*)&#34;&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+  DECORATION_PATTERN = re.compile(r&#39;[.~HLMOPSTuv]&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+  # Either an opening parenthesis (not followed by a digit, since that indicates
+  # a tuplet) or a closing parenthesis.
+  SLUR_PATTERN = re.compile(r&#39;\((?!\d)|\)&#39;)
+  TIE_PATTERN = re.compile(r&#39;-&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#duplets_triplets_quadruplets_etc
+  TUPLET_PATTERN = re.compile(r&#39;\(\d&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#typesetting_line-breaks
+  LINE_CONTINUATION_PATTERN = re.compile(r&#39;\\$&#39;)
+
+  def _parse_music_code(self, line):
+    &#34;&#34;&#34;Parse the music code within an ABC file.&#34;&#34;&#34;
+
+    # http://abcnotation.com/wiki/abc:standard:v2.1#the_tune_body
+    pos = 0
+    broken_rhythm = None
+    while pos &lt; len(line):
+      match = None
+      for regex in [
+          ABCTune.NOTE_PATTERN,
+          ABCTune.CHORD_PATTERN,
+          ABCTune.BROKEN_RHYTHM_PATTERN,
+          ABCTune.INLINE_INFORMATION_FIELD_PATTERN,
+          ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN,
+          ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN,
+          ABCTune.REPEAT_SYMBOLS_PATTERN,
+          ABCTune.TEXT_ANNOTATION_PATTERN,
+          ABCTune.DECORATION_PATTERN,
+          ABCTune.SLUR_PATTERN,
+          ABCTune.TIE_PATTERN,
+          ABCTune.TUPLET_PATTERN,
+          ABCTune.LINE_CONTINUATION_PATTERN]:
+        match = regex.match(line, pos)
+        if match:
+          break
+
+      if not match:
+        if not line[pos].isspace():
+          raise InvalidCharacterError(
+              &#39;Unexpected character: [{}]&#39;.format(line[pos].encode(&#39;utf-8&#39;)))
+        pos += 1
+        continue
+
+      pos = match.end()
+      if match.re == ABCTune.NOTE_PATTERN:
+        note = self._ns.notes.add()
+        note.velocity = self._current_velocity
+        note.start_time = self._current_time
+
+        note.pitch = ABCTune.ABC_NOTE_TO_MIDI[match.group(2)]
+        note_name = match.group(2).upper()
+
+        # Accidentals
+        if match.group(1):
+          pitch_change = 0
+          for accidental in match.group(1).split():
+            if accidental == &#39;^&#39;:
+              pitch_change += 1
+            elif accidental == &#39;_&#39;:
+              pitch_change -= 1
+            elif accidental == &#39;=&#39;:
+              pass
+            else:
+              raise ABCParseError(
+                  &#39;Invalid accidental: {}&#39;.format(accidental))
+          note.pitch += pitch_change
+          self._bar_accidentals[note_name] = pitch_change
+        elif note_name in self._bar_accidentals:
+          note.pitch += self._bar_accidentals[note_name]
+        else:
+          # No accidentals, so modify according to current key.
+          note.pitch += self._accidentals[note_name]
+
+        # Octaves
+        if match.group(3):
+          for octave in match.group(3):
+            if octave == &#39;\&#39;&#39;:
+              note.pitch += 12
+            elif octave == &#39;,&#39;:
+              note.pitch -= 12
+            else:
+              raise ABCParseError(&#39;Invalid octave: {}&#39;.format(octave))
+
+        if (note.pitch &lt; constants.MIN_MIDI_PITCH or
+            note.pitch &gt; constants.MAX_MIDI_PITCH):
+          raise ABCParseError(&#39;pitch {} is invalid&#39;.format(note.pitch))
+
+        # Note length
+        length = self._current_unit_note_length
+        # http://abcnotation.com/wiki/abc:standard:v2.1#note_lengths
+        if match.group(4):
+          slash_count = match.group(4).count(&#39;/&#39;)
+          if slash_count == len(match.group(4)):
+            # Handle A// shorthand case.
+            length /= 2 ** slash_count
+          elif match.group(4).startswith(&#39;/&#39;):
+            length /= int(match.group(4)[1:])
+          elif slash_count == 1:
+            fraction = match.group(4).split(&#39;/&#39;, 1)
+            # If no denominator is specified (e.g., &#34;3/&#34;), default to 2.
+            if not fraction[1]:
+              fraction[1] = 2
+            length *= Fraction(int(fraction[0]), int(fraction[1]))
+          elif slash_count == 0:
+            length *= int(match.group(4))
+          else:
+            raise ABCParseError(
+                &#39;Could not parse note length: {}&#39;.format(match.group(4)))
+
+        # Advance clock based on note length.
+        self._current_time += (1 / (self._qpm / 60)) * (length / Fraction(1, 4))
+
+        note.end_time = self._current_time
+
+        if broken_rhythm:
+          self._apply_broken_rhythm(broken_rhythm)
+          broken_rhythm = None
+      elif match.re == ABCTune.CHORD_PATTERN:
+        raise ChordError(&#39;Chords are not supported.&#39;)
+      elif match.re == ABCTune.BROKEN_RHYTHM_PATTERN:
+        if broken_rhythm:
+          raise ABCParseError(
+              &#39;Cannot specify a broken rhythm twice in a row.&#39;)
+        broken_rhythm = match.group(1)
+      elif match.re == ABCTune.INLINE_INFORMATION_FIELD_PATTERN:
+        self._parse_information_field(match.group(1), match.group(2))
+      elif match.re == ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN:
+        raise VariantEndingError(
+            &#39;Variant ending {} is not supported.&#39;.format(match.group(0)))
+      elif (match.re == ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN or
+            match.re == ABCTune.REPEAT_SYMBOLS_PATTERN):
+        if match.re == ABCTune.REPEAT_SYMBOLS_PATTERN:
+          colon_count = len(match.group(1))
+          if colon_count % 2 != 0:
+            raise RepeatParseError(
+                &#39;Colon-only repeats must be divisible by 2: {}&#39;.format(
+                    match.group(1)))
+          backward_repeats = forward_repeats = int((colon_count / 2) + 1)
+        elif match.re == ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN:
+          # We&#39;re in a new bar, so clear the bar-wise accidentals.
+          self._bar_accidentals.clear()
+
+          is_repeat = &#39;:&#39; in match.group(1) or match.group(3)
+          if not is_repeat:
+            if len(match.group(2)) &gt;= 2:
+              # This is a double bar that isn&#39;t a repeat.
+              if not self._current_expected_repeats and self._current_time &gt; 0:
+                # There was no previous forward repeat symbol.
+                # Add a new section so that if there is a backward repeat later
+                # on, it will repeat to this bar.
+                new_section_id = self._add_section(self._current_time)
+                if new_section_id is not None:
+                  sg = self._ns.section_groups.add()
+                  sg.sections.add(
+                      section_id=self._ns.section_annotations[-2].section_id)
+                  sg.num_times = 1
+
+            # If this isn&#39;t a repeat, no additional work to do.
+            continue
+
+          # Count colons on either side.
+          if match.group(1):
+            backward_repeats = len(match.group(1)) + 1
+          else:
+            backward_repeats = None
+
+          if match.group(3):
+            forward_repeats = len(match.group(3)) + 1
+          else:
+            forward_repeats = None
+        else:
+          raise ABCParseError(&#39;Unexpected regex. Should not happen.&#39;)
+
+        if (self._current_expected_repeats and
+            backward_repeats != self._current_expected_repeats):
+          raise RepeatParseError(
+              &#39;Mismatched forward/backward repeat symbols. &#39;
+              &#39;Expected {} but got {}.&#39;.format(
+                  self._current_expected_repeats, backward_repeats))
+
+        # A repeat implies the start of a new section, so make one.
+        new_section_id = self._add_section(self._current_time)
+
+        if backward_repeats:
+          if self._current_time == 0:
+            raise RepeatParseError(
+                &#39;Cannot have a backward repeat at time 0&#39;)
+          sg = self._ns.section_groups.add()
+          sg.sections.add(
+              section_id=self._ns.section_annotations[-2].section_id)
+          sg.num_times = backward_repeats
+        elif self._current_time &gt; 0 and new_section_id is not None:
+          # There were not backward repeats, but we still want to play the
+          # previous section once.
+          # If new_section_id is None (implying that a section at the current
+          # time was created elsewhere), this is not needed because it should
+          # have been done when the section was created.
+          sg = self._ns.section_groups.add()
+          sg.sections.add(
+              section_id=self._ns.section_annotations[-2].section_id)
+          sg.num_times = 1
+
+        self._current_expected_repeats = forward_repeats
+      elif match.re == ABCTune.TEXT_ANNOTATION_PATTERN:
+        # Text annotation
+        # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+        # http://abcnotation.com/wiki/abc:standard:v2.1#annotations
+        annotation = match.group(1)
+        ta = self._ns.text_annotations.add()
+        ta.time = self._current_time
+        ta.text = annotation
+        if annotation and annotation[0] in ABCTune.ABC_NOTE_TO_MIDI:
+          # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols
+          ta.annotation_type = (
+              music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL)
+        else:
+          ta.annotation_type = (
+              music_pb2.NoteSequence.TextAnnotation.UNKNOWN)
+      elif match.re == ABCTune.DECORATION_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#decorations
+        # We don&#39;t currently do anything with decorations.
+        pass
+      elif match.re == ABCTune.SLUR_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+        # We don&#39;t currently do anything with slurs.
+        pass
+      elif match.re == ABCTune.TIE_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#ties_and_slurs
+        # We don&#39;t currently do anything with ties.
+        # TODO(fjord): Ideally, we would extend the duration of the previous
+        # note to include the duration of the next note.
+        pass
+      elif match.re == ABCTune.TUPLET_PATTERN:
+        raise TupletError(&#39;Tuplets are not supported.&#39;)
+      elif match.re == ABCTune.LINE_CONTINUATION_PATTERN:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#typesetting_line-breaks
+        # Line continuations are only for typesetting, so we can ignore them.
+        pass
+      else:
+        raise ABCParseError(&#39;Unknown regex match!&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  KEY_PATTERN = re.compile(
+      r&#39;([A-G])\s*([#b]?)\s*&#39;
+      r&#39;((?:(?:maj|ion|min|aeo|mix|dor|phr|lyd|loc|m)[^ ]*)?)&#39;,
+      re.IGNORECASE)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  KEY_ACCIDENTALS_PATTERN = re.compile(r&#39;(__|_|=|\^|\^\^)?([A-Ga-g])&#39;)
+
+  @staticmethod
+  def parse_key(key):
+    &#34;&#34;&#34;Parse an ABC key string.&#34;&#34;&#34;
+
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    key_match = ABCTune.KEY_PATTERN.match(key)
+    if not key_match:
+      raise ABCParseError(&#39;Could not parse key: {}&#39;.format(key))
+
+    key_components = list(key_match.groups())
+
+    # Shorten the mode to be at most 3 letters long.
+    mode = key_components[2][:3].lower()
+
+    # &#34;Minor&#34; and &#34;Aeolian&#34; are special cases that are abbreviated to &#39;m&#39;.
+    # &#34;Major&#34; and &#34;Ionian&#34; are special cases that are abbreviated to &#39;&#39;.
+    if mode in (&#39;min&#39;, &#39;aeo&#39;):
+      mode = &#39;m&#39;
+    elif mode in (&#39;maj&#39;, &#39;ion&#39;):
+      mode = &#39;&#39;
+
+    sig = ABCTune.KEY_TO_SIG[&#39;&#39;.join(key_components[0:2] + [mode]).lower()]
+
+    proto_key = ABCTune.KEY_TO_PROTO_KEY[&#39;&#39;.join(key_components[0:2]).lower()]
+
+    if mode == &#39;&#39;:  # pylint: disable=g-explicit-bool-comparison
+      proto_mode = music_pb2.NoteSequence.KeySignature.MAJOR
+    elif mode == &#39;m&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.MINOR
+    elif mode == &#39;mix&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.MIXOLYDIAN
+    elif mode == &#39;dor&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.DORIAN
+    elif mode == &#39;phr&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.PHRYGIAN
+    elif mode == &#39;lyd&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.LYDIAN
+    elif mode == &#39;loc&#39;:
+      proto_mode = music_pb2.NoteSequence.KeySignature.LOCRIAN
+    else:
+      raise ABCParseError(&#39;Unknown mode: {}&#39;.format(mode))
+
+    # Match the rest of the string for possible modifications.
+    pos = key_match.end()
+    exppos = key[pos:].find(&#39;exp&#39;)
+    if exppos != -1:
+      # Only explicit accidentals will be used.
+      accidentals = ABCTune._sig_to_accidentals(0)
+      pos += exppos + 3
+    else:
+      accidentals = ABCTune._sig_to_accidentals(sig)
+
+    while pos &lt; len(key):
+      note_match = ABCTune.KEY_ACCIDENTALS_PATTERN.match(key, pos)
+      if note_match:
+        pos += len(note_match.group(0))
+
+        note = note_match.group(2).upper()
+        if note_match.group(1):
+          if note_match.group(1) == &#39;^&#39;:
+            accidentals[note] = 1
+          elif note_match.group(1) == &#39;_&#39;:
+            accidentals[note] = -1
+          elif note_match.group(1) == &#39;=&#39;:
+            accidentals[note] = 0
+          else:
+            raise ABCParseError(
+                &#39;Invalid accidental: {}&#39;.format(note_match.group(1)))
+      else:
+        pos += 1
+
+    return accidentals, proto_key, proto_mode
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#outdated_information_field_syntax
+  # This syntax is deprecated but must still be supported.
+  TEMPO_DEPRECATED_PATTERN = re.compile(r&#39;C?\s*=?\s*(\d+)$&#39;)
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+  TEMPO_PATTERN = re.compile(r&#39;(?:&#34;[^&#34;]*&#34;)?\s*((?:\d+/\d+\s*)+)\s*=\s*(\d+)&#39;)
+  TEMPO_PATTERN_STRING_ONLY = re.compile(r&#39;&#34;([^&#34;]*)&#34;$&#39;)
+
+  def _parse_information_field(self, field_name, field_content):
+    &#34;&#34;&#34;Parses information field.&#34;&#34;&#34;
+    # http://abcnotation.com/wiki/abc:standard:v2.1#information_fields
+    if field_name == &#39;A&#39;:
+      pass
+    elif field_name == &#39;B&#39;:
+      pass
+    elif field_name == &#39;C&#39;:
+      # Composer
+      # http://abcnotation.com/wiki/abc:standard:v2.1#ccomposer
+      self._ns.sequence_metadata.composers.append(field_content)
+
+      # The first composer will be set as the primary artist.
+      if not self._ns.sequence_metadata.artist:
+        self._ns.sequence_metadata.artist = field_content
+    elif field_name == &#39;D&#39;:
+      pass
+    elif field_name == &#39;F&#39;:
+      pass
+    elif field_name == &#39;G&#39;:
+      pass
+    elif field_name == &#39;H&#39;:
+      pass
+    elif field_name == &#39;I&#39;:
+      pass
+    elif field_name == &#39;K&#39;:
+      # Key
+      # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+      accidentals, proto_key, proto_mode = ABCTune.parse_key(field_content)
+      self._accidentals = accidentals
+      ks = self._ns.key_signatures.add()
+      ks.key = proto_key
+      ks.mode = proto_mode
+      ks.time = self._current_time
+    elif field_name == &#39;L&#39;:
+      # Unit note length
+      # http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length
+      length = field_content.split(&#39;/&#39;, 1)
+
+      # Handle the case of L:1 being equivalent to L:1/1
+      if len(length) &lt; 2:
+        length.append(&#39;1&#39;)
+
+      try:
+        numerator = int(length[0])
+        denominator = int(length[1])
+      except ValueError as e:
+        raise ABCParseError(
+            e, &#39;Could not parse unit note length: {}&#39;.format(field_content))
+
+      self._current_unit_note_length = Fraction(numerator, denominator)
+    elif field_name == &#39;M&#39;:
+      # Meter
+      # http://abcnotation.com/wiki/abc:standard:v2.1#mmeter
+      if field_content.upper() == &#39;C&#39;:
+        ts = self._ns.time_signatures.add()
+        ts.numerator = 4
+        ts.denominator = 4
+        ts.time = self._current_time
+      elif field_content.upper() == &#39;C|&#39;:
+        ts = self._ns.time_signatures.add()
+        ts.numerator = 2
+        ts.denominator = 2
+        ts.time = self._current_time
+      elif field_content.lower() == &#39;none&#39;:
+        pass
+      else:
+        timesig = field_content.split(&#39;/&#39;, 1)
+        if len(timesig) != 2:
+          raise ABCParseError(&#39;Could not parse meter: {}&#39;.format(field_content))
+
+        ts = self._ns.time_signatures.add()
+        ts.time = self._current_time
+        try:
+          ts.numerator = int(timesig[0])
+          ts.denominator = int(timesig[1])
+        except ValueError as e:
+          raise ABCParseError(
+              e, &#39;Could not parse meter: {}&#39;.format(field_content))
+    elif field_name == &#39;m&#39;:
+      pass
+    elif field_name == &#39;N&#39;:
+      pass
+    elif field_name == &#39;O&#39;:
+      pass
+    elif field_name == &#39;P&#39;:
+      # TODO(fjord): implement part parsing.
+      raise PartError(&#39;ABC parts are not yet supported.&#39;)
+    elif field_name == &#39;Q&#39;:
+      # Tempo
+      # http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+
+      tempo_match = ABCTune.TEMPO_PATTERN.match(field_content)
+      deprecated_tempo_match = ABCTune.TEMPO_DEPRECATED_PATTERN.match(
+          field_content)
+      tempo_string_only_match = ABCTune.TEMPO_PATTERN_STRING_ONLY.match(
+          field_content)
+      if tempo_match:
+        tempo_rate = int(tempo_match.group(2))
+        tempo_unit = Fraction(0)
+        for beat in tempo_match.group(1).split():
+          tempo_unit += Fraction(beat)
+      elif deprecated_tempo_match:
+        # http://abcnotation.com/wiki/abc:standard:v2.1#outdated_information_field_syntax
+        # In the deprecated syntax, the tempo is interpreted based on the unit
+        # note length, which is potentially dependent on the current meter.
+        # Set tempo_unit to None for now, and the current unit note length will
+        # be filled in later.
+        tempo_unit = None
+        tempo_rate = int(deprecated_tempo_match.group(1))
+      elif tempo_string_only_match:
+        logging.warning(&#39;Ignoring string-only tempo marking: %s&#39;, field_content)
+        return
+      else:
+        raise ABCParseError(&#39;Could not parse tempo: {}&#39;.format(field_content))
+
+      if self._in_header:
+        # If we&#39;re in the header, save these until we&#39;ve finished parsing the
+        # header. The deprecated syntax relies on the unit note length and
+        # meter, which may not be set yet. At the end of the header, we&#39;ll fill
+        # in the necessary information and add these.
+        self._header_tempo_unit = tempo_unit
+        self._header_tempo_rate = tempo_rate
+      else:
+        self._add_tempo(tempo_unit, tempo_rate)
+    elif field_name == &#39;R&#39;:
+      pass
+    elif field_name == &#39;r&#39;:
+      pass
+    elif field_name == &#39;S&#39;:
+      pass
+    elif field_name == &#39;s&#39;:
+      pass
+    elif field_name == &#39;T&#39;:
+      # Title
+      # http://abcnotation.com/wiki/abc:standard:v2.1#ttune_title
+
+      if not self._in_header:
+        # TODO(fjord): Non-header titles are used to name parts of tunes, but
+        # NoteSequence doesn&#39;t currently have any place to put that information.
+        logging.warning(&#39;Ignoring non-header title: %s&#39;, field_content)
+        return
+
+      # If there are multiple titles, separate them with semicolons.
+      if self._ns.sequence_metadata.title:
+        self._ns.sequence_metadata.title += &#39;; &#39; + field_content
+      else:
+        self._ns.sequence_metadata.title = field_content
+    elif field_name == &#39;U&#39;:
+      pass
+    elif field_name == &#39;V&#39;:
+      raise MultiVoiceError(&#39;Multi-voice files are not currently supported.&#39;)
+    elif field_name == &#39;W&#39;:
+      pass
+    elif field_name == &#39;w&#39;:
+      pass
+    elif field_name == &#39;X&#39;:
+      # Reference number
+      # http://abcnotation.com/wiki/abc:standard:v2.1#xreference_number
+      self._ns.reference_number = int(field_content)
+    elif field_name == &#39;Z&#39;:
+      pass
+    else:
+      logging.warning(
+          &#39;Unknown field name %s with content %s&#39;, field_name, field_content)</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.abc_parser.ABCTune.ABC_NOTE_TO_MIDI"><code class="name">var <span class="ident">ABC_NOTE_TO_MIDI</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN"><code class="name">var <span class="ident">BAR_AND_REPEAT_SYMBOLS_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN"><code class="name">var <span class="ident">BAR_AND_VARIANT_ENDINGS_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.BROKEN_RHYTHM_PATTERN"><code class="name">var <span class="ident">BROKEN_RHYTHM_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.CHORD_PATTERN"><code class="name">var <span class="ident">CHORD_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.DECORATION_PATTERN"><code class="name">var <span class="ident">DECORATION_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.DECORATION_TO_VELOCITY"><code class="name">var <span class="ident">DECORATION_TO_VELOCITY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.FLATS_ORDER"><code class="name">var <span class="ident">FLATS_ORDER</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.INFORMATION_FIELD_PATTERN"><code class="name">var <span class="ident">INFORMATION_FIELD_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.INLINE_INFORMATION_FIELD_PATTERN"><code class="name">var <span class="ident">INLINE_INFORMATION_FIELD_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.KEY_ACCIDENTALS_PATTERN"><code class="name">var <span class="ident">KEY_ACCIDENTALS_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.KEY_PATTERN"><code class="name">var <span class="ident">KEY_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.KEY_TO_PROTO_KEY"><code class="name">var <span class="ident">KEY_TO_PROTO_KEY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.KEY_TO_SIG"><code class="name">var <span class="ident">KEY_TO_SIG</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.LINE_CONTINUATION_PATTERN"><code class="name">var <span class="ident">LINE_CONTINUATION_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.NOTE_PATTERN"><code class="name">var <span class="ident">NOTE_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.REPEAT_SYMBOLS_PATTERN"><code class="name">var <span class="ident">REPEAT_SYMBOLS_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.SHARPS_ORDER"><code class="name">var <span class="ident">SHARPS_ORDER</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.SIG_TO_KEYS"><code class="name">var <span class="ident">SIG_TO_KEYS</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.SLUR_PATTERN"><code class="name">var <span class="ident">SLUR_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TEMPO_DEPRECATED_PATTERN"><code class="name">var <span class="ident">TEMPO_DEPRECATED_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TEMPO_PATTERN"><code class="name">var <span class="ident">TEMPO_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TEMPO_PATTERN_STRING_ONLY"><code class="name">var <span class="ident">TEMPO_PATTERN_STRING_ONLY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TEXT_ANNOTATION_PATTERN"><code class="name">var <span class="ident">TEXT_ANNOTATION_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TIE_PATTERN"><code class="name">var <span class="ident">TIE_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.TUPLET_PATTERN"><code class="name">var <span class="ident">TUPLET_PATTERN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.key"><code class="name">var <span class="ident">key</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.keys"><code class="name">var <span class="ident">keys</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.abc_parser.ABCTune.sig"><code class="name">var <span class="ident">sig</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Static methods</h3>
+<dl>
+<dt id="note_seq.abc_parser.ABCTune.parse_key"><code class="name flex">
+<span>def <span class="ident">parse_key</span></span>(<span>key)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Parse an ABC key string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def parse_key(key):
+  &#34;&#34;&#34;Parse an ABC key string.&#34;&#34;&#34;
+
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  key_match = ABCTune.KEY_PATTERN.match(key)
+  if not key_match:
+    raise ABCParseError(&#39;Could not parse key: {}&#39;.format(key))
+
+  key_components = list(key_match.groups())
+
+  # Shorten the mode to be at most 3 letters long.
+  mode = key_components[2][:3].lower()
+
+  # &#34;Minor&#34; and &#34;Aeolian&#34; are special cases that are abbreviated to &#39;m&#39;.
+  # &#34;Major&#34; and &#34;Ionian&#34; are special cases that are abbreviated to &#39;&#39;.
+  if mode in (&#39;min&#39;, &#39;aeo&#39;):
+    mode = &#39;m&#39;
+  elif mode in (&#39;maj&#39;, &#39;ion&#39;):
+    mode = &#39;&#39;
+
+  sig = ABCTune.KEY_TO_SIG[&#39;&#39;.join(key_components[0:2] + [mode]).lower()]
+
+  proto_key = ABCTune.KEY_TO_PROTO_KEY[&#39;&#39;.join(key_components[0:2]).lower()]
+
+  if mode == &#39;&#39;:  # pylint: disable=g-explicit-bool-comparison
+    proto_mode = music_pb2.NoteSequence.KeySignature.MAJOR
+  elif mode == &#39;m&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.MINOR
+  elif mode == &#39;mix&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.MIXOLYDIAN
+  elif mode == &#39;dor&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.DORIAN
+  elif mode == &#39;phr&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.PHRYGIAN
+  elif mode == &#39;lyd&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.LYDIAN
+  elif mode == &#39;loc&#39;:
+    proto_mode = music_pb2.NoteSequence.KeySignature.LOCRIAN
+  else:
+    raise ABCParseError(&#39;Unknown mode: {}&#39;.format(mode))
+
+  # Match the rest of the string for possible modifications.
+  pos = key_match.end()
+  exppos = key[pos:].find(&#39;exp&#39;)
+  if exppos != -1:
+    # Only explicit accidentals will be used.
+    accidentals = ABCTune._sig_to_accidentals(0)
+    pos += exppos + 3
+  else:
+    accidentals = ABCTune._sig_to_accidentals(sig)
+
+  while pos &lt; len(key):
+    note_match = ABCTune.KEY_ACCIDENTALS_PATTERN.match(key, pos)
+    if note_match:
+      pos += len(note_match.group(0))
+
+      note = note_match.group(2).upper()
+      if note_match.group(1):
+        if note_match.group(1) == &#39;^&#39;:
+          accidentals[note] = 1
+        elif note_match.group(1) == &#39;_&#39;:
+          accidentals[note] = -1
+        elif note_match.group(1) == &#39;=&#39;:
+          accidentals[note] = 0
+        else:
+          raise ABCParseError(
+              &#39;Invalid accidental: {}&#39;.format(note_match.group(1)))
+    else:
+      pos += 1
+
+  return accidentals, proto_key, proto_mode</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.abc_parser.ABCTune.note_sequence"><code class="name">var <span class="ident">note_sequence</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def note_sequence(self):
+  return self._ns</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.abc_parser.ChordError"><code class="flex name class">
+<span>class <span class="ident">ChordError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Chords are not supported.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordError(ABCParseError):
+  &#34;&#34;&#34;Chords are not supported.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.DuplicateReferenceNumberError"><code class="flex name class">
+<span>class <span class="ident">DuplicateReferenceNumberError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Found duplicate reference numbers.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DuplicateReferenceNumberError(ABCParseError):
+  &#34;&#34;&#34;Found duplicate reference numbers.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.InvalidCharacterError"><code class="flex name class">
+<span>class <span class="ident">InvalidCharacterError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Invalid character.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InvalidCharacterError(ABCParseError):
+  &#34;&#34;&#34;Invalid character.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.MultiVoiceError"><code class="flex name class">
+<span>class <span class="ident">MultiVoiceError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception when a multi-voice directive is encountered.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultiVoiceError(ABCParseError):
+  &#34;&#34;&#34;Exception when a multi-voice directive is encountered.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.PartError"><code class="flex name class">
+<span>class <span class="ident">PartError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>ABC Parts are not yet supported.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PartError(ABCParseError):
+  &#34;&#34;&#34;ABC Parts are not yet supported.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.RepeatParseError"><code class="flex name class">
+<span>class <span class="ident">RepeatParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception when a repeat directive could not be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class RepeatParseError(ABCParseError):
+  &#34;&#34;&#34;Exception when a repeat directive could not be parsed.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.TupletError"><code class="flex name class">
+<span>class <span class="ident">TupletError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Tuplets are not supported.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TupletError(ABCParseError):
+  &#34;&#34;&#34;Tuplets are not supported.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.abc_parser.VariantEndingError"><code class="flex name class">
+<span>class <span class="ident">VariantEndingError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Variant endings are not yet supported.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class VariantEndingError(ABCParseError):
+  &#34;&#34;&#34;Variant endings are not yet supported.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.abc_parser.parse_abc_tunebook" href="#note_seq.abc_parser.parse_abc_tunebook">parse_abc_tunebook</a></code></li>
+<li><code><a title="note_seq.abc_parser.parse_abc_tunebook_file" href="#note_seq.abc_parser.parse_abc_tunebook_file">parse_abc_tunebook_file</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.abc_parser.ABCParseError" href="#note_seq.abc_parser.ABCParseError">ABCParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.ABCTune" href="#note_seq.abc_parser.ABCTune">ABCTune</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.abc_parser.ABCTune.ABC_NOTE_TO_MIDI" href="#note_seq.abc_parser.ABCTune.ABC_NOTE_TO_MIDI">ABC_NOTE_TO_MIDI</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN" href="#note_seq.abc_parser.ABCTune.BAR_AND_REPEAT_SYMBOLS_PATTERN">BAR_AND_REPEAT_SYMBOLS_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN" href="#note_seq.abc_parser.ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN">BAR_AND_VARIANT_ENDINGS_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.BROKEN_RHYTHM_PATTERN" href="#note_seq.abc_parser.ABCTune.BROKEN_RHYTHM_PATTERN">BROKEN_RHYTHM_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.CHORD_PATTERN" href="#note_seq.abc_parser.ABCTune.CHORD_PATTERN">CHORD_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.DECORATION_PATTERN" href="#note_seq.abc_parser.ABCTune.DECORATION_PATTERN">DECORATION_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.DECORATION_TO_VELOCITY" href="#note_seq.abc_parser.ABCTune.DECORATION_TO_VELOCITY">DECORATION_TO_VELOCITY</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.FLATS_ORDER" href="#note_seq.abc_parser.ABCTune.FLATS_ORDER">FLATS_ORDER</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.INFORMATION_FIELD_PATTERN" href="#note_seq.abc_parser.ABCTune.INFORMATION_FIELD_PATTERN">INFORMATION_FIELD_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.INLINE_INFORMATION_FIELD_PATTERN" href="#note_seq.abc_parser.ABCTune.INLINE_INFORMATION_FIELD_PATTERN">INLINE_INFORMATION_FIELD_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.KEY_ACCIDENTALS_PATTERN" href="#note_seq.abc_parser.ABCTune.KEY_ACCIDENTALS_PATTERN">KEY_ACCIDENTALS_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.KEY_PATTERN" href="#note_seq.abc_parser.ABCTune.KEY_PATTERN">KEY_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.KEY_TO_PROTO_KEY" href="#note_seq.abc_parser.ABCTune.KEY_TO_PROTO_KEY">KEY_TO_PROTO_KEY</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.KEY_TO_SIG" href="#note_seq.abc_parser.ABCTune.KEY_TO_SIG">KEY_TO_SIG</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.LINE_CONTINUATION_PATTERN" href="#note_seq.abc_parser.ABCTune.LINE_CONTINUATION_PATTERN">LINE_CONTINUATION_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.NOTE_PATTERN" href="#note_seq.abc_parser.ABCTune.NOTE_PATTERN">NOTE_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.REPEAT_SYMBOLS_PATTERN" href="#note_seq.abc_parser.ABCTune.REPEAT_SYMBOLS_PATTERN">REPEAT_SYMBOLS_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.SHARPS_ORDER" href="#note_seq.abc_parser.ABCTune.SHARPS_ORDER">SHARPS_ORDER</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.SIG_TO_KEYS" href="#note_seq.abc_parser.ABCTune.SIG_TO_KEYS">SIG_TO_KEYS</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.SLUR_PATTERN" href="#note_seq.abc_parser.ABCTune.SLUR_PATTERN">SLUR_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TEMPO_DEPRECATED_PATTERN" href="#note_seq.abc_parser.ABCTune.TEMPO_DEPRECATED_PATTERN">TEMPO_DEPRECATED_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TEMPO_PATTERN" href="#note_seq.abc_parser.ABCTune.TEMPO_PATTERN">TEMPO_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TEMPO_PATTERN_STRING_ONLY" href="#note_seq.abc_parser.ABCTune.TEMPO_PATTERN_STRING_ONLY">TEMPO_PATTERN_STRING_ONLY</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TEXT_ANNOTATION_PATTERN" href="#note_seq.abc_parser.ABCTune.TEXT_ANNOTATION_PATTERN">TEXT_ANNOTATION_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TIE_PATTERN" href="#note_seq.abc_parser.ABCTune.TIE_PATTERN">TIE_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.TUPLET_PATTERN" href="#note_seq.abc_parser.ABCTune.TUPLET_PATTERN">TUPLET_PATTERN</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.key" href="#note_seq.abc_parser.ABCTune.key">key</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.keys" href="#note_seq.abc_parser.ABCTune.keys">keys</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.note_sequence" href="#note_seq.abc_parser.ABCTune.note_sequence">note_sequence</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.parse_key" href="#note_seq.abc_parser.ABCTune.parse_key">parse_key</a></code></li>
+<li><code><a title="note_seq.abc_parser.ABCTune.sig" href="#note_seq.abc_parser.ABCTune.sig">sig</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.ChordError" href="#note_seq.abc_parser.ChordError">ChordError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.DuplicateReferenceNumberError" href="#note_seq.abc_parser.DuplicateReferenceNumberError">DuplicateReferenceNumberError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.InvalidCharacterError" href="#note_seq.abc_parser.InvalidCharacterError">InvalidCharacterError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.MultiVoiceError" href="#note_seq.abc_parser.MultiVoiceError">MultiVoiceError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.PartError" href="#note_seq.abc_parser.PartError">PartError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.RepeatParseError" href="#note_seq.abc_parser.RepeatParseError">RepeatParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.TupletError" href="#note_seq.abc_parser.TupletError">TupletError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.abc_parser.VariantEndingError" href="#note_seq.abc_parser.VariantEndingError">VariantEndingError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/abc_parser_test.html
+++ b/docs/abc_parser_test.html
@@ -1,0 +1,3882 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.abc_parser_test API documentation</title>
+<meta name="description" content="Tests for abc_parser." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.abc_parser_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for abc_parser.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for abc_parser.&#34;&#34;&#34;
+
+import copy
+import os.path
+
+from absl.testing import absltest
+from note_seq import abc_parser
+from note_seq import midi_io
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+
+class AbcParserTest(testing_lib.ProtoTestCase):
+
+  def compare_accidentals(self, expected, accidentals):
+    self.assertCountEqual(expected, accidentals.values())
+
+  def compare_proto_list(self, expected, test):
+    self.assertEqual(len(expected), len(test))
+    for e, t in zip(expected, test):
+      self.assertProtoEquals(e, t)
+
+  def compare_to_abc2midi_and_metadata(
+      self, midi_path, expected_metadata, expected_expanded_metadata, test):
+    &#34;&#34;&#34;Compare parsing results to the abc2midi &#34;reference&#34; implementation.&#34;&#34;&#34;
+    # Compare section annotations and groups before expanding.
+    self.compare_proto_list(expected_metadata.section_annotations,
+                            test.section_annotations)
+    self.compare_proto_list(expected_metadata.section_groups,
+                            test.section_groups)
+
+    expanded_test = sequences_lib.expand_section_groups(test)
+
+    abc2midi = midi_io.midi_file_to_sequence_proto(
+        os.path.join(testing_lib.get_testdata_dir(), midi_path))
+
+    # abc2midi adds a 1-tick delay to the start of every note, but we don&#39;t.
+    tick_length = ((1 / (abc2midi.tempos[0].qpm / 60)) /
+                   abc2midi.ticks_per_quarter)
+
+    for note in abc2midi.notes:
+      # For now, don&#39;t compare velocities.
+      note.velocity = 90
+      note.start_time -= tick_length
+
+    self.compare_proto_list(abc2midi.notes, expanded_test.notes)
+
+    self.assertEqual(abc2midi.total_time, expanded_test.total_time)
+
+    self.compare_proto_list(abc2midi.time_signatures,
+                            expanded_test.time_signatures)
+
+    # We&#39;ve checked the notes and time signatures, now compare the rest of the
+    # proto to the expected proto.
+    expanded_test_copy = copy.deepcopy(expanded_test)
+    del expanded_test_copy.notes[:]
+    expanded_test_copy.ClearField(&#39;total_time&#39;)
+    del expanded_test_copy.time_signatures[:]
+
+    self.assertProtoEquals(expected_expanded_metadata, expanded_test_copy)
+
+  def testParseKeyBasic(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;C major&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;A minor&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;C ionian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;A aeolian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;G Mixolydian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.G, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D dorian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.DORIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;E phrygian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.E, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F Lydian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.LYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;B Locrian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.B, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.LOCRIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F# mixolydian&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F#Mix&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F#MIX&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;Fm&#39;)
+    self.compare_accidentals([-1, -1, 0, -1, -1, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+  def testParseKeyExplicit(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D exp _b _e ^f&#39;)
+    self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  def testParseKeyAccidentals(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D Phr ^f&#39;)
+    self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D maj =c&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D =c&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  def testParseEnglishAbc(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+        os.path.join(testing_lib.get_testdata_dir(), &#39;english.abc&#39;))
+    self.assertLen(tunes, 1)
+    self.assertLen(exceptions, 2)
+    self.assertIsInstance(exceptions[0], abc_parser.VariantEndingError)
+    self.assertIsInstance(exceptions[1], abc_parser.PartError)
+
+    expected_metadata1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+          artist: &#34;Trad.&#34;
+          composers: &#34;Trad.&#34;
+        }
+        key_signatures {
+          key: G
+        }
+        section_annotations {
+          time: 0.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 6.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 12.0
+          section_id: 2
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
+        &#34;&#34;&#34;)
+    expected_expanded_metadata1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+          artist: &#34;Trad.&#34;
+          composers: &#34;Trad.&#34;
+        }
+        key_signatures {
+          key: G
+        }
+        section_annotations {
+          time: 0.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 6.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 12.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 18.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 24.0
+          section_id: 2
+        }
+        section_annotations {
+          time: 30.0
+          section_id: 2
+        }
+        &#34;&#34;&#34;)
+    self.compare_to_abc2midi_and_metadata(
+        &#39;english1.mid&#39;, expected_metadata1,
+        expected_expanded_metadata1, tunes[1])
+
+    # TODO(fjord): re-enable once we support variant endings.
+    # expected_ns2_metadata = testing_lib.parse_test_proto(
+    #     music_pb2.NoteSequence,
+    #     &#34;&#34;&#34;
+    #     ticks_per_quarter: 220
+    #     source_info: {
+    #       source_type: SCORE_BASED
+    #       encoding_type: ABC
+    #       parser: MAGENTA_ABC
+    #     }
+    #     reference_number: 2
+    #     sequence_metadata {
+    #       title: &#34;Old Sir Simon the King&#34;
+    #       artist: &#34;Trad.&#34;
+    #       composers: &#34;Trad.&#34;
+    #     }
+    #     key_signatures {
+    #       key: G
+    #     }
+    #     &#34;&#34;&#34;)
+    # self.compare_to_abc2midi_and_metadata(
+    #     &#39;english2.mid&#39;, expected_ns2_metadata, tunes[1])
+
+    # TODO(fjord): re-enable once we support parts.
+    # expected_ns3_metadata = testing_lib.parse_test_proto(
+    #     music_pb2.NoteSequence,
+    #     &#34;&#34;&#34;
+    #     ticks_per_quarter: 220
+    #     source_info: {
+    #       source_type: SCORE_BASED
+    #       encoding_type: ABC
+    #       parser: MAGENTA_ABC
+    #     }
+    #     reference_number: 3
+    #     sequence_metadata {
+    #       title: &#34;William and Nancy; New Mown Hay; Legacy, The&#34;
+    #       artist: &#34;Trad.&#34;
+    #       composers: &#34;Trad.&#34;
+    #     }
+    #     key_signatures {
+    #       key: G
+    #     }
+    #     &#34;&#34;&#34;)
+    # # TODO(fjord): verify chord annotations
+    # del tunes[3].text_annotations[:]
+    # self.compare_to_abc2midi_and_metadata(
+    #     &#39;english3.mid&#39;, expected_ns3_metadata, tunes[3])
+
+  def testParseOctaves(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+        T:Test
+        CC,&#39;,C,C&#39;c
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          end_time: 0.25
+        }
+        notes {
+          pitch: 48
+          velocity: 90
+          start_time: 0.25
+          end_time: 0.5
+        }
+        notes {
+          pitch: 48
+          velocity: 90
+          start_time: 0.5
+          end_time: 0.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.75
+          end_time: 1.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.25
+        }
+        total_time: 1.25
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testParseTempos(self):
+    # Examples from http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        L:1/4
+        Q:60
+
+        X:2
+        L:1/4
+        Q:C=100
+
+        X:3
+        Q:1/2=120
+
+        X:4
+        Q:1/4 3/8 1/4 3/8=40
+
+        X:5
+        Q:5/4=40
+
+        X:6
+        Q: &#34;Allegro&#34; 1/4=120
+
+        X:7
+        Q: 1/4=120 &#34;Allegro&#34;
+
+        X:8
+        Q: 3/8=50 &#34;Slowly&#34;
+
+        X:9
+        Q:&#34;Andante&#34;
+
+        X:10
+        Q:100  % define tempo using deprecated syntax
+        % deprecated tempo syntax depends on unit note length. if it is
+        % not defined, it is derived from the current meter.
+        M:2/4  % define meter after tempo to verify that is supported.
+
+        X:11
+        Q:100  % define tempo using deprecated syntax
+        % deprecated tempo syntax depends on unit note length.
+        L:1/4  % define note length after tempo to verify that is supported.
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 11)
+    self.assertEmpty(exceptions)
+
+    self.assertEqual(60, tunes[1].tempos[0].qpm)
+    self.assertEqual(100, tunes[2].tempos[0].qpm)
+    self.assertEqual(240, tunes[3].tempos[0].qpm)
+    self.assertEqual(200, tunes[4].tempos[0].qpm)
+    self.assertEqual(200, tunes[5].tempos[0].qpm)
+    self.assertEqual(120, tunes[6].tempos[0].qpm)
+    self.assertEqual(120, tunes[7].tempos[0].qpm)
+    self.assertEqual(75, tunes[8].tempos[0].qpm)
+    self.assertEmpty(tunes[9].tempos, 0)
+    self.assertEqual(25, tunes[10].tempos[0].qpm)
+    self.assertEqual(100, tunes[11].tempos[0].qpm)
+
+  def testParseBrokenRhythm(self):
+    # These tunes should be equivalent.
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B&gt;cd B&lt;cd
+
+        X:2
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B3/2c/2d B/2c3/2d
+
+        X:3
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B3/c/d B/c3/d
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 3)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        time_signatures {
+          numerator: 3
+          denominator: 4
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.75
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 1.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 1.75
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+    expected_ns2 = copy.deepcopy(expected_ns1)
+    expected_ns2.reference_number = 2
+    self.assertProtoEquals(expected_ns2, tunes[2])
+    expected_ns2.reference_number = 3
+    self.assertProtoEquals(expected_ns2, tunes[3])
+
+  def testSlashDuration(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        CC/C//C///C////
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.5
+          end_time: 0.75
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.75
+          end_time: 0.875
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.875
+          end_time: 0.9375
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.9375
+          end_time: 0.96875
+        }
+        total_time: 0.96875
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testMultiVoice(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+        os.path.join(testing_lib.get_testdata_dir(),
+                     &#39;zocharti_loch.abc&#39;))
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.MultiVoiceError)
+
+  def testRepeats(self):
+    # Several equivalent versions of the same tune.
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd ::[]|[]:: Bcd ::|
+
+        X:2
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd :::: Bcd ::|
+
+        X:3
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |::Bcd ::|:: Bcd ::|
+
+        % This version contains mismatched repeat symbols.
+        X:4
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |::Bcd ::|: Bcd ::|
+
+        % This version is missing a repeat symbol at the end.
+        X:5
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::|: Bcd |
+
+        % Ambiguous repeat that should go to the last repeat symbol.
+        X:6
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd :|
+
+        % Ambiguous repeat that should go to the last double bar.
+        X:7
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd || Bcd :|
+
+        % Ambiguous repeat that should go to the last double bar.
+        X:8
+        Q:1/4=120
+        L:1/4
+        T:Test
+        || Bcd ::| Bcd || Bcd :|
+
+        % Ensure double bar doesn&#39;t confuse declared repeat.
+        X:9
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: B || cd ::| Bcd || |: Bcd :|
+
+        % Mismatched repeat at the very beginning.
+        X:10
+        Q:1/4=120
+        L:1/4
+        T:Test
+        :| Bcd |:: Bcd ::|
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 7)
+    self.assertLen(exceptions, 3)
+    self.assertIsInstance(exceptions[0], abc_parser.RepeatParseError)
+    self.assertIsInstance(exceptions[1], abc_parser.RepeatParseError)
+    self.assertIsInstance(exceptions[2], abc_parser.RepeatParseError)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 3
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 3
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+    # Other versions are identical except for the reference number.
+    expected_ns2 = copy.deepcopy(expected_ns1)
+    expected_ns2.reference_number = 2
+    self.assertProtoEquals(expected_ns2, tunes[2])
+
+    expected_ns3 = copy.deepcopy(expected_ns1)
+    expected_ns3.reference_number = 3
+    self.assertProtoEquals(expected_ns3, tunes[3])
+
+    # Also identical, except the last section is played only twice.
+    expected_ns6 = copy.deepcopy(expected_ns1)
+    expected_ns6.reference_number = 6
+    expected_ns6.section_groups[-1].num_times = 2
+    self.assertProtoEquals(expected_ns6, tunes[6])
+
+    expected_ns7 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 7
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 3.5
+          end_time: 4.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 4.0
+          end_time: 4.5
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_annotations {
+          time: 3.0
+          section_id: 2
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 3
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 1
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
+        total_time: 4.5
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns7, tunes[7])
+
+    expected_ns8 = copy.deepcopy(expected_ns7)
+    expected_ns8.reference_number = 8
+    self.assertProtoEquals(expected_ns8, tunes[8])
+
+    expected_ns9 = copy.deepcopy(expected_ns7)
+    expected_ns9.reference_number = 9
+    self.assertProtoEquals(expected_ns9, tunes[9])
+
+  def testInvalidCharacter(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        invalid notes!&#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.InvalidCharacterError)
+
+  def testOneSidedRepeat(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd :| Bcd
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 1
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testChords(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        [CEG]&#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.ChordError)
+
+  def testChordAnnotations(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        &#34;G&#34;G
+        % verify that an empty annotation doesn&#39;t cause problems.
+        &#34;&#34;D
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          end_time: 0.5
+        }
+        notes {
+          pitch: 62
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        text_annotations {
+          text: &#34;G&#34;
+          annotation_type: CHORD_SYMBOL
+        }
+        text_annotations {
+          time: 0.5
+        }
+        total_time: 1.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testNoteAccidentalsPerBar(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        GF^GGg|Gg
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 65
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 80
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 79
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        total_time: 3.5
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testDecorations(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        .a~bHcLdMeOfPgSATbucvd
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 11)
+
+  def testSlur(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        (ABC) ( a b c ) (c (d e f) g a)
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 12)
+
+  def testTie(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        abc-|cba c4-c4 C.-C
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 10)
+
+  def testTuplet(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        (3abc
+        &#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.TupletError)
+
+  def testLineContinuation(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(r&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        abc \
+        cba|
+        abc\
+         cba|
+        abc cba|
+        cdef|\
+        \
+        cedf:|
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 26)
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.abc_parser_test.AbcParserTest"><code class="flex name class">
+<span>class <span class="ident">AbcParserTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AbcParserTest(testing_lib.ProtoTestCase):
+
+  def compare_accidentals(self, expected, accidentals):
+    self.assertCountEqual(expected, accidentals.values())
+
+  def compare_proto_list(self, expected, test):
+    self.assertEqual(len(expected), len(test))
+    for e, t in zip(expected, test):
+      self.assertProtoEquals(e, t)
+
+  def compare_to_abc2midi_and_metadata(
+      self, midi_path, expected_metadata, expected_expanded_metadata, test):
+    &#34;&#34;&#34;Compare parsing results to the abc2midi &#34;reference&#34; implementation.&#34;&#34;&#34;
+    # Compare section annotations and groups before expanding.
+    self.compare_proto_list(expected_metadata.section_annotations,
+                            test.section_annotations)
+    self.compare_proto_list(expected_metadata.section_groups,
+                            test.section_groups)
+
+    expanded_test = sequences_lib.expand_section_groups(test)
+
+    abc2midi = midi_io.midi_file_to_sequence_proto(
+        os.path.join(testing_lib.get_testdata_dir(), midi_path))
+
+    # abc2midi adds a 1-tick delay to the start of every note, but we don&#39;t.
+    tick_length = ((1 / (abc2midi.tempos[0].qpm / 60)) /
+                   abc2midi.ticks_per_quarter)
+
+    for note in abc2midi.notes:
+      # For now, don&#39;t compare velocities.
+      note.velocity = 90
+      note.start_time -= tick_length
+
+    self.compare_proto_list(abc2midi.notes, expanded_test.notes)
+
+    self.assertEqual(abc2midi.total_time, expanded_test.total_time)
+
+    self.compare_proto_list(abc2midi.time_signatures,
+                            expanded_test.time_signatures)
+
+    # We&#39;ve checked the notes and time signatures, now compare the rest of the
+    # proto to the expected proto.
+    expanded_test_copy = copy.deepcopy(expanded_test)
+    del expanded_test_copy.notes[:]
+    expanded_test_copy.ClearField(&#39;total_time&#39;)
+    del expanded_test_copy.time_signatures[:]
+
+    self.assertProtoEquals(expected_expanded_metadata, expanded_test_copy)
+
+  def testParseKeyBasic(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;C major&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;A minor&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;C ionian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;A aeolian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;G Mixolydian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.G, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D dorian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.DORIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;E phrygian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.E, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F Lydian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.LYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;B Locrian&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.B, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.LOCRIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F# mixolydian&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F#Mix&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;F#MIX&#39;)
+    self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;Fm&#39;)
+    self.compare_accidentals([-1, -1, 0, -1, -1, 0, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+  def testParseKeyExplicit(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D exp _b _e ^f&#39;)
+    self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  def testParseKeyAccidentals(self):
+    # Most examples taken from
+    # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D Phr ^f&#39;)
+    self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                     proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D maj =c&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+    accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+        &#39;D =c&#39;)
+    self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  def testParseEnglishAbc(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+        os.path.join(testing_lib.get_testdata_dir(), &#39;english.abc&#39;))
+    self.assertLen(tunes, 1)
+    self.assertLen(exceptions, 2)
+    self.assertIsInstance(exceptions[0], abc_parser.VariantEndingError)
+    self.assertIsInstance(exceptions[1], abc_parser.PartError)
+
+    expected_metadata1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+          artist: &#34;Trad.&#34;
+          composers: &#34;Trad.&#34;
+        }
+        key_signatures {
+          key: G
+        }
+        section_annotations {
+          time: 0.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 6.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 12.0
+          section_id: 2
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
+        &#34;&#34;&#34;)
+    expected_expanded_metadata1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+          artist: &#34;Trad.&#34;
+          composers: &#34;Trad.&#34;
+        }
+        key_signatures {
+          key: G
+        }
+        section_annotations {
+          time: 0.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 6.0
+          section_id: 0
+        }
+        section_annotations {
+          time: 12.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 18.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 24.0
+          section_id: 2
+        }
+        section_annotations {
+          time: 30.0
+          section_id: 2
+        }
+        &#34;&#34;&#34;)
+    self.compare_to_abc2midi_and_metadata(
+        &#39;english1.mid&#39;, expected_metadata1,
+        expected_expanded_metadata1, tunes[1])
+
+    # TODO(fjord): re-enable once we support variant endings.
+    # expected_ns2_metadata = testing_lib.parse_test_proto(
+    #     music_pb2.NoteSequence,
+    #     &#34;&#34;&#34;
+    #     ticks_per_quarter: 220
+    #     source_info: {
+    #       source_type: SCORE_BASED
+    #       encoding_type: ABC
+    #       parser: MAGENTA_ABC
+    #     }
+    #     reference_number: 2
+    #     sequence_metadata {
+    #       title: &#34;Old Sir Simon the King&#34;
+    #       artist: &#34;Trad.&#34;
+    #       composers: &#34;Trad.&#34;
+    #     }
+    #     key_signatures {
+    #       key: G
+    #     }
+    #     &#34;&#34;&#34;)
+    # self.compare_to_abc2midi_and_metadata(
+    #     &#39;english2.mid&#39;, expected_ns2_metadata, tunes[1])
+
+    # TODO(fjord): re-enable once we support parts.
+    # expected_ns3_metadata = testing_lib.parse_test_proto(
+    #     music_pb2.NoteSequence,
+    #     &#34;&#34;&#34;
+    #     ticks_per_quarter: 220
+    #     source_info: {
+    #       source_type: SCORE_BASED
+    #       encoding_type: ABC
+    #       parser: MAGENTA_ABC
+    #     }
+    #     reference_number: 3
+    #     sequence_metadata {
+    #       title: &#34;William and Nancy; New Mown Hay; Legacy, The&#34;
+    #       artist: &#34;Trad.&#34;
+    #       composers: &#34;Trad.&#34;
+    #     }
+    #     key_signatures {
+    #       key: G
+    #     }
+    #     &#34;&#34;&#34;)
+    # # TODO(fjord): verify chord annotations
+    # del tunes[3].text_annotations[:]
+    # self.compare_to_abc2midi_and_metadata(
+    #     &#39;english3.mid&#39;, expected_ns3_metadata, tunes[3])
+
+  def testParseOctaves(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+        T:Test
+        CC,&#39;,C,C&#39;c
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          end_time: 0.25
+        }
+        notes {
+          pitch: 48
+          velocity: 90
+          start_time: 0.25
+          end_time: 0.5
+        }
+        notes {
+          pitch: 48
+          velocity: 90
+          start_time: 0.5
+          end_time: 0.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.75
+          end_time: 1.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.25
+        }
+        total_time: 1.25
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testParseTempos(self):
+    # Examples from http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        L:1/4
+        Q:60
+
+        X:2
+        L:1/4
+        Q:C=100
+
+        X:3
+        Q:1/2=120
+
+        X:4
+        Q:1/4 3/8 1/4 3/8=40
+
+        X:5
+        Q:5/4=40
+
+        X:6
+        Q: &#34;Allegro&#34; 1/4=120
+
+        X:7
+        Q: 1/4=120 &#34;Allegro&#34;
+
+        X:8
+        Q: 3/8=50 &#34;Slowly&#34;
+
+        X:9
+        Q:&#34;Andante&#34;
+
+        X:10
+        Q:100  % define tempo using deprecated syntax
+        % deprecated tempo syntax depends on unit note length. if it is
+        % not defined, it is derived from the current meter.
+        M:2/4  % define meter after tempo to verify that is supported.
+
+        X:11
+        Q:100  % define tempo using deprecated syntax
+        % deprecated tempo syntax depends on unit note length.
+        L:1/4  % define note length after tempo to verify that is supported.
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 11)
+    self.assertEmpty(exceptions)
+
+    self.assertEqual(60, tunes[1].tempos[0].qpm)
+    self.assertEqual(100, tunes[2].tempos[0].qpm)
+    self.assertEqual(240, tunes[3].tempos[0].qpm)
+    self.assertEqual(200, tunes[4].tempos[0].qpm)
+    self.assertEqual(200, tunes[5].tempos[0].qpm)
+    self.assertEqual(120, tunes[6].tempos[0].qpm)
+    self.assertEqual(120, tunes[7].tempos[0].qpm)
+    self.assertEqual(75, tunes[8].tempos[0].qpm)
+    self.assertEmpty(tunes[9].tempos, 0)
+    self.assertEqual(25, tunes[10].tempos[0].qpm)
+    self.assertEqual(100, tunes[11].tempos[0].qpm)
+
+  def testParseBrokenRhythm(self):
+    # These tunes should be equivalent.
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B&gt;cd B&lt;cd
+
+        X:2
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B3/2c/2d B/2c3/2d
+
+        X:3
+        Q:1/4=120
+        L:1/4
+        M:3/4
+        T:Test
+        B3/c/d B/c3/d
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 3)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        time_signatures {
+          numerator: 3
+          denominator: 4
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.75
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 1.75
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 1.75
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+    expected_ns2 = copy.deepcopy(expected_ns1)
+    expected_ns2.reference_number = 2
+    self.assertProtoEquals(expected_ns2, tunes[2])
+    expected_ns2.reference_number = 3
+    self.assertProtoEquals(expected_ns2, tunes[3])
+
+  def testSlashDuration(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        CC/C//C///C////
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.5
+          end_time: 0.75
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.75
+          end_time: 0.875
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.875
+          end_time: 0.9375
+        }
+        notes {
+          pitch: 60
+          velocity: 90
+          start_time: 0.9375
+          end_time: 0.96875
+        }
+        total_time: 0.96875
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testMultiVoice(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+        os.path.join(testing_lib.get_testdata_dir(),
+                     &#39;zocharti_loch.abc&#39;))
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.MultiVoiceError)
+
+  def testRepeats(self):
+    # Several equivalent versions of the same tune.
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd ::[]|[]:: Bcd ::|
+
+        X:2
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd :::: Bcd ::|
+
+        X:3
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |::Bcd ::|:: Bcd ::|
+
+        % This version contains mismatched repeat symbols.
+        X:4
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |::Bcd ::|: Bcd ::|
+
+        % This version is missing a repeat symbol at the end.
+        X:5
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::|: Bcd |
+
+        % Ambiguous repeat that should go to the last repeat symbol.
+        X:6
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd :|
+
+        % Ambiguous repeat that should go to the last double bar.
+        X:7
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd || Bcd :|
+
+        % Ambiguous repeat that should go to the last double bar.
+        X:8
+        Q:1/4=120
+        L:1/4
+        T:Test
+        || Bcd ::| Bcd || Bcd :|
+
+        % Ensure double bar doesn&#39;t confuse declared repeat.
+        X:9
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: B || cd ::| Bcd || |: Bcd :|
+
+        % Mismatched repeat at the very beginning.
+        X:10
+        Q:1/4=120
+        L:1/4
+        T:Test
+        :| Bcd |:: Bcd ::|
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 7)
+    self.assertLen(exceptions, 3)
+    self.assertIsInstance(exceptions[0], abc_parser.RepeatParseError)
+    self.assertIsInstance(exceptions[1], abc_parser.RepeatParseError)
+    self.assertIsInstance(exceptions[2], abc_parser.RepeatParseError)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 3
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 3
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+    # Other versions are identical except for the reference number.
+    expected_ns2 = copy.deepcopy(expected_ns1)
+    expected_ns2.reference_number = 2
+    self.assertProtoEquals(expected_ns2, tunes[2])
+
+    expected_ns3 = copy.deepcopy(expected_ns1)
+    expected_ns3.reference_number = 3
+    self.assertProtoEquals(expected_ns3, tunes[3])
+
+    # Also identical, except the last section is played only twice.
+    expected_ns6 = copy.deepcopy(expected_ns1)
+    expected_ns6.reference_number = 6
+    expected_ns6.section_groups[-1].num_times = 2
+    self.assertProtoEquals(expected_ns6, tunes[6])
+
+    expected_ns7 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 7
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 3.5
+          end_time: 4.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 4.0
+          end_time: 4.5
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_annotations {
+          time: 3.0
+          section_id: 2
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 3
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 1
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
+        total_time: 4.5
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns7, tunes[7])
+
+    expected_ns8 = copy.deepcopy(expected_ns7)
+    expected_ns8.reference_number = 8
+    self.assertProtoEquals(expected_ns8, tunes[8])
+
+    expected_ns9 = copy.deepcopy(expected_ns7)
+    expected_ns9.reference_number = 9
+    self.assertProtoEquals(expected_ns9, tunes[9])
+
+  def testInvalidCharacter(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        invalid notes!&#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.InvalidCharacterError)
+
+  def testOneSidedRepeat(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        Bcd :| Bcd
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 1
+        }
+        total_time: 3.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testChords(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        [CEG]&#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.ChordError)
+
+  def testChordAnnotations(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        &#34;G&#34;G
+        % verify that an empty annotation doesn&#39;t cause problems.
+        &#34;&#34;D
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          end_time: 0.5
+        }
+        notes {
+          pitch: 62
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        text_annotations {
+          text: &#34;G&#34;
+          annotation_type: CHORD_SYMBOL
+        }
+        text_annotations {
+          time: 0.5
+        }
+        total_time: 1.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testNoteAccidentalsPerBar(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        GF^GGg|Gg
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    expected_ns1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: &#34;Test&#34;
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 65
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 80
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 79
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        total_time: 3.5
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testDecorations(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        .a~bHcLdMeOfPgSATbucvd
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 11)
+
+  def testSlur(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        (ABC) ( a b c ) (c (d e f) g a)
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 12)
+
+  def testTie(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        abc-|cba c4-c4 C.-C
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 10)
+
+  def testTuplet(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        (3abc
+        &#34;&#34;&#34;)
+    self.assertEmpty(tunes)
+    self.assertLen(exceptions, 1)
+    self.assertIsInstance(exceptions[0], abc_parser.TupletError)
+
+  def testLineContinuation(self):
+    tunes, exceptions = abc_parser.parse_abc_tunebook(r&#34;&#34;&#34;
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        abc \
+        cba|
+        abc\
+         cba|
+        abc cba|
+        cdef|\
+        \
+        cedf:|
+        &#34;&#34;&#34;)
+    self.assertLen(tunes, 1)
+    self.assertEmpty(exceptions)
+    self.assertLen(tunes[1].notes, 26)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.abc_parser_test.AbcParserTest.compare_accidentals"><code class="name flex">
+<span>def <span class="ident">compare_accidentals</span></span>(<span>self, expected, accidentals)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def compare_accidentals(self, expected, accidentals):
+  self.assertCountEqual(expected, accidentals.values())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.compare_proto_list"><code class="name flex">
+<span>def <span class="ident">compare_proto_list</span></span>(<span>self, expected, test)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def compare_proto_list(self, expected, test):
+  self.assertEqual(len(expected), len(test))
+  for e, t in zip(expected, test):
+    self.assertProtoEquals(e, t)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.compare_to_abc2midi_and_metadata"><code class="name flex">
+<span>def <span class="ident">compare_to_abc2midi_and_metadata</span></span>(<span>self, midi_path, expected_metadata, expected_expanded_metadata, test)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compare parsing results to the abc2midi "reference" implementation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def compare_to_abc2midi_and_metadata(
+    self, midi_path, expected_metadata, expected_expanded_metadata, test):
+  &#34;&#34;&#34;Compare parsing results to the abc2midi &#34;reference&#34; implementation.&#34;&#34;&#34;
+  # Compare section annotations and groups before expanding.
+  self.compare_proto_list(expected_metadata.section_annotations,
+                          test.section_annotations)
+  self.compare_proto_list(expected_metadata.section_groups,
+                          test.section_groups)
+
+  expanded_test = sequences_lib.expand_section_groups(test)
+
+  abc2midi = midi_io.midi_file_to_sequence_proto(
+      os.path.join(testing_lib.get_testdata_dir(), midi_path))
+
+  # abc2midi adds a 1-tick delay to the start of every note, but we don&#39;t.
+  tick_length = ((1 / (abc2midi.tempos[0].qpm / 60)) /
+                 abc2midi.ticks_per_quarter)
+
+  for note in abc2midi.notes:
+    # For now, don&#39;t compare velocities.
+    note.velocity = 90
+    note.start_time -= tick_length
+
+  self.compare_proto_list(abc2midi.notes, expanded_test.notes)
+
+  self.assertEqual(abc2midi.total_time, expanded_test.total_time)
+
+  self.compare_proto_list(abc2midi.time_signatures,
+                          expanded_test.time_signatures)
+
+  # We&#39;ve checked the notes and time signatures, now compare the rest of the
+  # proto to the expected proto.
+  expanded_test_copy = copy.deepcopy(expanded_test)
+  del expanded_test_copy.notes[:]
+  expanded_test_copy.ClearField(&#39;total_time&#39;)
+  del expanded_test_copy.time_signatures[:]
+
+  self.assertProtoEquals(expected_expanded_metadata, expanded_test_copy)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testChordAnnotations"><code class="name flex">
+<span>def <span class="ident">testChordAnnotations</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChordAnnotations(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      &#34;G&#34;G
+      % verify that an empty annotation doesn&#39;t cause problems.
+      &#34;&#34;D
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 67
+        velocity: 90
+        end_time: 0.5
+      }
+      notes {
+        pitch: 62
+        velocity: 90
+        start_time: 0.5
+        end_time: 1.0
+      }
+      text_annotations {
+        text: &#34;G&#34;
+        annotation_type: CHORD_SYMBOL
+      }
+      text_annotations {
+        time: 0.5
+      }
+      total_time: 1.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testChords"><code class="name flex">
+<span>def <span class="ident">testChords</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChords(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      [CEG]&#34;&#34;&#34;)
+  self.assertEmpty(tunes)
+  self.assertLen(exceptions, 1)
+  self.assertIsInstance(exceptions[0], abc_parser.ChordError)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testDecorations"><code class="name flex">
+<span>def <span class="ident">testDecorations</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecorations(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      .a~bHcLdMeOfPgSATbucvd
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  self.assertLen(tunes[1].notes, 11)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testInvalidCharacter"><code class="name flex">
+<span>def <span class="ident">testInvalidCharacter</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInvalidCharacter(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      invalid notes!&#34;&#34;&#34;)
+  self.assertEmpty(tunes)
+  self.assertLen(exceptions, 1)
+  self.assertIsInstance(exceptions[0], abc_parser.InvalidCharacterError)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testLineContinuation"><code class="name flex">
+<span>def <span class="ident">testLineContinuation</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testLineContinuation(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(r&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      abc \
+      cba|
+      abc\
+       cba|
+      abc cba|
+      cdef|\
+      \
+      cedf:|
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  self.assertLen(tunes[1].notes, 26)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testMultiVoice"><code class="name flex">
+<span>def <span class="ident">testMultiVoice</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMultiVoice(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+      os.path.join(testing_lib.get_testdata_dir(),
+                   &#39;zocharti_loch.abc&#39;))
+  self.assertEmpty(tunes)
+  self.assertLen(exceptions, 1)
+  self.assertIsInstance(exceptions[0], abc_parser.MultiVoiceError)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testNoteAccidentalsPerBar"><code class="name flex">
+<span>def <span class="ident">testNoteAccidentalsPerBar</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNoteAccidentalsPerBar(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      GF^GGg|Gg
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 67
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.5
+      }
+      notes {
+        pitch: 65
+        velocity: 90
+        start_time: 0.5
+        end_time: 1.0
+      }
+      notes {
+        pitch: 68
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.5
+      }
+      notes {
+        pitch: 68
+        velocity: 90
+        start_time: 1.5
+        end_time: 2.0
+      }
+      notes {
+        pitch: 80
+        velocity: 90
+        start_time: 2.0
+        end_time: 2.5
+      }
+      notes {
+        pitch: 67
+        velocity: 90
+        start_time: 2.5
+        end_time: 3.0
+      }
+      notes {
+        pitch: 79
+        velocity: 90
+        start_time: 3.0
+        end_time: 3.5
+      }
+      total_time: 3.5
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testOneSidedRepeat"><code class="name flex">
+<span>def <span class="ident">testOneSidedRepeat</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testOneSidedRepeat(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      Bcd :| Bcd
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.5
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 0.5
+        end_time: 1.0
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.5
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 1.5
+        end_time: 2.0
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 2.0
+        end_time: 2.5
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 2.5
+        end_time: 3.0
+      }
+      section_annotations {
+        time: 0
+        section_id: 0
+      }
+      section_annotations {
+        time: 1.5
+        section_id: 1
+      }
+      section_groups {
+        sections {
+          section_id: 0
+        }
+        num_times: 2
+      }
+      section_groups {
+        sections {
+          section_id: 1
+        }
+        num_times: 1
+      }
+      total_time: 3.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseBrokenRhythm"><code class="name flex">
+<span>def <span class="ident">testParseBrokenRhythm</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseBrokenRhythm(self):
+  # These tunes should be equivalent.
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      M:3/4
+      T:Test
+      B&gt;cd B&lt;cd
+
+      X:2
+      Q:1/4=120
+      L:1/4
+      M:3/4
+      T:Test
+      B3/2c/2d B/2c3/2d
+
+      X:3
+      Q:1/4=120
+      L:1/4
+      M:3/4
+      T:Test
+      B3/c/d B/c3/d
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 3)
+  self.assertEmpty(exceptions)
+
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      time_signatures {
+        numerator: 3
+        denominator: 4
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.75
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 0.75
+        end_time: 1.0
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.5
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 1.5
+        end_time: 1.75
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 1.75
+        end_time: 2.5
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 2.5
+        end_time: 3.0
+      }
+      total_time: 3.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])
+  expected_ns2 = copy.deepcopy(expected_ns1)
+  expected_ns2.reference_number = 2
+  self.assertProtoEquals(expected_ns2, tunes[2])
+  expected_ns2.reference_number = 3
+  self.assertProtoEquals(expected_ns2, tunes[3])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseEnglishAbc"><code class="name flex">
+<span>def <span class="ident">testParseEnglishAbc</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseEnglishAbc(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook_file(
+      os.path.join(testing_lib.get_testdata_dir(), &#39;english.abc&#39;))
+  self.assertLen(tunes, 1)
+  self.assertLen(exceptions, 2)
+  self.assertIsInstance(exceptions[0], abc_parser.VariantEndingError)
+  self.assertIsInstance(exceptions[1], abc_parser.PartError)
+
+  expected_metadata1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+        artist: &#34;Trad.&#34;
+        composers: &#34;Trad.&#34;
+      }
+      key_signatures {
+        key: G
+      }
+      section_annotations {
+        time: 0.0
+        section_id: 0
+      }
+      section_annotations {
+        time: 6.0
+        section_id: 1
+      }
+      section_annotations {
+        time: 12.0
+        section_id: 2
+      }
+      section_groups {
+        sections {
+          section_id: 0
+        }
+        num_times: 2
+      }
+      section_groups {
+        sections {
+          section_id: 1
+        }
+        num_times: 2
+      }
+      section_groups {
+        sections {
+          section_id: 2
+        }
+        num_times: 2
+      }
+      &#34;&#34;&#34;)
+  expected_expanded_metadata1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Dusty Miller, The; Binny&#39;s Jig&#34;
+        artist: &#34;Trad.&#34;
+        composers: &#34;Trad.&#34;
+      }
+      key_signatures {
+        key: G
+      }
+      section_annotations {
+        time: 0.0
+        section_id: 0
+      }
+      section_annotations {
+        time: 6.0
+        section_id: 0
+      }
+      section_annotations {
+        time: 12.0
+        section_id: 1
+      }
+      section_annotations {
+        time: 18.0
+        section_id: 1
+      }
+      section_annotations {
+        time: 24.0
+        section_id: 2
+      }
+      section_annotations {
+        time: 30.0
+        section_id: 2
+      }
+      &#34;&#34;&#34;)
+  self.compare_to_abc2midi_and_metadata(
+      &#39;english1.mid&#39;, expected_metadata1,
+      expected_expanded_metadata1, tunes[1])
+
+  # TODO(fjord): re-enable once we support variant endings.
+  # expected_ns2_metadata = testing_lib.parse_test_proto(
+  #     music_pb2.NoteSequence,
+  #     &#34;&#34;&#34;
+  #     ticks_per_quarter: 220
+  #     source_info: {
+  #       source_type: SCORE_BASED
+  #       encoding_type: ABC
+  #       parser: MAGENTA_ABC
+  #     }
+  #     reference_number: 2
+  #     sequence_metadata {
+  #       title: &#34;Old Sir Simon the King&#34;
+  #       artist: &#34;Trad.&#34;
+  #       composers: &#34;Trad.&#34;
+  #     }
+  #     key_signatures {
+  #       key: G
+  #     }
+  #     &#34;&#34;&#34;)
+  # self.compare_to_abc2midi_and_metadata(
+  #     &#39;english2.mid&#39;, expected_ns2_metadata, tunes[1])
+
+  # TODO(fjord): re-enable once we support parts.
+  # expected_ns3_metadata = testing_lib.parse_test_proto(
+  #     music_pb2.NoteSequence,
+  #     &#34;&#34;&#34;
+  #     ticks_per_quarter: 220
+  #     source_info: {
+  #       source_type: SCORE_BASED
+  #       encoding_type: ABC
+  #       parser: MAGENTA_ABC
+  #     }
+  #     reference_number: 3
+  #     sequence_metadata {
+  #       title: &#34;William and Nancy; New Mown Hay; Legacy, The&#34;
+  #       artist: &#34;Trad.&#34;
+  #       composers: &#34;Trad.&#34;
+  #     }
+  #     key_signatures {
+  #       key: G
+  #     }
+  #     &#34;&#34;&#34;)
+  # # TODO(fjord): verify chord annotations
+  # del tunes[3].text_annotations[:]
+  # self.compare_to_abc2midi_and_metadata(
+  #     &#39;english3.mid&#39;, expected_ns3_metadata, tunes[3])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseKeyAccidentals"><code class="name flex">
+<span>def <span class="ident">testParseKeyAccidentals</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseKeyAccidentals(self):
+  # Most examples taken from
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;D Phr ^f&#39;)
+  self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;D maj =c&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;D =c&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 1, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseKeyBasic"><code class="name flex">
+<span>def <span class="ident">testParseKeyBasic</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseKeyBasic(self):
+  # Most examples taken from
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;C major&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(&#39;A minor&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;C ionian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.C, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;A aeolian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.A, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;G Mixolydian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.G, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;D dorian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.DORIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;E phrygian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.E, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.PHRYGIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;F Lydian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.LYDIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;B Locrian&#39;)
+  self.compare_accidentals([0, 0, 0, 0, 0, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.B, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.LOCRIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;F# mixolydian&#39;)
+  self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;F#Mix&#39;)
+  self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;F#MIX&#39;)
+  self.compare_accidentals([1, 0, 1, 1, 0, 1, 1], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.F_SHARP, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MIXOLYDIAN,
+                   proto_mode)
+
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;Fm&#39;)
+  self.compare_accidentals([-1, -1, 0, -1, -1, 0, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.F, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MINOR, proto_mode)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseKeyExplicit"><code class="name flex">
+<span>def <span class="ident">testParseKeyExplicit</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseKeyExplicit(self):
+  # Most examples taken from
+  # http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+  accidentals, proto_key, proto_mode = abc_parser.ABCTune.parse_key(
+      &#39;D exp _b _e ^f&#39;)
+  self.compare_accidentals([0, -1, 0, 0, -1, 1, 0], accidentals)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.D, proto_key)
+  self.assertEqual(music_pb2.NoteSequence.KeySignature.MAJOR, proto_mode)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseOctaves"><code class="name flex">
+<span>def <span class="ident">testParseOctaves</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseOctaves(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+      T:Test
+      CC,&#39;,C,C&#39;c
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        end_time: 0.25
+      }
+      notes {
+        pitch: 48
+        velocity: 90
+        start_time: 0.25
+        end_time: 0.5
+      }
+      notes {
+        pitch: 48
+        velocity: 90
+        start_time: 0.5
+        end_time: 0.75
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 0.75
+        end_time: 1.0
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.25
+      }
+      total_time: 1.25
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testParseTempos"><code class="name flex">
+<span>def <span class="ident">testParseTempos</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testParseTempos(self):
+  # Examples from http://abcnotation.com/wiki/abc:standard:v2.1#qtempo
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      L:1/4
+      Q:60
+
+      X:2
+      L:1/4
+      Q:C=100
+
+      X:3
+      Q:1/2=120
+
+      X:4
+      Q:1/4 3/8 1/4 3/8=40
+
+      X:5
+      Q:5/4=40
+
+      X:6
+      Q: &#34;Allegro&#34; 1/4=120
+
+      X:7
+      Q: 1/4=120 &#34;Allegro&#34;
+
+      X:8
+      Q: 3/8=50 &#34;Slowly&#34;
+
+      X:9
+      Q:&#34;Andante&#34;
+
+      X:10
+      Q:100  % define tempo using deprecated syntax
+      % deprecated tempo syntax depends on unit note length. if it is
+      % not defined, it is derived from the current meter.
+      M:2/4  % define meter after tempo to verify that is supported.
+
+      X:11
+      Q:100  % define tempo using deprecated syntax
+      % deprecated tempo syntax depends on unit note length.
+      L:1/4  % define note length after tempo to verify that is supported.
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 11)
+  self.assertEmpty(exceptions)
+
+  self.assertEqual(60, tunes[1].tempos[0].qpm)
+  self.assertEqual(100, tunes[2].tempos[0].qpm)
+  self.assertEqual(240, tunes[3].tempos[0].qpm)
+  self.assertEqual(200, tunes[4].tempos[0].qpm)
+  self.assertEqual(200, tunes[5].tempos[0].qpm)
+  self.assertEqual(120, tunes[6].tempos[0].qpm)
+  self.assertEqual(120, tunes[7].tempos[0].qpm)
+  self.assertEqual(75, tunes[8].tempos[0].qpm)
+  self.assertEmpty(tunes[9].tempos, 0)
+  self.assertEqual(25, tunes[10].tempos[0].qpm)
+  self.assertEqual(100, tunes[11].tempos[0].qpm)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testRepeats"><code class="name flex">
+<span>def <span class="ident">testRepeats</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRepeats(self):
+  # Several equivalent versions of the same tune.
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      Bcd ::[]|[]:: Bcd ::|
+
+      X:2
+      Q:1/4=120
+      L:1/4
+      T:Test
+      Bcd :::: Bcd ::|
+
+      X:3
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |::Bcd ::|:: Bcd ::|
+
+      % This version contains mismatched repeat symbols.
+      X:4
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |::Bcd ::|: Bcd ::|
+
+      % This version is missing a repeat symbol at the end.
+      X:5
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |:: Bcd ::|: Bcd |
+
+      % Ambiguous repeat that should go to the last repeat symbol.
+      X:6
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |:: Bcd ::| Bcd :|
+
+      % Ambiguous repeat that should go to the last double bar.
+      X:7
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |:: Bcd ::| Bcd || Bcd :|
+
+      % Ambiguous repeat that should go to the last double bar.
+      X:8
+      Q:1/4=120
+      L:1/4
+      T:Test
+      || Bcd ::| Bcd || Bcd :|
+
+      % Ensure double bar doesn&#39;t confuse declared repeat.
+      X:9
+      Q:1/4=120
+      L:1/4
+      T:Test
+      |:: B || cd ::| Bcd || |: Bcd :|
+
+      % Mismatched repeat at the very beginning.
+      X:10
+      Q:1/4=120
+      L:1/4
+      T:Test
+      :| Bcd |:: Bcd ::|
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 7)
+  self.assertLen(exceptions, 3)
+  self.assertIsInstance(exceptions[0], abc_parser.RepeatParseError)
+  self.assertIsInstance(exceptions[1], abc_parser.RepeatParseError)
+  self.assertIsInstance(exceptions[2], abc_parser.RepeatParseError)
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.5
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 0.5
+        end_time: 1.0
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.5
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 1.5
+        end_time: 2.0
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 2.0
+        end_time: 2.5
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 2.5
+        end_time: 3.0
+      }
+      section_annotations {
+        time: 0
+        section_id: 0
+      }
+      section_annotations {
+        time: 1.5
+        section_id: 1
+      }
+      section_groups {
+        sections {
+          section_id: 0
+        }
+        num_times: 3
+      }
+      section_groups {
+        sections {
+          section_id: 1
+        }
+        num_times: 3
+      }
+      total_time: 3.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])
+
+  # Other versions are identical except for the reference number.
+  expected_ns2 = copy.deepcopy(expected_ns1)
+  expected_ns2.reference_number = 2
+  self.assertProtoEquals(expected_ns2, tunes[2])
+
+  expected_ns3 = copy.deepcopy(expected_ns1)
+  expected_ns3.reference_number = 3
+  self.assertProtoEquals(expected_ns3, tunes[3])
+
+  # Also identical, except the last section is played only twice.
+  expected_ns6 = copy.deepcopy(expected_ns1)
+  expected_ns6.reference_number = 6
+  expected_ns6.section_groups[-1].num_times = 2
+  self.assertProtoEquals(expected_ns6, tunes[6])
+
+  expected_ns7 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 7
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.5
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 0.5
+        end_time: 1.0
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 1.0
+        end_time: 1.5
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 1.5
+        end_time: 2.0
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 2.0
+        end_time: 2.5
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 2.5
+        end_time: 3.0
+      }
+      notes {
+        pitch: 71
+        velocity: 90
+        start_time: 3.0
+        end_time: 3.5
+      }
+      notes {
+        pitch: 72
+        velocity: 90
+        start_time: 3.5
+        end_time: 4.0
+      }
+      notes {
+        pitch: 74
+        velocity: 90
+        start_time: 4.0
+        end_time: 4.5
+      }
+      section_annotations {
+        time: 0
+        section_id: 0
+      }
+      section_annotations {
+        time: 1.5
+        section_id: 1
+      }
+      section_annotations {
+        time: 3.0
+        section_id: 2
+      }
+      section_groups {
+        sections {
+          section_id: 0
+        }
+        num_times: 3
+      }
+      section_groups {
+        sections {
+          section_id: 1
+        }
+        num_times: 1
+      }
+      section_groups {
+        sections {
+          section_id: 2
+        }
+        num_times: 2
+      }
+      total_time: 4.5
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns7, tunes[7])
+
+  expected_ns8 = copy.deepcopy(expected_ns7)
+  expected_ns8.reference_number = 8
+  self.assertProtoEquals(expected_ns8, tunes[8])
+
+  expected_ns9 = copy.deepcopy(expected_ns7)
+  expected_ns9.reference_number = 9
+  self.assertProtoEquals(expected_ns9, tunes[9])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testSlashDuration"><code class="name flex">
+<span>def <span class="ident">testSlashDuration</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSlashDuration(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      CC/C//C///C////
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+
+  expected_ns1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: ABC
+        parser: MAGENTA_ABC
+      }
+      reference_number: 1
+      sequence_metadata {
+        title: &#34;Test&#34;
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        start_time: 0.0
+        end_time: 0.5
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        start_time: 0.5
+        end_time: 0.75
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        start_time: 0.75
+        end_time: 0.875
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        start_time: 0.875
+        end_time: 0.9375
+      }
+      notes {
+        pitch: 60
+        velocity: 90
+        start_time: 0.9375
+        end_time: 0.96875
+      }
+      total_time: 0.96875
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns1, tunes[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testSlur"><code class="name flex">
+<span>def <span class="ident">testSlur</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSlur(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      (ABC) ( a b c ) (c (d e f) g a)
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  self.assertLen(tunes[1].notes, 12)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testTie"><code class="name flex">
+<span>def <span class="ident">testTie</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTie(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      abc-|cba c4-c4 C.-C
+      &#34;&#34;&#34;)
+  self.assertLen(tunes, 1)
+  self.assertEmpty(exceptions)
+  self.assertLen(tunes[1].notes, 10)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.abc_parser_test.AbcParserTest.testTuplet"><code class="name flex">
+<span>def <span class="ident">testTuplet</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTuplet(self):
+  tunes, exceptions = abc_parser.parse_abc_tunebook(&#34;&#34;&#34;
+      X:1
+      Q:1/4=120
+      L:1/4
+      T:Test
+      (3abc
+      &#34;&#34;&#34;)
+  self.assertEmpty(tunes)
+  self.assertLen(exceptions, 1)
+  self.assertIsInstance(exceptions[0], abc_parser.TupletError)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.abc_parser_test.AbcParserTest" href="#note_seq.abc_parser_test.AbcParserTest">AbcParserTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.compare_accidentals" href="#note_seq.abc_parser_test.AbcParserTest.compare_accidentals">compare_accidentals</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.compare_proto_list" href="#note_seq.abc_parser_test.AbcParserTest.compare_proto_list">compare_proto_list</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.compare_to_abc2midi_and_metadata" href="#note_seq.abc_parser_test.AbcParserTest.compare_to_abc2midi_and_metadata">compare_to_abc2midi_and_metadata</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testChordAnnotations" href="#note_seq.abc_parser_test.AbcParserTest.testChordAnnotations">testChordAnnotations</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testChords" href="#note_seq.abc_parser_test.AbcParserTest.testChords">testChords</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testDecorations" href="#note_seq.abc_parser_test.AbcParserTest.testDecorations">testDecorations</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testInvalidCharacter" href="#note_seq.abc_parser_test.AbcParserTest.testInvalidCharacter">testInvalidCharacter</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testLineContinuation" href="#note_seq.abc_parser_test.AbcParserTest.testLineContinuation">testLineContinuation</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testMultiVoice" href="#note_seq.abc_parser_test.AbcParserTest.testMultiVoice">testMultiVoice</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testNoteAccidentalsPerBar" href="#note_seq.abc_parser_test.AbcParserTest.testNoteAccidentalsPerBar">testNoteAccidentalsPerBar</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testOneSidedRepeat" href="#note_seq.abc_parser_test.AbcParserTest.testOneSidedRepeat">testOneSidedRepeat</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseBrokenRhythm" href="#note_seq.abc_parser_test.AbcParserTest.testParseBrokenRhythm">testParseBrokenRhythm</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseEnglishAbc" href="#note_seq.abc_parser_test.AbcParserTest.testParseEnglishAbc">testParseEnglishAbc</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseKeyAccidentals" href="#note_seq.abc_parser_test.AbcParserTest.testParseKeyAccidentals">testParseKeyAccidentals</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseKeyBasic" href="#note_seq.abc_parser_test.AbcParserTest.testParseKeyBasic">testParseKeyBasic</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseKeyExplicit" href="#note_seq.abc_parser_test.AbcParserTest.testParseKeyExplicit">testParseKeyExplicit</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseOctaves" href="#note_seq.abc_parser_test.AbcParserTest.testParseOctaves">testParseOctaves</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testParseTempos" href="#note_seq.abc_parser_test.AbcParserTest.testParseTempos">testParseTempos</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testRepeats" href="#note_seq.abc_parser_test.AbcParserTest.testRepeats">testRepeats</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testSlashDuration" href="#note_seq.abc_parser_test.AbcParserTest.testSlashDuration">testSlashDuration</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testSlur" href="#note_seq.abc_parser_test.AbcParserTest.testSlur">testSlur</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testTie" href="#note_seq.abc_parser_test.AbcParserTest.testTie">testTie</a></code></li>
+<li><code><a title="note_seq.abc_parser_test.AbcParserTest.testTuplet" href="#note_seq.abc_parser_test.AbcParserTest.testTuplet">testTuplet</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/audio_io.html
+++ b/docs/audio_io.html
@@ -1,0 +1,1055 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.audio_io API documentation</title>
+<meta name="description" content="Audio file helper functions." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.audio_io</code></h1>
+</header>
+<section id="section-intro">
+<p>Audio file helper functions.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Audio file helper functions.&#34;&#34;&#34;
+
+import io
+import math
+import tempfile
+
+import librosa
+import numpy as np
+import pydub
+import scipy.io.wavfile
+
+
+class AudioIOError(BaseException):  # pylint:disable=g-bad-exception-name
+  pass
+
+
+class AudioIOReadError(AudioIOError):
+  pass
+
+
+class AudioIODataTypeError(AudioIOError):
+  pass
+
+
+def int16_samples_to_float32(y):
+  &#34;&#34;&#34;Convert int16 numpy array of audio samples to float32.&#34;&#34;&#34;
+  if y.dtype != np.int16:
+    raise ValueError(&#39;input samples not int16&#39;)
+  return y.astype(np.float32) / np.iinfo(np.int16).max
+
+
+def float_samples_to_int16(y):
+  &#34;&#34;&#34;Convert floating-point numpy array of audio samples to int16.&#34;&#34;&#34;
+  if not issubclass(y.dtype.type, np.floating):
+    raise ValueError(&#39;input samples not floating-point&#39;)
+  return (y * np.iinfo(np.int16).max).astype(np.int16)
+
+
+def wav_data_to_samples_pydub(wav_data: bytes,
+                              sample_rate: int,
+                              remove_dc_bias: bool = False,
+                              num_channels: int = None,
+                              normalize_db: float = None):
+  &#34;&#34;&#34;Convert audio file data (in bytes) into a numpy array using Pydub.
+
+  Args:
+    wav_data: A byte stream of audio data.
+    sample_rate: Resample recorded audio to this sample rate.
+    remove_dc_bias: If true, will remove DC bias from audio.
+    num_channels: If not specified, output shape will be based on the contents
+      of wav_data. Otherwise, will force to be 1 or 2 channels.
+    normalize_db: Normalize the audio to this many decibels. Set to None to skip
+      normalization step.
+
+  Returns:
+    An array of the recorded audio at sample_rate. If mono, will be shape
+    [samples], otherwise [channels, samples].
+  &#34;&#34;&#34;
+  # Parse and normalize the audio.
+  aseg = pydub.AudioSegment.from_file(io.BytesIO(wav_data))
+  if num_channels:
+    aseg = aseg.set_channels(num_channels)
+  if remove_dc_bias:
+    aseg = aseg.remove_dc_offset()
+  if normalize_db is not None:
+    aseg.normalize(headroom=normalize_db)
+  aseg = aseg.set_frame_rate(sample_rate)
+
+  # Convert to numpy array.
+  channel_asegs = aseg.split_to_mono()
+  samples = [s.get_array_of_samples() for s in channel_asegs]
+  fp_arr = np.array(samples).astype(np.float32)
+  fp_arr /= np.iinfo(samples[0].typecode).max
+
+  # If only 1 channel, remove extra dim.
+  if fp_arr.shape[0] == 1:
+    fp_arr = fp_arr[0]
+
+  return fp_arr
+
+
+def wav_data_to_samples(wav_data, sample_rate):
+  &#34;&#34;&#34;Read PCM-formatted WAV data and return a NumPy array of samples.
+
+  Uses scipy to read and librosa to process WAV data. Audio will be converted to
+  mono if necessary.
+
+  Args:
+    wav_data: WAV audio data to read.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadError: If scipy is unable to read the WAV data.
+    AudioIOError: If audio processing fails.
+  &#34;&#34;&#34;
+  try:
+    # Read the wav file, converting sample rate &amp; number of channels.
+    native_sr, y = scipy.io.wavfile.read(io.BytesIO(wav_data))
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOReadError(e)
+
+  if y.dtype == np.int16:
+    # Convert to float32.
+    y = int16_samples_to_float32(y)
+  elif y.dtype == np.float32:
+    # Already float32.
+    pass
+  else:
+    raise AudioIOError(
+        &#39;WAV file not 16-bit or 32-bit float PCM, unsupported&#39;)
+  try:
+    # Convert to mono and the desired sample rate.
+    if y.ndim == 2 and y.shape[1] == 2:
+      y = y.T
+      y = librosa.to_mono(y)
+    if native_sr != sample_rate:
+      y = librosa.resample(y, native_sr, sample_rate)
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOError(e)
+  return y
+
+
+def wav_data_to_samples_librosa(audio_file, sample_rate):
+  &#34;&#34;&#34;Loads an in-memory audio file with librosa.
+
+  Use this instead of wav_data_to_samples if the wav is 24-bit, as that&#39;s
+  incompatible with wav_data_to_samples internal scipy call.
+
+  Will copy to a local temp file before loading so that librosa can read a file
+  path. Librosa does not currently read in-memory files.
+
+  It will be treated as a .wav file.
+
+  Args:
+    audio_file: Wav file to load.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadException: If librosa is unable to load the audio data.
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile(suffix=&#39;.wav&#39;) as wav_input_file:
+    wav_input_file.write(audio_file)
+    # Before copying the file, flush any contents
+    wav_input_file.flush()
+    # And back the file position to top (not need for Copy but for certainty)
+    wav_input_file.seek(0)
+    return load_audio(wav_input_file.name, sample_rate)
+
+
+def samples_to_wav_data(samples, sample_rate):
+  &#34;&#34;&#34;Converts floating point samples to wav data.&#34;&#34;&#34;
+  wav_io = io.BytesIO()
+  scipy.io.wavfile.write(wav_io, sample_rate, float_samples_to_int16(samples))
+  return wav_io.getvalue()
+
+
+def crop_samples(samples, sample_rate, crop_beginning_seconds,
+                 total_length_seconds):
+  &#34;&#34;&#34;Crop WAV data.
+
+  Args:
+    samples: Numpy Array containing samples.
+    sample_rate: The sample rate at which to interpret the samples.
+    crop_beginning_seconds: How many seconds to crop from the beginning of the
+        audio.
+    total_length_seconds: The desired duration of the audio. After cropping the
+        beginning of the audio, any audio longer than this value will be
+        deleted.
+
+  Returns:
+    A cropped version of the samples.
+  &#34;&#34;&#34;
+  samples_to_crop = int(crop_beginning_seconds * sample_rate)
+  total_samples = int(total_length_seconds * sample_rate)
+  cropped_samples = samples[samples_to_crop:(samples_to_crop + total_samples)]
+  return cropped_samples
+
+
+def repeat_samples_to_duration(samples, sample_rate, duration):
+  &#34;&#34;&#34;Repeat a sequence of samples until it is a given duration, trimming extra.
+
+  Args:
+    samples: The sequence to repeat
+    sample_rate: The sample rate at which to interpret the samples.
+    duration: The desired duration
+
+  Returns:
+    The repeated and possibly trimmed sequence.
+  &#34;&#34;&#34;
+  sequence_duration = len(samples) / sample_rate
+  num_repeats = int(math.ceil(duration / sequence_duration))
+  repeated_samples = np.concatenate([samples] * num_repeats)
+  trimmed = crop_samples(
+      repeated_samples, sample_rate,
+      crop_beginning_seconds=0, total_length_seconds=duration)
+  return trimmed
+
+
+def crop_wav_data(wav_data, sample_rate, crop_beginning_seconds,
+                  total_length_seconds):
+  &#34;&#34;&#34;Crop WAV data.
+
+  Args:
+    wav_data: WAV audio data to crop.
+    sample_rate: The sample rate at which to read the WAV data.
+    crop_beginning_seconds: How many seconds to crop from the beginning of the
+        audio.
+    total_length_seconds: The desired duration of the audio. After cropping the
+        beginning of the audio, any audio longer than this value will be
+        deleted.
+
+  Returns:
+    A cropped version of the WAV audio.
+  &#34;&#34;&#34;
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  samples_to_crop = int(crop_beginning_seconds * sample_rate)
+  total_samples = int(total_length_seconds * sample_rate)
+  cropped_samples = y[samples_to_crop:(samples_to_crop + total_samples)]
+  return samples_to_wav_data(cropped_samples, sample_rate)
+
+
+def jitter_wav_data(wav_data, sample_rate, jitter_seconds):
+  &#34;&#34;&#34;Add silence to the beginning of the file.
+
+  Args:
+     wav_data: WAV audio data to prepend with silence.
+     sample_rate: The sample rate at which to read the WAV data.
+     jitter_seconds: Seconds of silence to prepend.
+
+  Returns:
+     A version of the WAV audio with jitter_seconds silence prepended.
+  &#34;&#34;&#34;
+
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  silence_samples = jitter_seconds * sample_rate
+  new_y = np.concatenate((np.zeros(np.int(silence_samples)), y))
+  return samples_to_wav_data(new_y, sample_rate)
+
+
+def load_audio(audio_filename, sample_rate):
+  &#34;&#34;&#34;Loads an audio file.
+
+  Args:
+    audio_filename: File path to load.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadError: If librosa is unable to load the audio data.
+  &#34;&#34;&#34;
+  try:
+    y, unused_sr = librosa.load(audio_filename, sr=sample_rate, mono=True)
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOReadError(e)
+  return y
+
+
+def make_stereo(left, right):
+  &#34;&#34;&#34;Combine two mono signals into one stereo signal.
+
+  Both signals must have the same data type. The resulting track will be the
+  length of the longer of the two signals.
+
+  Args:
+    left: Samples for the left channel.
+    right: Samples for the right channel.
+
+  Returns:
+    The two channels combined into a stereo signal.
+
+  Raises:
+    AudioIODataTypeError: if the two signals have different data types.
+  &#34;&#34;&#34;
+  if left.dtype != right.dtype:
+    raise AudioIODataTypeError(
+        &#39;left channel is of type {}, but right channel is {}&#39;.format(
+            left.dtype, right.dtype))
+
+  # Mask of valid places in each row
+  lens = np.array([len(left), len(right)])
+  mask = np.arange(lens.max()) &lt; lens[:, None]
+
+  # Setup output array and put elements from data into masked positions
+  out = np.zeros(mask.shape, dtype=left.dtype)
+  out[mask] = np.concatenate([left, right])
+  return out.T
+
+
+def normalize_wav_data(wav_data, sample_rate, norm=np.inf):
+  &#34;&#34;&#34;Normalizes wav data.
+
+  Args:
+     wav_data: WAV audio data to prepend with silence.
+     sample_rate: The sample rate at which to read the WAV data.
+     norm: See the norm argument of librosa.util.normalize.
+
+  Returns:
+     A version of the WAV audio that has been normalized.
+  &#34;&#34;&#34;
+
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  new_y = librosa.util.normalize(y, norm=norm)
+  return samples_to_wav_data(new_y, sample_rate)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.audio_io.crop_samples"><code class="name flex">
+<span>def <span class="ident">crop_samples</span></span>(<span>samples, sample_rate, crop_beginning_seconds, total_length_seconds)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Crop WAV data.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>samples</code></strong></dt>
+<dd>Numpy Array containing samples.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to interpret the samples.</dd>
+<dt><strong><code>crop_beginning_seconds</code></strong></dt>
+<dd>How many seconds to crop from the beginning of the
+audio.</dd>
+<dt><strong><code>total_length_seconds</code></strong></dt>
+<dd>The desired duration of the audio. After cropping the
+beginning of the audio, any audio longer than this value will be
+deleted.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A cropped version of the samples.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def crop_samples(samples, sample_rate, crop_beginning_seconds,
+                 total_length_seconds):
+  &#34;&#34;&#34;Crop WAV data.
+
+  Args:
+    samples: Numpy Array containing samples.
+    sample_rate: The sample rate at which to interpret the samples.
+    crop_beginning_seconds: How many seconds to crop from the beginning of the
+        audio.
+    total_length_seconds: The desired duration of the audio. After cropping the
+        beginning of the audio, any audio longer than this value will be
+        deleted.
+
+  Returns:
+    A cropped version of the samples.
+  &#34;&#34;&#34;
+  samples_to_crop = int(crop_beginning_seconds * sample_rate)
+  total_samples = int(total_length_seconds * sample_rate)
+  cropped_samples = samples[samples_to_crop:(samples_to_crop + total_samples)]
+  return cropped_samples</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.crop_wav_data"><code class="name flex">
+<span>def <span class="ident">crop_wav_data</span></span>(<span>wav_data, sample_rate, crop_beginning_seconds, total_length_seconds)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Crop WAV data.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>wav_data</code></strong></dt>
+<dd>WAV audio data to crop.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to read the WAV data.</dd>
+<dt><strong><code>crop_beginning_seconds</code></strong></dt>
+<dd>How many seconds to crop from the beginning of the
+audio.</dd>
+<dt><strong><code>total_length_seconds</code></strong></dt>
+<dd>The desired duration of the audio. After cropping the
+beginning of the audio, any audio longer than this value will be
+deleted.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A cropped version of the WAV audio.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def crop_wav_data(wav_data, sample_rate, crop_beginning_seconds,
+                  total_length_seconds):
+  &#34;&#34;&#34;Crop WAV data.
+
+  Args:
+    wav_data: WAV audio data to crop.
+    sample_rate: The sample rate at which to read the WAV data.
+    crop_beginning_seconds: How many seconds to crop from the beginning of the
+        audio.
+    total_length_seconds: The desired duration of the audio. After cropping the
+        beginning of the audio, any audio longer than this value will be
+        deleted.
+
+  Returns:
+    A cropped version of the WAV audio.
+  &#34;&#34;&#34;
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  samples_to_crop = int(crop_beginning_seconds * sample_rate)
+  total_samples = int(total_length_seconds * sample_rate)
+  cropped_samples = y[samples_to_crop:(samples_to_crop + total_samples)]
+  return samples_to_wav_data(cropped_samples, sample_rate)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.float_samples_to_int16"><code class="name flex">
+<span>def <span class="ident">float_samples_to_int16</span></span>(<span>y)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert floating-point numpy array of audio samples to int16.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def float_samples_to_int16(y):
+  &#34;&#34;&#34;Convert floating-point numpy array of audio samples to int16.&#34;&#34;&#34;
+  if not issubclass(y.dtype.type, np.floating):
+    raise ValueError(&#39;input samples not floating-point&#39;)
+  return (y * np.iinfo(np.int16).max).astype(np.int16)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.int16_samples_to_float32"><code class="name flex">
+<span>def <span class="ident">int16_samples_to_float32</span></span>(<span>y)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert int16 numpy array of audio samples to float32.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def int16_samples_to_float32(y):
+  &#34;&#34;&#34;Convert int16 numpy array of audio samples to float32.&#34;&#34;&#34;
+  if y.dtype != np.int16:
+    raise ValueError(&#39;input samples not int16&#39;)
+  return y.astype(np.float32) / np.iinfo(np.int16).max</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.jitter_wav_data"><code class="name flex">
+<span>def <span class="ident">jitter_wav_data</span></span>(<span>wav_data, sample_rate, jitter_seconds)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Add silence to the beginning of the file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>wav_data</code></strong></dt>
+<dd>WAV audio data to prepend with silence.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to read the WAV data.</dd>
+<dt><strong><code>jitter_seconds</code></strong></dt>
+<dd>Seconds of silence to prepend.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A version of the WAV audio with jitter_seconds silence prepended.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def jitter_wav_data(wav_data, sample_rate, jitter_seconds):
+  &#34;&#34;&#34;Add silence to the beginning of the file.
+
+  Args:
+     wav_data: WAV audio data to prepend with silence.
+     sample_rate: The sample rate at which to read the WAV data.
+     jitter_seconds: Seconds of silence to prepend.
+
+  Returns:
+     A version of the WAV audio with jitter_seconds silence prepended.
+  &#34;&#34;&#34;
+
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  silence_samples = jitter_seconds * sample_rate
+  new_y = np.concatenate((np.zeros(np.int(silence_samples)), y))
+  return samples_to_wav_data(new_y, sample_rate)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.load_audio"><code class="name flex">
+<span>def <span class="ident">load_audio</span></span>(<span>audio_filename, sample_rate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Loads an audio file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>audio_filename</code></strong></dt>
+<dd>File path to load.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The number of samples per second at which the audio will be
+returned. Resampling will be performed if necessary.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A numpy array of audio samples, single-channel (mono) and sampled at the
+specified rate, in float32 format.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.audio_io.AudioIOReadError" href="#note_seq.audio_io.AudioIOReadError">AudioIOReadError</a></code></dt>
+<dd>If librosa is unable to load the audio data.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def load_audio(audio_filename, sample_rate):
+  &#34;&#34;&#34;Loads an audio file.
+
+  Args:
+    audio_filename: File path to load.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadError: If librosa is unable to load the audio data.
+  &#34;&#34;&#34;
+  try:
+    y, unused_sr = librosa.load(audio_filename, sr=sample_rate, mono=True)
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOReadError(e)
+  return y</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.make_stereo"><code class="name flex">
+<span>def <span class="ident">make_stereo</span></span>(<span>left, right)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Combine two mono signals into one stereo signal.</p>
+<p>Both signals must have the same data type. The resulting track will be the
+length of the longer of the two signals.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>left</code></strong></dt>
+<dd>Samples for the left channel.</dd>
+<dt><strong><code>right</code></strong></dt>
+<dd>Samples for the right channel.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The two channels combined into a stereo signal.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.audio_io.AudioIODataTypeError" href="#note_seq.audio_io.AudioIODataTypeError">AudioIODataTypeError</a></code></dt>
+<dd>if the two signals have different data types.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def make_stereo(left, right):
+  &#34;&#34;&#34;Combine two mono signals into one stereo signal.
+
+  Both signals must have the same data type. The resulting track will be the
+  length of the longer of the two signals.
+
+  Args:
+    left: Samples for the left channel.
+    right: Samples for the right channel.
+
+  Returns:
+    The two channels combined into a stereo signal.
+
+  Raises:
+    AudioIODataTypeError: if the two signals have different data types.
+  &#34;&#34;&#34;
+  if left.dtype != right.dtype:
+    raise AudioIODataTypeError(
+        &#39;left channel is of type {}, but right channel is {}&#39;.format(
+            left.dtype, right.dtype))
+
+  # Mask of valid places in each row
+  lens = np.array([len(left), len(right)])
+  mask = np.arange(lens.max()) &lt; lens[:, None]
+
+  # Setup output array and put elements from data into masked positions
+  out = np.zeros(mask.shape, dtype=left.dtype)
+  out[mask] = np.concatenate([left, right])
+  return out.T</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.normalize_wav_data"><code class="name flex">
+<span>def <span class="ident">normalize_wav_data</span></span>(<span>wav_data, sample_rate, norm=inf)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Normalizes wav data.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>wav_data</code></strong></dt>
+<dd>WAV audio data to prepend with silence.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to read the WAV data.</dd>
+<dt><strong><code>norm</code></strong></dt>
+<dd>See the norm argument of librosa.util.normalize.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A version of the WAV audio that has been normalized.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def normalize_wav_data(wav_data, sample_rate, norm=np.inf):
+  &#34;&#34;&#34;Normalizes wav data.
+
+  Args:
+     wav_data: WAV audio data to prepend with silence.
+     sample_rate: The sample rate at which to read the WAV data.
+     norm: See the norm argument of librosa.util.normalize.
+
+  Returns:
+     A version of the WAV audio that has been normalized.
+  &#34;&#34;&#34;
+
+  y = wav_data_to_samples(wav_data, sample_rate=sample_rate)
+  new_y = librosa.util.normalize(y, norm=norm)
+  return samples_to_wav_data(new_y, sample_rate)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.repeat_samples_to_duration"><code class="name flex">
+<span>def <span class="ident">repeat_samples_to_duration</span></span>(<span>samples, sample_rate, duration)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Repeat a sequence of samples until it is a given duration, trimming extra.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>samples</code></strong></dt>
+<dd>The sequence to repeat</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to interpret the samples.</dd>
+<dt><strong><code>duration</code></strong></dt>
+<dd>The desired duration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The repeated and possibly trimmed sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def repeat_samples_to_duration(samples, sample_rate, duration):
+  &#34;&#34;&#34;Repeat a sequence of samples until it is a given duration, trimming extra.
+
+  Args:
+    samples: The sequence to repeat
+    sample_rate: The sample rate at which to interpret the samples.
+    duration: The desired duration
+
+  Returns:
+    The repeated and possibly trimmed sequence.
+  &#34;&#34;&#34;
+  sequence_duration = len(samples) / sample_rate
+  num_repeats = int(math.ceil(duration / sequence_duration))
+  repeated_samples = np.concatenate([samples] * num_repeats)
+  trimmed = crop_samples(
+      repeated_samples, sample_rate,
+      crop_beginning_seconds=0, total_length_seconds=duration)
+  return trimmed</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.samples_to_wav_data"><code class="name flex">
+<span>def <span class="ident">samples_to_wav_data</span></span>(<span>samples, sample_rate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts floating point samples to wav data.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def samples_to_wav_data(samples, sample_rate):
+  &#34;&#34;&#34;Converts floating point samples to wav data.&#34;&#34;&#34;
+  wav_io = io.BytesIO()
+  scipy.io.wavfile.write(wav_io, sample_rate, float_samples_to_int16(samples))
+  return wav_io.getvalue()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.wav_data_to_samples"><code class="name flex">
+<span>def <span class="ident">wav_data_to_samples</span></span>(<span>wav_data, sample_rate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Read PCM-formatted WAV data and return a NumPy array of samples.</p>
+<p>Uses scipy to read and librosa to process WAV data. Audio will be converted to
+mono if necessary.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>wav_data</code></strong></dt>
+<dd>WAV audio data to read.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The number of samples per second at which the audio will be
+returned. Resampling will be performed if necessary.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A numpy array of audio samples, single-channel (mono) and sampled at the
+specified rate, in float32 format.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.audio_io.AudioIOReadError" href="#note_seq.audio_io.AudioIOReadError">AudioIOReadError</a></code></dt>
+<dd>If scipy is unable to read the WAV data.</dd>
+<dt><code><a title="note_seq.audio_io.AudioIOError" href="#note_seq.audio_io.AudioIOError">AudioIOError</a></code></dt>
+<dd>If audio processing fails.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def wav_data_to_samples(wav_data, sample_rate):
+  &#34;&#34;&#34;Read PCM-formatted WAV data and return a NumPy array of samples.
+
+  Uses scipy to read and librosa to process WAV data. Audio will be converted to
+  mono if necessary.
+
+  Args:
+    wav_data: WAV audio data to read.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadError: If scipy is unable to read the WAV data.
+    AudioIOError: If audio processing fails.
+  &#34;&#34;&#34;
+  try:
+    # Read the wav file, converting sample rate &amp; number of channels.
+    native_sr, y = scipy.io.wavfile.read(io.BytesIO(wav_data))
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOReadError(e)
+
+  if y.dtype == np.int16:
+    # Convert to float32.
+    y = int16_samples_to_float32(y)
+  elif y.dtype == np.float32:
+    # Already float32.
+    pass
+  else:
+    raise AudioIOError(
+        &#39;WAV file not 16-bit or 32-bit float PCM, unsupported&#39;)
+  try:
+    # Convert to mono and the desired sample rate.
+    if y.ndim == 2 and y.shape[1] == 2:
+      y = y.T
+      y = librosa.to_mono(y)
+    if native_sr != sample_rate:
+      y = librosa.resample(y, native_sr, sample_rate)
+  except Exception as e:  # pylint: disable=broad-except
+    raise AudioIOError(e)
+  return y</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.wav_data_to_samples_librosa"><code class="name flex">
+<span>def <span class="ident">wav_data_to_samples_librosa</span></span>(<span>audio_file, sample_rate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Loads an in-memory audio file with librosa.</p>
+<p>Use this instead of wav_data_to_samples if the wav is 24-bit, as that's
+incompatible with wav_data_to_samples internal scipy call.</p>
+<p>Will copy to a local temp file before loading so that librosa can read a file
+path. Librosa does not currently read in-memory files.</p>
+<p>It will be treated as a .wav file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>audio_file</code></strong></dt>
+<dd>Wav file to load.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The number of samples per second at which the audio will be
+returned. Resampling will be performed if necessary.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A numpy array of audio samples, single-channel (mono) and sampled at the
+specified rate, in float32 format.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>AudioIOReadException</code></dt>
+<dd>If librosa is unable to load the audio data.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def wav_data_to_samples_librosa(audio_file, sample_rate):
+  &#34;&#34;&#34;Loads an in-memory audio file with librosa.
+
+  Use this instead of wav_data_to_samples if the wav is 24-bit, as that&#39;s
+  incompatible with wav_data_to_samples internal scipy call.
+
+  Will copy to a local temp file before loading so that librosa can read a file
+  path. Librosa does not currently read in-memory files.
+
+  It will be treated as a .wav file.
+
+  Args:
+    audio_file: Wav file to load.
+    sample_rate: The number of samples per second at which the audio will be
+        returned. Resampling will be performed if necessary.
+
+  Returns:
+    A numpy array of audio samples, single-channel (mono) and sampled at the
+    specified rate, in float32 format.
+
+  Raises:
+    AudioIOReadException: If librosa is unable to load the audio data.
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile(suffix=&#39;.wav&#39;) as wav_input_file:
+    wav_input_file.write(audio_file)
+    # Before copying the file, flush any contents
+    wav_input_file.flush()
+    # And back the file position to top (not need for Copy but for certainty)
+    wav_input_file.seek(0)
+    return load_audio(wav_input_file.name, sample_rate)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io.wav_data_to_samples_pydub"><code class="name flex">
+<span>def <span class="ident">wav_data_to_samples_pydub</span></span>(<span>wav_data: bytes, sample_rate: int, remove_dc_bias: bool = False, num_channels: int = None, normalize_db: float = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert audio file data (in bytes) into a numpy array using Pydub.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>wav_data</code></strong></dt>
+<dd>A byte stream of audio data.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>Resample recorded audio to this sample rate.</dd>
+<dt><strong><code>remove_dc_bias</code></strong></dt>
+<dd>If true, will remove DC bias from audio.</dd>
+<dt><strong><code>num_channels</code></strong></dt>
+<dd>If not specified, output shape will be based on the contents
+of wav_data. Otherwise, will force to be 1 or 2 channels.</dd>
+<dt><strong><code>normalize_db</code></strong></dt>
+<dd>Normalize the audio to this many decibels. Set to None to skip
+normalization step.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An array of the recorded audio at sample_rate. If mono, will be shape
+[samples], otherwise [channels, samples].</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def wav_data_to_samples_pydub(wav_data: bytes,
+                              sample_rate: int,
+                              remove_dc_bias: bool = False,
+                              num_channels: int = None,
+                              normalize_db: float = None):
+  &#34;&#34;&#34;Convert audio file data (in bytes) into a numpy array using Pydub.
+
+  Args:
+    wav_data: A byte stream of audio data.
+    sample_rate: Resample recorded audio to this sample rate.
+    remove_dc_bias: If true, will remove DC bias from audio.
+    num_channels: If not specified, output shape will be based on the contents
+      of wav_data. Otherwise, will force to be 1 or 2 channels.
+    normalize_db: Normalize the audio to this many decibels. Set to None to skip
+      normalization step.
+
+  Returns:
+    An array of the recorded audio at sample_rate. If mono, will be shape
+    [samples], otherwise [channels, samples].
+  &#34;&#34;&#34;
+  # Parse and normalize the audio.
+  aseg = pydub.AudioSegment.from_file(io.BytesIO(wav_data))
+  if num_channels:
+    aseg = aseg.set_channels(num_channels)
+  if remove_dc_bias:
+    aseg = aseg.remove_dc_offset()
+  if normalize_db is not None:
+    aseg.normalize(headroom=normalize_db)
+  aseg = aseg.set_frame_rate(sample_rate)
+
+  # Convert to numpy array.
+  channel_asegs = aseg.split_to_mono()
+  samples = [s.get_array_of_samples() for s in channel_asegs]
+  fp_arr = np.array(samples).astype(np.float32)
+  fp_arr /= np.iinfo(samples[0].typecode).max
+
+  # If only 1 channel, remove extra dim.
+  if fp_arr.shape[0] == 1:
+    fp_arr = fp_arr[0]
+
+  return fp_arr</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.audio_io.AudioIODataTypeError"><code class="flex name class">
+<span>class <span class="ident">AudioIODataTypeError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all exceptions</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AudioIODataTypeError(AudioIOError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.audio_io.AudioIOError" href="#note_seq.audio_io.AudioIOError">AudioIOError</a></li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.audio_io.AudioIOError"><code class="flex name class">
+<span>class <span class="ident">AudioIOError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all exceptions</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AudioIOError(BaseException):  # pylint:disable=g-bad-exception-name
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.audio_io.AudioIODataTypeError" href="#note_seq.audio_io.AudioIODataTypeError">AudioIODataTypeError</a></li>
+<li><a title="note_seq.audio_io.AudioIOReadError" href="#note_seq.audio_io.AudioIOReadError">AudioIOReadError</a></li>
+</ul>
+</dd>
+<dt id="note_seq.audio_io.AudioIOReadError"><code class="flex name class">
+<span>class <span class="ident">AudioIOReadError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all exceptions</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AudioIOReadError(AudioIOError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.audio_io.AudioIOError" href="#note_seq.audio_io.AudioIOError">AudioIOError</a></li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.audio_io.crop_samples" href="#note_seq.audio_io.crop_samples">crop_samples</a></code></li>
+<li><code><a title="note_seq.audio_io.crop_wav_data" href="#note_seq.audio_io.crop_wav_data">crop_wav_data</a></code></li>
+<li><code><a title="note_seq.audio_io.float_samples_to_int16" href="#note_seq.audio_io.float_samples_to_int16">float_samples_to_int16</a></code></li>
+<li><code><a title="note_seq.audio_io.int16_samples_to_float32" href="#note_seq.audio_io.int16_samples_to_float32">int16_samples_to_float32</a></code></li>
+<li><code><a title="note_seq.audio_io.jitter_wav_data" href="#note_seq.audio_io.jitter_wav_data">jitter_wav_data</a></code></li>
+<li><code><a title="note_seq.audio_io.load_audio" href="#note_seq.audio_io.load_audio">load_audio</a></code></li>
+<li><code><a title="note_seq.audio_io.make_stereo" href="#note_seq.audio_io.make_stereo">make_stereo</a></code></li>
+<li><code><a title="note_seq.audio_io.normalize_wav_data" href="#note_seq.audio_io.normalize_wav_data">normalize_wav_data</a></code></li>
+<li><code><a title="note_seq.audio_io.repeat_samples_to_duration" href="#note_seq.audio_io.repeat_samples_to_duration">repeat_samples_to_duration</a></code></li>
+<li><code><a title="note_seq.audio_io.samples_to_wav_data" href="#note_seq.audio_io.samples_to_wav_data">samples_to_wav_data</a></code></li>
+<li><code><a title="note_seq.audio_io.wav_data_to_samples" href="#note_seq.audio_io.wav_data_to_samples">wav_data_to_samples</a></code></li>
+<li><code><a title="note_seq.audio_io.wav_data_to_samples_librosa" href="#note_seq.audio_io.wav_data_to_samples_librosa">wav_data_to_samples_librosa</a></code></li>
+<li><code><a title="note_seq.audio_io.wav_data_to_samples_pydub" href="#note_seq.audio_io.wav_data_to_samples_pydub">wav_data_to_samples_pydub</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.audio_io.AudioIODataTypeError" href="#note_seq.audio_io.AudioIODataTypeError">AudioIODataTypeError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.audio_io.AudioIOError" href="#note_seq.audio_io.AudioIOError">AudioIOError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.audio_io.AudioIOReadError" href="#note_seq.audio_io.AudioIOReadError">AudioIOReadError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/audio_io_test.html
+++ b/docs/audio_io_test.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.audio_io_test API documentation</title>
+<meta name="description" content="Tests for audio_io.py." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.audio_io_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for audio_io.py.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for audio_io.py.&#34;&#34;&#34;
+
+import io
+import os
+import wave
+
+from absl.testing import absltest
+from note_seq import audio_io
+from note_seq import testing_lib
+import numpy as np
+import scipy
+
+
+class AudioIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.wav_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example.wav&#39;)
+    self.wav_filename_mono = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_mono.wav&#39;)
+    self.wav_data = open(self.wav_filename, &#39;rb&#39;).read()
+    self.wav_data_mono = open(self.wav_filename_mono, &#39;rb&#39;).read()
+
+  def testWavDataToSamples(self):
+    w = wave.open(self.wav_filename, &#39;rb&#39;)
+    w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+    # Check content size.
+    y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+    y_mono = audio_io.wav_data_to_samples(self.wav_data_mono, sample_rate=22050)
+    self.assertEqual(
+        round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+    self.assertEqual(
+        round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+        y_mono.shape[0])
+
+    # Check a few obvious failure modes.
+    self.assertLess(0.01, y.std())
+    self.assertLess(0.01, y_mono.std())
+    self.assertGreater(-0.1, y.min())
+    self.assertGreater(-0.1, y_mono.min())
+    self.assertLess(0.1, y.max())
+    self.assertLess(0.1, y_mono.max())
+
+  def testFloatWavDataToSamples(self):
+    y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+    wav_io = io.BytesIO()
+    scipy.io.wavfile.write(wav_io, 16000, y)
+    y_from_float = audio_io.wav_data_to_samples(
+        wav_io.getvalue(), sample_rate=16000)
+    np.testing.assert_array_equal(y, y_from_float)
+
+  def testWavDataToSamplesPydub(self):
+    w = wave.open(self.wav_filename, &#39;rb&#39;)
+    w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+    # Check content size.
+    y = audio_io.wav_data_to_samples_pydub(
+        self.wav_data, sample_rate=16000, num_channels=1)
+    y_mono = audio_io.wav_data_to_samples_pydub(
+        self.wav_data_mono, sample_rate=22050, num_channels=1)
+    self.assertEqual(
+        round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+    self.assertEqual(
+        round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+        y_mono.shape[0])
+
+    # Check a few obvious failure modes.
+    self.assertLess(0.01, y.std())
+    self.assertLess(0.01, y_mono.std())
+    self.assertGreater(-0.1, y.min())
+    self.assertGreater(-0.1, y_mono.min())
+    self.assertLess(0.1, y.max())
+    self.assertLess(0.1, y_mono.max())
+
+  def testRepeatSamplesToDuration(self):
+    samples = np.arange(5)
+    repeated = audio_io.repeat_samples_to_duration(
+        samples, sample_rate=5, duration=1.8)
+    expected_samples = [0, 1, 2, 3, 4, 0, 1, 2, 3]
+    np.testing.assert_array_equal(expected_samples, repeated)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.audio_io_test.AudioIoTest"><code class="flex name class">
+<span>class <span class="ident">AudioIoTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AudioIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.wav_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example.wav&#39;)
+    self.wav_filename_mono = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_mono.wav&#39;)
+    self.wav_data = open(self.wav_filename, &#39;rb&#39;).read()
+    self.wav_data_mono = open(self.wav_filename_mono, &#39;rb&#39;).read()
+
+  def testWavDataToSamples(self):
+    w = wave.open(self.wav_filename, &#39;rb&#39;)
+    w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+    # Check content size.
+    y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+    y_mono = audio_io.wav_data_to_samples(self.wav_data_mono, sample_rate=22050)
+    self.assertEqual(
+        round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+    self.assertEqual(
+        round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+        y_mono.shape[0])
+
+    # Check a few obvious failure modes.
+    self.assertLess(0.01, y.std())
+    self.assertLess(0.01, y_mono.std())
+    self.assertGreater(-0.1, y.min())
+    self.assertGreater(-0.1, y_mono.min())
+    self.assertLess(0.1, y.max())
+    self.assertLess(0.1, y_mono.max())
+
+  def testFloatWavDataToSamples(self):
+    y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+    wav_io = io.BytesIO()
+    scipy.io.wavfile.write(wav_io, 16000, y)
+    y_from_float = audio_io.wav_data_to_samples(
+        wav_io.getvalue(), sample_rate=16000)
+    np.testing.assert_array_equal(y, y_from_float)
+
+  def testWavDataToSamplesPydub(self):
+    w = wave.open(self.wav_filename, &#39;rb&#39;)
+    w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+    # Check content size.
+    y = audio_io.wav_data_to_samples_pydub(
+        self.wav_data, sample_rate=16000, num_channels=1)
+    y_mono = audio_io.wav_data_to_samples_pydub(
+        self.wav_data_mono, sample_rate=22050, num_channels=1)
+    self.assertEqual(
+        round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+    self.assertEqual(
+        round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+        y_mono.shape[0])
+
+    # Check a few obvious failure modes.
+    self.assertLess(0.01, y.std())
+    self.assertLess(0.01, y_mono.std())
+    self.assertGreater(-0.1, y.min())
+    self.assertGreater(-0.1, y_mono.min())
+    self.assertLess(0.1, y.max())
+    self.assertLess(0.1, y_mono.max())
+
+  def testRepeatSamplesToDuration(self):
+    samples = np.arange(5)
+    repeated = audio_io.repeat_samples_to_duration(
+        samples, sample_rate=5, duration=1.8)
+    expected_samples = [0, 1, 2, 3, 4, 0, 1, 2, 3]
+    np.testing.assert_array_equal(expected_samples, repeated)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.audio_io_test.AudioIoTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.wav_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example.wav&#39;)
+  self.wav_filename_mono = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example_mono.wav&#39;)
+  self.wav_data = open(self.wav_filename, &#39;rb&#39;).read()
+  self.wav_data_mono = open(self.wav_filename_mono, &#39;rb&#39;).read()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io_test.AudioIoTest.testFloatWavDataToSamples"><code class="name flex">
+<span>def <span class="ident">testFloatWavDataToSamples</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFloatWavDataToSamples(self):
+  y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+  wav_io = io.BytesIO()
+  scipy.io.wavfile.write(wav_io, 16000, y)
+  y_from_float = audio_io.wav_data_to_samples(
+      wav_io.getvalue(), sample_rate=16000)
+  np.testing.assert_array_equal(y, y_from_float)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io_test.AudioIoTest.testRepeatSamplesToDuration"><code class="name flex">
+<span>def <span class="ident">testRepeatSamplesToDuration</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRepeatSamplesToDuration(self):
+  samples = np.arange(5)
+  repeated = audio_io.repeat_samples_to_duration(
+      samples, sample_rate=5, duration=1.8)
+  expected_samples = [0, 1, 2, 3, 4, 0, 1, 2, 3]
+  np.testing.assert_array_equal(expected_samples, repeated)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io_test.AudioIoTest.testWavDataToSamples"><code class="name flex">
+<span>def <span class="ident">testWavDataToSamples</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testWavDataToSamples(self):
+  w = wave.open(self.wav_filename, &#39;rb&#39;)
+  w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+  # Check content size.
+  y = audio_io.wav_data_to_samples(self.wav_data, sample_rate=16000)
+  y_mono = audio_io.wav_data_to_samples(self.wav_data_mono, sample_rate=22050)
+  self.assertEqual(
+      round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+  self.assertEqual(
+      round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+      y_mono.shape[0])
+
+  # Check a few obvious failure modes.
+  self.assertLess(0.01, y.std())
+  self.assertLess(0.01, y_mono.std())
+  self.assertGreater(-0.1, y.min())
+  self.assertGreater(-0.1, y_mono.min())
+  self.assertLess(0.1, y.max())
+  self.assertLess(0.1, y_mono.max())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.audio_io_test.AudioIoTest.testWavDataToSamplesPydub"><code class="name flex">
+<span>def <span class="ident">testWavDataToSamplesPydub</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testWavDataToSamplesPydub(self):
+  w = wave.open(self.wav_filename, &#39;rb&#39;)
+  w_mono = wave.open(self.wav_filename_mono, &#39;rb&#39;)
+
+  # Check content size.
+  y = audio_io.wav_data_to_samples_pydub(
+      self.wav_data, sample_rate=16000, num_channels=1)
+  y_mono = audio_io.wav_data_to_samples_pydub(
+      self.wav_data_mono, sample_rate=22050, num_channels=1)
+  self.assertEqual(
+      round(16000.0 * w.getnframes() / w.getframerate()), y.shape[0])
+  self.assertEqual(
+      round(22050.0 * w_mono.getnframes() / w_mono.getframerate()),
+      y_mono.shape[0])
+
+  # Check a few obvious failure modes.
+  self.assertLess(0.01, y.std())
+  self.assertLess(0.01, y_mono.std())
+  self.assertGreater(-0.1, y.min())
+  self.assertGreater(-0.1, y_mono.min())
+  self.assertLess(0.1, y.max())
+  self.assertLess(0.1, y_mono.max())</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.audio_io_test.AudioIoTest" href="#note_seq.audio_io_test.AudioIoTest">AudioIoTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.audio_io_test.AudioIoTest.setUp" href="#note_seq.audio_io_test.AudioIoTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.audio_io_test.AudioIoTest.testFloatWavDataToSamples" href="#note_seq.audio_io_test.AudioIoTest.testFloatWavDataToSamples">testFloatWavDataToSamples</a></code></li>
+<li><code><a title="note_seq.audio_io_test.AudioIoTest.testRepeatSamplesToDuration" href="#note_seq.audio_io_test.AudioIoTest.testRepeatSamplesToDuration">testRepeatSamplesToDuration</a></code></li>
+<li><code><a title="note_seq.audio_io_test.AudioIoTest.testWavDataToSamples" href="#note_seq.audio_io_test.AudioIoTest.testWavDataToSamples">testWavDataToSamples</a></code></li>
+<li><code><a title="note_seq.audio_io_test.AudioIoTest.testWavDataToSamplesPydub" href="#note_seq.audio_io_test.AudioIoTest.testWavDataToSamplesPydub">testWavDataToSamplesPydub</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chord_inference.html
+++ b/docs/chord_inference.html
@@ -1,0 +1,972 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chord_inference API documentation</title>
+<meta name="description" content="Chord inference for NoteSequences." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chord_inference</code></h1>
+</header>
+<section id="section-intro">
+<p>Chord inference for NoteSequences.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Chord inference for NoteSequences.&#34;&#34;&#34;
+import bisect
+import itertools
+import math
+import numbers
+
+from absl import logging
+from note_seq import constants
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+import numpy as np
+
+# Names of pitch classes to use (mostly ignoring spelling).
+_PITCH_CLASS_NAMES = [
+    &#39;C&#39;, &#39;C#&#39;, &#39;D&#39;, &#39;Eb&#39;, &#39;E&#39;, &#39;F&#39;, &#39;F#&#39;, &#39;G&#39;, &#39;Ab&#39;, &#39;A&#39;, &#39;Bb&#39;, &#39;B&#39;]
+
+# Pitch classes in a key (rooted at zero).
+_KEY_PITCHES = [0, 2, 4, 5, 7, 9, 11]
+
+# Pitch classes in each chord kind (rooted at zero).
+_CHORD_KIND_PITCHES = {
+    &#39;&#39;: [0, 4, 7],
+    &#39;m&#39;: [0, 3, 7],
+    &#39;+&#39;: [0, 4, 8],
+    &#39;dim&#39;: [0, 3, 6],
+    &#39;7&#39;: [0, 4, 7, 10],
+    &#39;maj7&#39;: [0, 4, 7, 11],
+    &#39;m7&#39;: [0, 3, 7, 10],
+    &#39;m7b5&#39;: [0, 3, 6, 10],
+}
+_CHORD_KINDS = _CHORD_KIND_PITCHES.keys()
+
+# All usable chords, including no-chord.
+_CHORDS = [constants.NO_CHORD] + list(
+    itertools.product(range(12), _CHORD_KINDS))
+
+# All key-chord pairs.
+_KEY_CHORDS = list(itertools.product(range(12), _CHORDS))
+
+# Maximum length of chord sequence to infer.
+_MAX_NUM_CHORDS = 1000
+
+# Mapping from time signature to number of chords to infer per bar.
+_DEFAULT_TIME_SIGNATURE_CHORDS_PER_BAR = {
+    (2, 2): 1,
+    (2, 4): 1,
+    (3, 4): 1,
+    (4, 4): 2,
+    (6, 8): 2,
+}
+
+
+def _key_chord_distribution(chord_pitch_out_of_key_prob):
+  &#34;&#34;&#34;Probability distribution over chords for each key.&#34;&#34;&#34;
+  num_pitches_in_key = np.zeros([12, len(_CHORDS)], dtype=np.int32)
+  num_pitches_out_of_key = np.zeros([12, len(_CHORDS)], dtype=np.int32)
+
+  # For each key and chord, compute the number of chord notes in the key and the
+  # number of chord notes outside the key.
+  for key in range(12):
+    key_pitches = set((key + offset) % 12 for offset in _KEY_PITCHES)
+    for i, chord in enumerate(_CHORDS[1:]):
+      root, kind = chord
+      chord_pitches = set((root + offset) % 12
+                          for offset in _CHORD_KIND_PITCHES[kind])
+      num_pitches_in_key[key, i + 1] = len(chord_pitches &amp; key_pitches)
+      num_pitches_out_of_key[key, i + 1] = len(chord_pitches - key_pitches)
+
+  # Compute the probability of each chord under each key, normalizing to sum to
+  # one for each key.
+  mat = ((1 - chord_pitch_out_of_key_prob) ** num_pitches_in_key *
+         chord_pitch_out_of_key_prob ** num_pitches_out_of_key)
+  mat /= mat.sum(axis=1)[:, np.newaxis]
+  return mat
+
+
+def _key_chord_transition_distribution(
+    key_chord_distribution, key_change_prob, chord_change_prob):
+  &#34;&#34;&#34;Transition distribution between key-chord pairs.&#34;&#34;&#34;
+  mat = np.zeros([len(_KEY_CHORDS), len(_KEY_CHORDS)])
+
+  for i, key_chord_1 in enumerate(_KEY_CHORDS):
+    key_1, chord_1 = key_chord_1
+    chord_index_1 = i % len(_CHORDS)
+
+    for j, key_chord_2 in enumerate(_KEY_CHORDS):
+      key_2, chord_2 = key_chord_2
+      chord_index_2 = j % len(_CHORDS)
+
+      if key_1 != key_2:
+        # Key change. Chord probability depends only on key and not previous
+        # chord.
+        mat[i, j] = (key_change_prob / 11)
+        mat[i, j] *= key_chord_distribution[key_2, chord_index_2]
+
+      else:
+        # No key change.
+        mat[i, j] = 1 - key_change_prob
+        if chord_1 != chord_2:
+          # Chord probability depends on key, but we have to redistribute the
+          # probability mass on the previous chord since we know the chord
+          # changed.
+          mat[i, j] *= (
+              chord_change_prob * (
+                  key_chord_distribution[key_2, chord_index_2] +
+                  key_chord_distribution[key_2, chord_index_1] / (len(_CHORDS) -
+                                                                  1)))
+        else:
+          # No chord change.
+          mat[i, j] *= 1 - chord_change_prob
+
+  return mat
+
+
+def _chord_pitch_vectors():
+  &#34;&#34;&#34;Unit vectors over pitch classes for all chords.&#34;&#34;&#34;
+  x = np.zeros([len(_CHORDS), 12])
+  for i, chord in enumerate(_CHORDS[1:]):
+    root, kind = chord
+    for offset in _CHORD_KIND_PITCHES[kind]:
+      x[i + 1, (root + offset) % 12] = 1
+  x[1:, :] /= np.linalg.norm(x[1:, :], axis=1)[:, np.newaxis]
+  return x
+
+
+def sequence_note_pitch_vectors(sequence, seconds_per_frame):
+  &#34;&#34;&#34;Compute pitch class vectors for temporal frames across a sequence.
+
+  Args:
+    sequence: The NoteSequence for which to compute pitch class vectors.
+    seconds_per_frame: The size of the frame corresponding to each pitch class
+        vector, in seconds. Alternatively, a list of frame boundary times in
+        seconds (not including initial start time and final end time).
+
+  Returns:
+    A numpy array with shape `[num_frames, 12]` where each row is a unit-
+    normalized pitch class vector for the corresponding frame in `sequence`.
+  &#34;&#34;&#34;
+  if isinstance(seconds_per_frame, numbers.Number):
+    # Construct array of frame boundary times.
+    num_frames = int(math.ceil(sequence.total_time / seconds_per_frame))
+    frame_boundaries = seconds_per_frame * np.arange(1, num_frames)
+  else:
+    frame_boundaries = sorted(seconds_per_frame)
+    num_frames = len(frame_boundaries) + 1
+
+  x = np.zeros([num_frames, 12])
+
+  for note in sequence.notes:
+    if note.is_drum:
+      continue
+    if note.program in constants.UNPITCHED_PROGRAMS:
+      continue
+
+    start_frame = bisect.bisect_right(frame_boundaries, note.start_time)
+    end_frame = bisect.bisect_left(frame_boundaries, note.end_time)
+    pitch_class = note.pitch % 12
+
+    if start_frame &gt;= end_frame:
+      x[start_frame, pitch_class] += note.end_time - note.start_time
+    else:
+      x[start_frame, pitch_class] += (
+          frame_boundaries[start_frame] - note.start_time)
+      for frame in range(start_frame + 1, end_frame):
+        x[frame, pitch_class] += (
+            frame_boundaries[frame] - frame_boundaries[frame - 1])
+      x[end_frame, pitch_class] += (
+          note.end_time - frame_boundaries[end_frame - 1])
+
+  x_norm = np.linalg.norm(x, axis=1)
+  nonzero_frames = x_norm &gt; 0
+  x[nonzero_frames, :] /= x_norm[nonzero_frames, np.newaxis]
+
+  return x
+
+
+def _chord_frame_log_likelihood(note_pitch_vectors, chord_note_concentration):
+  &#34;&#34;&#34;Log-likelihood of observing each frame of note pitches under each chord.&#34;&#34;&#34;
+  return chord_note_concentration * np.dot(note_pitch_vectors,
+                                           _chord_pitch_vectors().T)
+
+
+def _key_chord_viterbi(chord_frame_loglik,
+                       key_chord_loglik,
+                       key_chord_transition_loglik):
+  &#34;&#34;&#34;Use the Viterbi algorithm to infer a sequence of key-chord pairs.&#34;&#34;&#34;
+  num_frames, num_chords = chord_frame_loglik.shape
+  num_key_chords = len(key_chord_transition_loglik)
+
+  loglik_matrix = np.zeros([num_frames, num_key_chords])
+  path_matrix = np.zeros([num_frames, num_key_chords], dtype=np.int32)
+
+  # Initialize with a uniform distribution over keys.
+  for i, key_chord in enumerate(_KEY_CHORDS):
+    key, unused_chord = key_chord
+    chord_index = i % len(_CHORDS)
+    loglik_matrix[0, i] = (
+        -np.log(12) + key_chord_loglik[key, chord_index] +
+        chord_frame_loglik[0, chord_index])
+
+  for frame in range(1, num_frames):
+    # At each frame, store the log-likelihood of the best sequence ending in
+    # each key-chord pair, along with the index of the parent key-chord pair
+    # from the previous frame.
+    mat = (np.tile(loglik_matrix[frame - 1][:, np.newaxis],
+                   [1, num_key_chords]) +
+           key_chord_transition_loglik)
+    path_matrix[frame, :] = mat.argmax(axis=0)
+    loglik_matrix[frame, :] = (
+        mat[path_matrix[frame, :], range(num_key_chords)] +
+        np.tile(chord_frame_loglik[frame], 12))
+
+  # Reconstruct the most likely sequence of key-chord pairs.
+  path = [np.argmax(loglik_matrix[-1])]
+  for frame in range(num_frames, 1, -1):
+    path.append(path_matrix[frame - 1, path[-1]])
+
+  return [(index // num_chords, _CHORDS[index % num_chords])
+          for index in path[::-1]]
+
+
+class ChordInferenceError(Exception):  # pylint:disable=g-bad-exception-name
+  pass
+
+
+class SequenceAlreadyHasChordsError(ChordInferenceError):
+  pass
+
+
+class UncommonTimeSignatureError(ChordInferenceError):
+  pass
+
+
+class NonIntegerStepsPerChordError(ChordInferenceError):
+  pass
+
+
+class EmptySequenceError(ChordInferenceError):
+  pass
+
+
+class SequenceTooLongError(ChordInferenceError):
+  pass
+
+
+def infer_chords_for_sequence(sequence,
+                              chords_per_bar=None,
+                              key_change_prob=0.001,
+                              chord_change_prob=0.5,
+                              chord_pitch_out_of_key_prob=0.01,
+                              chord_note_concentration=100.0,
+                              add_key_signatures=False):
+  &#34;&#34;&#34;Infer chords for a NoteSequence using the Viterbi algorithm.
+
+  This uses some heuristics to infer chords for a quantized NoteSequence. At
+  each chord position a key and chord will be inferred, and the chords will be
+  added (as text annotations) to the sequence.
+
+  If the sequence is quantized relative to meter, a fixed number of chords per
+  bar will be inferred. Otherwise, the sequence is expected to have beat
+  annotations and one chord will be inferred per beat.
+
+  Args:
+    sequence: The NoteSequence for which to infer chords. This NoteSequence will
+        be modified in place.
+    chords_per_bar: If `sequence` is quantized, the number of chords per bar to
+        infer. If None, use a default number of chords based on the time
+        signature of `sequence`.
+    key_change_prob: Probability of a key change between two adjacent frames.
+    chord_change_prob: Probability of a chord change between two adjacent
+        frames.
+    chord_pitch_out_of_key_prob: Probability of a pitch in a chord not belonging
+        to the current key.
+    chord_note_concentration: Concentration parameter for the distribution of
+        observed pitches played over a chord. At zero, all pitches are equally
+        likely. As concentration increases, observed pitches must match the
+        chord pitches more closely.
+    add_key_signatures: If True, also add inferred key signatures to
+        `quantized_sequence` (and remove any existing key signatures).
+
+  Raises:
+    SequenceAlreadyHasChordsError: If `sequence` already has chords.
+    QuantizationStatusError: If `sequence` is not quantized relative to
+        meter but `chords_per_bar` is specified or no beat annotations are
+        present.
+    UncommonTimeSignatureError: If `chords_per_bar` is not specified and
+        `sequence` is quantized and has an uncommon time signature.
+    NonIntegerStepsPerChordError: If the number of quantized steps per chord
+        is not an integer.
+    EmptySequenceError: If `sequence` is empty.
+    SequenceTooLongError: If the number of chords to be inferred is too
+        large.
+  &#34;&#34;&#34;
+  for ta in sequence.text_annotations:
+    if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL:
+      raise SequenceAlreadyHasChordsError(
+          &#39;NoteSequence already has chord(s): %s&#39; % ta.text)
+
+  if sequences_lib.is_relative_quantized_sequence(sequence):
+    # Infer a fixed number of chords per bar.
+    if chords_per_bar is None:
+      time_signature = (sequence.time_signatures[0].numerator,
+                        sequence.time_signatures[0].denominator)
+      if time_signature not in _DEFAULT_TIME_SIGNATURE_CHORDS_PER_BAR:
+        raise UncommonTimeSignatureError(
+            &#39;No default chords per bar for time signature: (%d, %d)&#39; %
+            time_signature)
+      chords_per_bar = _DEFAULT_TIME_SIGNATURE_CHORDS_PER_BAR[time_signature]
+
+    # Determine the number of seconds (and steps) each chord is held.
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        sequence)
+    steps_per_chord_float = steps_per_bar_float / chords_per_bar
+    if steps_per_chord_float != round(steps_per_chord_float):
+      raise NonIntegerStepsPerChordError(
+          &#39;Non-integer number of steps per chord: %f&#39; % steps_per_chord_float)
+    steps_per_chord = int(steps_per_chord_float)
+    steps_per_second = sequences_lib.steps_per_quarter_to_steps_per_second(
+        sequence.quantization_info.steps_per_quarter, sequence.tempos[0].qpm)
+    seconds_per_chord = steps_per_chord / steps_per_second
+
+    num_chords = int(math.ceil(sequence.total_time / seconds_per_chord))
+    if num_chords == 0:
+      raise EmptySequenceError(&#39;NoteSequence is empty.&#39;)
+
+  else:
+    # Sequence is not quantized relative to meter; chord changes will happen at
+    # annotated beat times.
+    if chords_per_bar is not None:
+      raise sequences_lib.QuantizationStatusError(
+          &#39;Sequence must be quantized to infer fixed number of chords per bar.&#39;)
+    beats = [
+        ta for ta in sequence.text_annotations
+        if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.BEAT
+    ]
+    if not beats:
+      raise sequences_lib.QuantizationStatusError(
+          &#39;Sequence must be quantized to infer chords without annotated beats.&#39;)
+
+    # Only keep unique beats in the interior of the sequence. The first chord
+    # always starts at time zero, the last chord always ends at
+    # `sequence.total_time`, and we don&#39;t want any zero-length chords.
+    sorted_beats = sorted(
+        [beat for beat in beats if 0.0 &lt; beat.time &lt; sequence.total_time],
+        key=lambda beat: beat.time)
+    unique_sorted_beats = [sorted_beats[i] for i in range(len(sorted_beats))
+                           if i == 0
+                           or sorted_beats[i].time &gt; sorted_beats[i - 1].time]
+
+    num_chords = len(unique_sorted_beats) + 1
+    sorted_beat_times = [beat.time for beat in unique_sorted_beats]
+    if sequences_lib.is_quantized_sequence(sequence):
+      sorted_beat_steps = [beat.quantized_step for beat in unique_sorted_beats]
+
+  if num_chords &gt; _MAX_NUM_CHORDS:
+    raise SequenceTooLongError(
+        &#39;NoteSequence too long for chord inference: %d frames&#39; % num_chords)
+
+  # Compute pitch vectors for each chord frame, then compute log-likelihood of
+  # observing those pitch vectors under each possible chord.
+  note_pitch_vectors = sequence_note_pitch_vectors(
+      sequence,
+      seconds_per_chord if chords_per_bar is not None else sorted_beat_times)
+  chord_frame_loglik = _chord_frame_log_likelihood(
+      note_pitch_vectors, chord_note_concentration)
+
+  # Compute distribution over chords for each key, and transition distribution
+  # between key-chord pairs.
+  key_chord_distribution = _key_chord_distribution(
+      chord_pitch_out_of_key_prob=chord_pitch_out_of_key_prob)
+  key_chord_transition_distribution = _key_chord_transition_distribution(
+      key_chord_distribution,
+      key_change_prob=key_change_prob,
+      chord_change_prob=chord_change_prob)
+  key_chord_loglik = np.log(key_chord_distribution)
+  key_chord_transition_loglik = np.log(key_chord_transition_distribution)
+
+  key_chords = _key_chord_viterbi(
+      chord_frame_loglik, key_chord_loglik, key_chord_transition_loglik)
+
+  if add_key_signatures:
+    del sequence.key_signatures[:]
+
+  # Add the inferred chord changes to the sequence, optionally adding key
+  # signature(s) as well.
+  current_key_name = None
+  current_chord_name = None
+  for frame, (key, chord) in enumerate(key_chords):
+    if chords_per_bar is not None:
+      time = frame * seconds_per_chord
+    else:
+      time = 0.0 if frame == 0 else sorted_beat_times[frame - 1]
+
+    if _PITCH_CLASS_NAMES[key] != current_key_name:
+      # A key change was inferred.
+      if add_key_signatures:
+        ks = sequence.key_signatures.add()
+        ks.time = time
+        ks.key = key
+      else:
+        if current_key_name is not None:
+          logging.info(
+              &#39;Sequence has key change from %s to %s at %f seconds.&#39;,
+              current_key_name, _PITCH_CLASS_NAMES[key], time)
+
+      current_key_name = _PITCH_CLASS_NAMES[key]
+
+    if chord == constants.NO_CHORD:
+      figure = constants.NO_CHORD
+    else:
+      root, kind = chord
+      figure = &#39;%s%s&#39; % (_PITCH_CLASS_NAMES[root], kind)
+
+    if figure != current_chord_name:
+      ta = sequence.text_annotations.add()
+      ta.time = time
+      if sequences_lib.is_quantized_sequence(sequence):
+        if chords_per_bar is not None:
+          ta.quantized_step = frame * steps_per_chord
+        else:
+          ta.quantized_step = 0 if frame == 0 else sorted_beat_steps[frame - 1]
+      ta.text = figure
+      ta.annotation_type = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+      current_chord_name = figure</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.chord_inference.infer_chords_for_sequence"><code class="name flex">
+<span>def <span class="ident">infer_chords_for_sequence</span></span>(<span>sequence, chords_per_bar=None, key_change_prob=0.001, chord_change_prob=0.5, chord_pitch_out_of_key_prob=0.01, chord_note_concentration=100.0, add_key_signatures=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Infer chords for a NoteSequence using the Viterbi algorithm.</p>
+<p>This uses some heuristics to infer chords for a quantized NoteSequence. At
+each chord position a key and chord will be inferred, and the chords will be
+added (as text annotations) to the sequence.</p>
+<p>If the sequence is quantized relative to meter, a fixed number of chords per
+bar will be inferred. Otherwise, the sequence is expected to have beat
+annotations and one chord will be inferred per beat.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to infer chords. This NoteSequence will
+be modified in place.</dd>
+<dt><strong><code>chords_per_bar</code></strong></dt>
+<dd>If <code>sequence</code> is quantized, the number of chords per bar to
+infer. If None, use a default number of chords based on the time
+signature of <code>sequence</code>.</dd>
+<dt><strong><code>key_change_prob</code></strong></dt>
+<dd>Probability of a key change between two adjacent frames.</dd>
+<dt><strong><code>chord_change_prob</code></strong></dt>
+<dd>Probability of a chord change between two adjacent
+frames.</dd>
+<dt><strong><code>chord_pitch_out_of_key_prob</code></strong></dt>
+<dd>Probability of a pitch in a chord not belonging
+to the current key.</dd>
+<dt><strong><code>chord_note_concentration</code></strong></dt>
+<dd>Concentration parameter for the distribution of
+observed pitches played over a chord. At zero, all pitches are equally
+likely. As concentration increases, observed pitches must match the
+chord pitches more closely.</dd>
+<dt><strong><code>add_key_signatures</code></strong></dt>
+<dd>If True, also add inferred key signatures to
+<code>quantized_sequence</code> (and remove any existing key signatures).</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_inference.SequenceAlreadyHasChordsError" href="#note_seq.chord_inference.SequenceAlreadyHasChordsError">SequenceAlreadyHasChordsError</a></code></dt>
+<dd>If <code>sequence</code> already has chords.</dd>
+<dt><code>QuantizationStatusError</code></dt>
+<dd>If <code>sequence</code> is not quantized relative to
+meter but <code>chords_per_bar</code> is specified or no beat annotations are
+present.</dd>
+<dt><code><a title="note_seq.chord_inference.UncommonTimeSignatureError" href="#note_seq.chord_inference.UncommonTimeSignatureError">UncommonTimeSignatureError</a></code></dt>
+<dd>If <code>chords_per_bar</code> is not specified and
+<code>sequence</code> is quantized and has an uncommon time signature.</dd>
+<dt><code><a title="note_seq.chord_inference.NonIntegerStepsPerChordError" href="#note_seq.chord_inference.NonIntegerStepsPerChordError">NonIntegerStepsPerChordError</a></code></dt>
+<dd>If the number of quantized steps per chord
+is not an integer.</dd>
+<dt><code><a title="note_seq.chord_inference.EmptySequenceError" href="#note_seq.chord_inference.EmptySequenceError">EmptySequenceError</a></code></dt>
+<dd>If <code>sequence</code> is empty.</dd>
+<dt><code><a title="note_seq.chord_inference.SequenceTooLongError" href="#note_seq.chord_inference.SequenceTooLongError">SequenceTooLongError</a></code></dt>
+<dd>If the number of chords to be inferred is too
+large.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def infer_chords_for_sequence(sequence,
+                              chords_per_bar=None,
+                              key_change_prob=0.001,
+                              chord_change_prob=0.5,
+                              chord_pitch_out_of_key_prob=0.01,
+                              chord_note_concentration=100.0,
+                              add_key_signatures=False):
+  &#34;&#34;&#34;Infer chords for a NoteSequence using the Viterbi algorithm.
+
+  This uses some heuristics to infer chords for a quantized NoteSequence. At
+  each chord position a key and chord will be inferred, and the chords will be
+  added (as text annotations) to the sequence.
+
+  If the sequence is quantized relative to meter, a fixed number of chords per
+  bar will be inferred. Otherwise, the sequence is expected to have beat
+  annotations and one chord will be inferred per beat.
+
+  Args:
+    sequence: The NoteSequence for which to infer chords. This NoteSequence will
+        be modified in place.
+    chords_per_bar: If `sequence` is quantized, the number of chords per bar to
+        infer. If None, use a default number of chords based on the time
+        signature of `sequence`.
+    key_change_prob: Probability of a key change between two adjacent frames.
+    chord_change_prob: Probability of a chord change between two adjacent
+        frames.
+    chord_pitch_out_of_key_prob: Probability of a pitch in a chord not belonging
+        to the current key.
+    chord_note_concentration: Concentration parameter for the distribution of
+        observed pitches played over a chord. At zero, all pitches are equally
+        likely. As concentration increases, observed pitches must match the
+        chord pitches more closely.
+    add_key_signatures: If True, also add inferred key signatures to
+        `quantized_sequence` (and remove any existing key signatures).
+
+  Raises:
+    SequenceAlreadyHasChordsError: If `sequence` already has chords.
+    QuantizationStatusError: If `sequence` is not quantized relative to
+        meter but `chords_per_bar` is specified or no beat annotations are
+        present.
+    UncommonTimeSignatureError: If `chords_per_bar` is not specified and
+        `sequence` is quantized and has an uncommon time signature.
+    NonIntegerStepsPerChordError: If the number of quantized steps per chord
+        is not an integer.
+    EmptySequenceError: If `sequence` is empty.
+    SequenceTooLongError: If the number of chords to be inferred is too
+        large.
+  &#34;&#34;&#34;
+  for ta in sequence.text_annotations:
+    if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL:
+      raise SequenceAlreadyHasChordsError(
+          &#39;NoteSequence already has chord(s): %s&#39; % ta.text)
+
+  if sequences_lib.is_relative_quantized_sequence(sequence):
+    # Infer a fixed number of chords per bar.
+    if chords_per_bar is None:
+      time_signature = (sequence.time_signatures[0].numerator,
+                        sequence.time_signatures[0].denominator)
+      if time_signature not in _DEFAULT_TIME_SIGNATURE_CHORDS_PER_BAR:
+        raise UncommonTimeSignatureError(
+            &#39;No default chords per bar for time signature: (%d, %d)&#39; %
+            time_signature)
+      chords_per_bar = _DEFAULT_TIME_SIGNATURE_CHORDS_PER_BAR[time_signature]
+
+    # Determine the number of seconds (and steps) each chord is held.
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        sequence)
+    steps_per_chord_float = steps_per_bar_float / chords_per_bar
+    if steps_per_chord_float != round(steps_per_chord_float):
+      raise NonIntegerStepsPerChordError(
+          &#39;Non-integer number of steps per chord: %f&#39; % steps_per_chord_float)
+    steps_per_chord = int(steps_per_chord_float)
+    steps_per_second = sequences_lib.steps_per_quarter_to_steps_per_second(
+        sequence.quantization_info.steps_per_quarter, sequence.tempos[0].qpm)
+    seconds_per_chord = steps_per_chord / steps_per_second
+
+    num_chords = int(math.ceil(sequence.total_time / seconds_per_chord))
+    if num_chords == 0:
+      raise EmptySequenceError(&#39;NoteSequence is empty.&#39;)
+
+  else:
+    # Sequence is not quantized relative to meter; chord changes will happen at
+    # annotated beat times.
+    if chords_per_bar is not None:
+      raise sequences_lib.QuantizationStatusError(
+          &#39;Sequence must be quantized to infer fixed number of chords per bar.&#39;)
+    beats = [
+        ta for ta in sequence.text_annotations
+        if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.BEAT
+    ]
+    if not beats:
+      raise sequences_lib.QuantizationStatusError(
+          &#39;Sequence must be quantized to infer chords without annotated beats.&#39;)
+
+    # Only keep unique beats in the interior of the sequence. The first chord
+    # always starts at time zero, the last chord always ends at
+    # `sequence.total_time`, and we don&#39;t want any zero-length chords.
+    sorted_beats = sorted(
+        [beat for beat in beats if 0.0 &lt; beat.time &lt; sequence.total_time],
+        key=lambda beat: beat.time)
+    unique_sorted_beats = [sorted_beats[i] for i in range(len(sorted_beats))
+                           if i == 0
+                           or sorted_beats[i].time &gt; sorted_beats[i - 1].time]
+
+    num_chords = len(unique_sorted_beats) + 1
+    sorted_beat_times = [beat.time for beat in unique_sorted_beats]
+    if sequences_lib.is_quantized_sequence(sequence):
+      sorted_beat_steps = [beat.quantized_step for beat in unique_sorted_beats]
+
+  if num_chords &gt; _MAX_NUM_CHORDS:
+    raise SequenceTooLongError(
+        &#39;NoteSequence too long for chord inference: %d frames&#39; % num_chords)
+
+  # Compute pitch vectors for each chord frame, then compute log-likelihood of
+  # observing those pitch vectors under each possible chord.
+  note_pitch_vectors = sequence_note_pitch_vectors(
+      sequence,
+      seconds_per_chord if chords_per_bar is not None else sorted_beat_times)
+  chord_frame_loglik = _chord_frame_log_likelihood(
+      note_pitch_vectors, chord_note_concentration)
+
+  # Compute distribution over chords for each key, and transition distribution
+  # between key-chord pairs.
+  key_chord_distribution = _key_chord_distribution(
+      chord_pitch_out_of_key_prob=chord_pitch_out_of_key_prob)
+  key_chord_transition_distribution = _key_chord_transition_distribution(
+      key_chord_distribution,
+      key_change_prob=key_change_prob,
+      chord_change_prob=chord_change_prob)
+  key_chord_loglik = np.log(key_chord_distribution)
+  key_chord_transition_loglik = np.log(key_chord_transition_distribution)
+
+  key_chords = _key_chord_viterbi(
+      chord_frame_loglik, key_chord_loglik, key_chord_transition_loglik)
+
+  if add_key_signatures:
+    del sequence.key_signatures[:]
+
+  # Add the inferred chord changes to the sequence, optionally adding key
+  # signature(s) as well.
+  current_key_name = None
+  current_chord_name = None
+  for frame, (key, chord) in enumerate(key_chords):
+    if chords_per_bar is not None:
+      time = frame * seconds_per_chord
+    else:
+      time = 0.0 if frame == 0 else sorted_beat_times[frame - 1]
+
+    if _PITCH_CLASS_NAMES[key] != current_key_name:
+      # A key change was inferred.
+      if add_key_signatures:
+        ks = sequence.key_signatures.add()
+        ks.time = time
+        ks.key = key
+      else:
+        if current_key_name is not None:
+          logging.info(
+              &#39;Sequence has key change from %s to %s at %f seconds.&#39;,
+              current_key_name, _PITCH_CLASS_NAMES[key], time)
+
+      current_key_name = _PITCH_CLASS_NAMES[key]
+
+    if chord == constants.NO_CHORD:
+      figure = constants.NO_CHORD
+    else:
+      root, kind = chord
+      figure = &#39;%s%s&#39; % (_PITCH_CLASS_NAMES[root], kind)
+
+    if figure != current_chord_name:
+      ta = sequence.text_annotations.add()
+      ta.time = time
+      if sequences_lib.is_quantized_sequence(sequence):
+        if chords_per_bar is not None:
+          ta.quantized_step = frame * steps_per_chord
+        else:
+          ta.quantized_step = 0 if frame == 0 else sorted_beat_steps[frame - 1]
+      ta.text = figure
+      ta.annotation_type = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+      current_chord_name = figure</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_inference.sequence_note_pitch_vectors"><code class="name flex">
+<span>def <span class="ident">sequence_note_pitch_vectors</span></span>(<span>sequence, seconds_per_frame)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compute pitch class vectors for temporal frames across a sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to compute pitch class vectors.</dd>
+<dt><strong><code>seconds_per_frame</code></strong></dt>
+<dd>The size of the frame corresponding to each pitch class
+vector, in seconds. Alternatively, a list of frame boundary times in
+seconds (not including initial start time and final end time).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A numpy array with shape <code>[num_frames, 12]</code> where each row is a unit-
+normalized pitch class vector for the corresponding frame in <code>sequence</code>.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_note_pitch_vectors(sequence, seconds_per_frame):
+  &#34;&#34;&#34;Compute pitch class vectors for temporal frames across a sequence.
+
+  Args:
+    sequence: The NoteSequence for which to compute pitch class vectors.
+    seconds_per_frame: The size of the frame corresponding to each pitch class
+        vector, in seconds. Alternatively, a list of frame boundary times in
+        seconds (not including initial start time and final end time).
+
+  Returns:
+    A numpy array with shape `[num_frames, 12]` where each row is a unit-
+    normalized pitch class vector for the corresponding frame in `sequence`.
+  &#34;&#34;&#34;
+  if isinstance(seconds_per_frame, numbers.Number):
+    # Construct array of frame boundary times.
+    num_frames = int(math.ceil(sequence.total_time / seconds_per_frame))
+    frame_boundaries = seconds_per_frame * np.arange(1, num_frames)
+  else:
+    frame_boundaries = sorted(seconds_per_frame)
+    num_frames = len(frame_boundaries) + 1
+
+  x = np.zeros([num_frames, 12])
+
+  for note in sequence.notes:
+    if note.is_drum:
+      continue
+    if note.program in constants.UNPITCHED_PROGRAMS:
+      continue
+
+    start_frame = bisect.bisect_right(frame_boundaries, note.start_time)
+    end_frame = bisect.bisect_left(frame_boundaries, note.end_time)
+    pitch_class = note.pitch % 12
+
+    if start_frame &gt;= end_frame:
+      x[start_frame, pitch_class] += note.end_time - note.start_time
+    else:
+      x[start_frame, pitch_class] += (
+          frame_boundaries[start_frame] - note.start_time)
+      for frame in range(start_frame + 1, end_frame):
+        x[frame, pitch_class] += (
+            frame_boundaries[frame] - frame_boundaries[frame - 1])
+      x[end_frame, pitch_class] += (
+          note.end_time - frame_boundaries[end_frame - 1])
+
+  x_norm = np.linalg.norm(x, axis=1)
+  nonzero_frames = x_norm &gt; 0
+  x[nonzero_frames, :] /= x_norm[nonzero_frames, np.newaxis]
+
+  return x</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chord_inference.ChordInferenceError"><code class="flex name class">
+<span>class <span class="ident">ChordInferenceError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordInferenceError(Exception):  # pylint:disable=g-bad-exception-name
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.EmptySequenceError" href="#note_seq.chord_inference.EmptySequenceError">EmptySequenceError</a></li>
+<li><a title="note_seq.chord_inference.NonIntegerStepsPerChordError" href="#note_seq.chord_inference.NonIntegerStepsPerChordError">NonIntegerStepsPerChordError</a></li>
+<li><a title="note_seq.chord_inference.SequenceAlreadyHasChordsError" href="#note_seq.chord_inference.SequenceAlreadyHasChordsError">SequenceAlreadyHasChordsError</a></li>
+<li><a title="note_seq.chord_inference.SequenceTooLongError" href="#note_seq.chord_inference.SequenceTooLongError">SequenceTooLongError</a></li>
+<li><a title="note_seq.chord_inference.UncommonTimeSignatureError" href="#note_seq.chord_inference.UncommonTimeSignatureError">UncommonTimeSignatureError</a></li>
+</ul>
+</dd>
+<dt id="note_seq.chord_inference.EmptySequenceError"><code class="flex name class">
+<span>class <span class="ident">EmptySequenceError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EmptySequenceError(ChordInferenceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chord_inference.NonIntegerStepsPerChordError"><code class="flex name class">
+<span>class <span class="ident">NonIntegerStepsPerChordError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NonIntegerStepsPerChordError(ChordInferenceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chord_inference.SequenceAlreadyHasChordsError"><code class="flex name class">
+<span>class <span class="ident">SequenceAlreadyHasChordsError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SequenceAlreadyHasChordsError(ChordInferenceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chord_inference.SequenceTooLongError"><code class="flex name class">
+<span>class <span class="ident">SequenceTooLongError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SequenceTooLongError(ChordInferenceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chord_inference.UncommonTimeSignatureError"><code class="flex name class">
+<span>class <span class="ident">UncommonTimeSignatureError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class UncommonTimeSignatureError(ChordInferenceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.chord_inference.infer_chords_for_sequence" href="#note_seq.chord_inference.infer_chords_for_sequence">infer_chords_for_sequence</a></code></li>
+<li><code><a title="note_seq.chord_inference.sequence_note_pitch_vectors" href="#note_seq.chord_inference.sequence_note_pitch_vectors">sequence_note_pitch_vectors</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chord_inference.ChordInferenceError" href="#note_seq.chord_inference.ChordInferenceError">ChordInferenceError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chord_inference.EmptySequenceError" href="#note_seq.chord_inference.EmptySequenceError">EmptySequenceError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chord_inference.NonIntegerStepsPerChordError" href="#note_seq.chord_inference.NonIntegerStepsPerChordError">NonIntegerStepsPerChordError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chord_inference.SequenceAlreadyHasChordsError" href="#note_seq.chord_inference.SequenceAlreadyHasChordsError">SequenceAlreadyHasChordsError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chord_inference.SequenceTooLongError" href="#note_seq.chord_inference.SequenceTooLongError">SequenceTooLongError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chord_inference.UncommonTimeSignatureError" href="#note_seq.chord_inference.UncommonTimeSignatureError">UncommonTimeSignatureError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chord_inference_test.html
+++ b/docs/chord_inference_test.html
@@ -1,0 +1,487 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chord_inference_test API documentation</title>
+<meta name="description" content="Tests for chord_inference." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chord_inference_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for chord_inference.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for chord_inference.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import chord_inference
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+class ChordInferenceTest(absltest.TestCase):
+
+  def testSequenceNotePitchVectors(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+         (60, 100, 1.5, 2.5),
+         (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+         (60, 100, 6.0, 6.0),
+        ])
+    note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+        sequence, seconds_per_frame=1.0)
+
+    expected_note_pitch_vectors = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+
+    self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())
+
+  def testSequenceNotePitchVectorsVariableLengthFrames(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+         (60, 100, 1.5, 2.5),
+         (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+         (60, 100, 6.0, 6.0),
+        ])
+    note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+        sequence, seconds_per_frame=[1.5, 2.0, 3.0, 5.0])
+
+    expected_note_pitch_vectors = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+
+    self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())
+
+  def testInferChordsForSequence(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+         (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+         (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+         (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0)])  # G
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        sequence, steps_per_quarter=4)
+    chord_inference.infer_chords_for_sequence(
+        quantized_sequence, chords_per_bar=2)
+
+    expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.0), (&#39;F&#39;, 2.0), (&#39;G&#39;, 3.0)]
+    chords = [(ta.text, ta.time) for ta in quantized_sequence.text_annotations]
+
+    self.assertEqual(expected_chords, chords)
+
+  def testInferChordsForSequenceAddKeySignatures(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+         (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+         (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+         (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0),   # G
+         (66, 100, 4.0, 5.0), (70, 100, 4.0, 5.0), (73, 100, 4.0, 5.0),   # F#
+         (68, 100, 5.0, 6.0), (71, 100, 5.0, 6.0), (75, 100, 5.0, 6.0),   # G#m
+         (66, 100, 6.0, 7.0), (71, 100, 6.0, 7.0), (75, 100, 6.0, 7.0),   # B
+         (65, 100, 7.0, 8.0), (68, 100, 7.0, 8.0), (73, 100, 7.0, 8.0)])  # C#
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        sequence, steps_per_quarter=4)
+    chord_inference.infer_chords_for_sequence(
+        quantized_sequence, chords_per_bar=2, add_key_signatures=True)
+
+    expected_key_signatures = [(0, 0.0), (6, 4.0)]
+    key_signatures = [(ks.key, ks.time)
+                      for ks in quantized_sequence.key_signatures]
+    self.assertEqual(expected_key_signatures, key_signatures)
+
+  def testInferChordsForSequenceWithBeats(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.1), (64, 100, 0.0, 1.1), (67, 100, 0.0, 1.1),   # C
+         (62, 100, 1.1, 1.9), (65, 100, 1.1, 1.9), (69, 100, 1.1, 1.9),   # Dm
+         (60, 100, 1.9, 3.0), (65, 100, 1.9, 3.0), (69, 100, 1.9, 3.0),   # F
+         (59, 100, 3.0, 4.5), (62, 100, 3.0, 4.5), (67, 100, 3.0, 4.5)])  # G
+    testing_lib.add_beats_to_sequence(sequence, [0.0, 1.1, 1.9, 1.9, 3.0])
+    chord_inference.infer_chords_for_sequence(sequence)
+
+    expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.1), (&#39;F&#39;, 1.9), (&#39;G&#39;, 3.0)]
+    chords = [(ta.text, ta.time) for ta in sequence.text_annotations
+              if ta.annotation_type == CHORD_SYMBOL]
+
+    self.assertEqual(expected_chords, chords)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest"><code class="flex name class">
+<span>class <span class="ident">ChordInferenceTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordInferenceTest(absltest.TestCase):
+
+  def testSequenceNotePitchVectors(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+         (60, 100, 1.5, 2.5),
+         (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+         (60, 100, 6.0, 6.0),
+        ])
+    note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+        sequence, seconds_per_frame=1.0)
+
+    expected_note_pitch_vectors = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+
+    self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())
+
+  def testSequenceNotePitchVectorsVariableLengthFrames(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+         (60, 100, 1.5, 2.5),
+         (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+         (60, 100, 6.0, 6.0),
+        ])
+    note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+        sequence, seconds_per_frame=[1.5, 2.0, 3.0, 5.0])
+
+    expected_note_pitch_vectors = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+
+    self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())
+
+  def testInferChordsForSequence(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+         (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+         (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+         (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0)])  # G
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        sequence, steps_per_quarter=4)
+    chord_inference.infer_chords_for_sequence(
+        quantized_sequence, chords_per_bar=2)
+
+    expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.0), (&#39;F&#39;, 2.0), (&#39;G&#39;, 3.0)]
+    chords = [(ta.text, ta.time) for ta in quantized_sequence.text_annotations]
+
+    self.assertEqual(expected_chords, chords)
+
+  def testInferChordsForSequenceAddKeySignatures(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+         (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+         (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+         (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0),   # G
+         (66, 100, 4.0, 5.0), (70, 100, 4.0, 5.0), (73, 100, 4.0, 5.0),   # F#
+         (68, 100, 5.0, 6.0), (71, 100, 5.0, 6.0), (75, 100, 5.0, 6.0),   # G#m
+         (66, 100, 6.0, 7.0), (71, 100, 6.0, 7.0), (75, 100, 6.0, 7.0),   # B
+         (65, 100, 7.0, 8.0), (68, 100, 7.0, 8.0), (73, 100, 7.0, 8.0)])  # C#
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        sequence, steps_per_quarter=4)
+    chord_inference.infer_chords_for_sequence(
+        quantized_sequence, chords_per_bar=2, add_key_signatures=True)
+
+    expected_key_signatures = [(0, 0.0), (6, 4.0)]
+    key_signatures = [(ks.key, ks.time)
+                      for ks in quantized_sequence.key_signatures]
+    self.assertEqual(expected_key_signatures, key_signatures)
+
+  def testInferChordsForSequenceWithBeats(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.1), (64, 100, 0.0, 1.1), (67, 100, 0.0, 1.1),   # C
+         (62, 100, 1.1, 1.9), (65, 100, 1.1, 1.9), (69, 100, 1.1, 1.9),   # Dm
+         (60, 100, 1.9, 3.0), (65, 100, 1.9, 3.0), (69, 100, 1.9, 3.0),   # F
+         (59, 100, 3.0, 4.5), (62, 100, 3.0, 4.5), (67, 100, 3.0, 4.5)])  # G
+    testing_lib.add_beats_to_sequence(sequence, [0.0, 1.1, 1.9, 1.9, 3.0])
+    chord_inference.infer_chords_for_sequence(sequence)
+
+    expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.1), (&#39;F&#39;, 1.9), (&#39;G&#39;, 3.0)]
+    chords = [(ta.text, ta.time) for ta in sequence.text_annotations
+              if ta.annotation_type == CHORD_SYMBOL]
+
+    self.assertEqual(expected_chords, chords)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequence"><code class="name flex">
+<span>def <span class="ident">testInferChordsForSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInferChordsForSequence(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+       (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+       (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+       (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0)])  # G
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=4)
+  chord_inference.infer_chords_for_sequence(
+      quantized_sequence, chords_per_bar=2)
+
+  expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.0), (&#39;F&#39;, 2.0), (&#39;G&#39;, 3.0)]
+  chords = [(ta.text, ta.time) for ta in quantized_sequence.text_annotations]
+
+  self.assertEqual(expected_chords, chords)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceAddKeySignatures"><code class="name flex">
+<span>def <span class="ident">testInferChordsForSequenceAddKeySignatures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInferChordsForSequenceAddKeySignatures(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),   # C
+       (62, 100, 1.0, 2.0), (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),   # Dm
+       (60, 100, 2.0, 3.0), (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),   # F
+       (59, 100, 3.0, 4.0), (62, 100, 3.0, 4.0), (67, 100, 3.0, 4.0),   # G
+       (66, 100, 4.0, 5.0), (70, 100, 4.0, 5.0), (73, 100, 4.0, 5.0),   # F#
+       (68, 100, 5.0, 6.0), (71, 100, 5.0, 6.0), (75, 100, 5.0, 6.0),   # G#m
+       (66, 100, 6.0, 7.0), (71, 100, 6.0, 7.0), (75, 100, 6.0, 7.0),   # B
+       (65, 100, 7.0, 8.0), (68, 100, 7.0, 8.0), (73, 100, 7.0, 8.0)])  # C#
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=4)
+  chord_inference.infer_chords_for_sequence(
+      quantized_sequence, chords_per_bar=2, add_key_signatures=True)
+
+  expected_key_signatures = [(0, 0.0), (6, 4.0)]
+  key_signatures = [(ks.key, ks.time)
+                    for ks in quantized_sequence.key_signatures]
+  self.assertEqual(expected_key_signatures, key_signatures)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceWithBeats"><code class="name flex">
+<span>def <span class="ident">testInferChordsForSequenceWithBeats</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInferChordsForSequenceWithBeats(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.1), (64, 100, 0.0, 1.1), (67, 100, 0.0, 1.1),   # C
+       (62, 100, 1.1, 1.9), (65, 100, 1.1, 1.9), (69, 100, 1.1, 1.9),   # Dm
+       (60, 100, 1.9, 3.0), (65, 100, 1.9, 3.0), (69, 100, 1.9, 3.0),   # F
+       (59, 100, 3.0, 4.5), (62, 100, 3.0, 4.5), (67, 100, 3.0, 4.5)])  # G
+  testing_lib.add_beats_to_sequence(sequence, [0.0, 1.1, 1.9, 1.9, 3.0])
+  chord_inference.infer_chords_for_sequence(sequence)
+
+  expected_chords = [(&#39;C&#39;, 0.0), (&#39;Dm&#39;, 1.1), (&#39;F&#39;, 1.9), (&#39;G&#39;, 3.0)]
+  chords = [(ta.text, ta.time) for ta in sequence.text_annotations
+            if ta.annotation_type == CHORD_SYMBOL]
+
+  self.assertEqual(expected_chords, chords)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectors"><code class="name flex">
+<span>def <span class="ident">testSequenceNotePitchVectors</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceNotePitchVectors(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+       (60, 100, 1.5, 2.5),
+       (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+       (60, 100, 6.0, 6.0),
+      ])
+  note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+      sequence, seconds_per_frame=1.0)
+
+  expected_note_pitch_vectors = [
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+  ]
+
+  self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectorsVariableLengthFrames"><code class="name flex">
+<span>def <span class="ident">testSequenceNotePitchVectorsVariableLengthFrames</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceNotePitchVectorsVariableLengthFrames(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 0.0), (62, 100, 0.0, 0.5),
+       (60, 100, 1.5, 2.5),
+       (64, 100, 2.0, 2.5), (67, 100, 2.25, 2.75), (70, 100, 2.5, 4.5),
+       (60, 100, 6.0, 6.0),
+      ])
+  note_pitch_vectors = chord_inference.sequence_note_pitch_vectors(
+      sequence, seconds_per_frame=[1.5, 2.0, 3.0, 5.0])
+
+  expected_note_pitch_vectors = [
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+  ]
+
+  self.assertEqual(expected_note_pitch_vectors, note_pitch_vectors.tolist())</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chord_inference_test.ChordInferenceTest" href="#note_seq.chord_inference_test.ChordInferenceTest">ChordInferenceTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequence" href="#note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequence">testInferChordsForSequence</a></code></li>
+<li><code><a title="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceAddKeySignatures" href="#note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceAddKeySignatures">testInferChordsForSequenceAddKeySignatures</a></code></li>
+<li><code><a title="note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceWithBeats" href="#note_seq.chord_inference_test.ChordInferenceTest.testInferChordsForSequenceWithBeats">testInferChordsForSequenceWithBeats</a></code></li>
+<li><code><a title="note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectors" href="#note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectors">testSequenceNotePitchVectors</a></code></li>
+<li><code><a title="note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectorsVariableLengthFrames" href="#note_seq.chord_inference_test.ChordInferenceTest.testSequenceNotePitchVectorsVariableLengthFrames">testSequenceNotePitchVectorsVariableLengthFrames</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chord_symbols_lib.html
+++ b/docs/chord_symbols_lib.html
@@ -1,0 +1,1202 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chord_symbols_lib API documentation</title>
+<meta name="description" content="Utility functions for working with chord symbols …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chord_symbols_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with chord symbols.</p>
+<p>The functions in this file treat a chord symbol string as having four
+components:</p>
+<p>Root: The root pitch class of the chord, e.g. 'C#'.
+Kind: The type of chord, e.g. major, half-diminished, 13th. In the chord
+symbol figure string the chord kind is abbreviated, e.g. 'm' or '-' means
+minor, 'dim' or 'o' means diminished, '7' means dominant 7th.
+Scale degree modifications: Zero or more modifications to the scale degrees
+present in the chord. There are three different modification types:
+addition (add a new scale degree), subtraction (remove a scale degree),
+and alteration (modify a scale degree). For example, '#9' means to add a
+raised 9th, or to alter the 9th to be raised if a 9th was already present
+in the chord. Other possible modification strings include 'no3' (remove
+the 3rd scale degree), 'add2' (add the 2nd scale degree), 'b5' (flatten
+the 5th scale degree), etc.
+Bass: The bass pitch class of the chord. If missing, the bass pitch class is
+assumed to be the same as the root pitch class.</p>
+<p>Before doing any other operations, the functions in this file attempt to
+split the chord symbol figure string into these four components; if that
+attempt fails a ChordSymbolError is raised.</p>
+<p>After that, some operations leave some of the components unexamined, e.g.
+transposition only modifies the root and bass, leaving the chord kind and scale
+degree modifications unchanged.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with chord symbols.
+
+The functions in this file treat a chord symbol string as having four
+components:
+
+  Root: The root pitch class of the chord, e.g. &#39;C#&#39;.
+  Kind: The type of chord, e.g. major, half-diminished, 13th. In the chord
+      symbol figure string the chord kind is abbreviated, e.g. &#39;m&#39; or &#39;-&#39; means
+      minor, &#39;dim&#39; or &#39;o&#39; means diminished, &#39;7&#39; means dominant 7th.
+  Scale degree modifications: Zero or more modifications to the scale degrees
+      present in the chord. There are three different modification types:
+      addition (add a new scale degree), subtraction (remove a scale degree),
+      and alteration (modify a scale degree). For example, &#39;#9&#39; means to add a
+      raised 9th, or to alter the 9th to be raised if a 9th was already present
+      in the chord. Other possible modification strings include &#39;no3&#39; (remove
+      the 3rd scale degree), &#39;add2&#39; (add the 2nd scale degree), &#39;b5&#39; (flatten
+      the 5th scale degree), etc.
+  Bass: The bass pitch class of the chord. If missing, the bass pitch class is
+      assumed to be the same as the root pitch class.
+
+Before doing any other operations, the functions in this file attempt to
+split the chord symbol figure string into these four components; if that
+attempt fails a ChordSymbolError is raised.
+
+After that, some operations leave some of the components unexamined, e.g.
+transposition only modifies the root and bass, leaving the chord kind and scale
+degree modifications unchanged.
+&#34;&#34;&#34;
+
+import itertools
+import re
+
+from note_seq import constants
+
+# Chord quality enum.
+CHORD_QUALITY_MAJOR = 0
+CHORD_QUALITY_MINOR = 1
+CHORD_QUALITY_AUGMENTED = 2
+CHORD_QUALITY_DIMINISHED = 3
+CHORD_QUALITY_OTHER = 4
+
+
+class ChordSymbolError(Exception):
+  pass
+
+
+# Intervals between scale steps.
+_STEPS_ABOVE = {&#39;A&#39;: 2, &#39;B&#39;: 1, &#39;C&#39;: 2, &#39;D&#39;: 2, &#39;E&#39;: 1, &#39;F&#39;: 2, &#39;G&#39;: 2}
+
+# Scale steps to MIDI mapping.
+_STEPS_MIDI = {&#39;C&#39;: 0, &#39;D&#39;: 2, &#39;E&#39;: 4, &#39;F&#39;: 5, &#39;G&#39;: 7, &#39;A&#39;: 9, &#39;B&#39;: 11}
+
+# Mapping from scale degree to offset in half steps.
+_DEGREE_OFFSETS = {1: 0, 2: 2, 3: 4, 4: 5, 5: 7, 6: 9, 7: 11}
+
+# All scale degree names within an octave, used when attempting to name a chord
+# given pitches.
+_SCALE_DEGREES = [
+    (&#39;1&#39;,),
+    (&#39;b2&#39;, &#39;b9&#39;),
+    (&#39;2&#39;, &#39;9&#39;),
+    (&#39;b3&#39;, &#39;#9&#39;),
+    (&#39;3&#39;,),
+    (&#39;4&#39;, &#39;11&#39;),
+    (&#39;b5&#39;, &#39;#11&#39;),
+    (&#39;5&#39;,),
+    (&#39;#5&#39;, &#39;b13&#39;),
+    (&#39;6&#39;, &#39;bb7&#39;, &#39;13&#39;),
+    (&#39;b7&#39;,),
+    (&#39;7&#39;,)
+]
+
+# List of chord kinds with abbreviations and scale degrees. Scale degrees are
+# represented as strings here a) for human readability, and b) because the
+# number of semitones is insufficient when the chords have scale degree
+# modifications.
+_CHORD_KINDS = [
+    # major triad
+    ([&#39;&#39;, &#39;maj&#39;, &#39;M&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;]),
+
+    # minor triad
+    ([&#39;m&#39;, &#39;min&#39;, &#39;-&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;]),
+
+    # augmented triad
+    ([&#39;+&#39;, &#39;aug&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;#5&#39;]),
+
+    # diminished triad
+    ([&#39;o&#39;, &#39;dim&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;b5&#39;]),
+
+    # dominant 7th
+    ([&#39;7&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;b7&#39;]),
+
+    # major 7th
+    ([&#39;maj7&#39;, &#39;M7&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;7&#39;]),
+
+    # minor 7th
+    ([&#39;m7&#39;, &#39;min7&#39;, &#39;-7&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;b7&#39;]),
+
+    # diminished 7th
+    ([&#39;o7&#39;, &#39;dim7&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;b5&#39;, &#39;bb7&#39;]),
+
+    # augmented 7th
+    ([&#39;+7&#39;, &#39;aug7&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;#5&#39;, &#39;b7&#39;]),
+
+    # half-diminished
+    ([&#39;m7b5&#39;, &#39;-7b5&#39;, &#39;/o&#39;, &#39;/o7&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;b5&#39;, &#39;b7&#39;]),
+
+    # minor triad with major 7th
+    ([&#39;mmaj7&#39;, &#39;mM7&#39;, &#39;minmaj7&#39;, &#39;minM7&#39;, &#39;-maj7&#39;, &#39;-M7&#39;,
+      &#39;m(maj7)&#39;, &#39;m(M7)&#39;, &#39;min(maj7)&#39;, &#39;min(M7)&#39;, &#39;-(maj7)&#39;, &#39;-(M7)&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;7&#39;]),
+
+    # major 6th
+    ([&#39;6&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;6&#39;]),
+
+    # minor 6th
+    ([&#39;m6&#39;, &#39;min6&#39;, &#39;-6&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;6&#39;]),
+
+    # dominant 9th
+    ([&#39;9&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;]),
+
+    # major 9th
+    ([&#39;maj9&#39;, &#39;M9&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;7&#39;, &#39;9&#39;]),
+
+    # minor 9th
+    ([&#39;m9&#39;, &#39;min9&#39;, &#39;-9&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;]),
+
+    # augmented 9th
+    ([&#39;+9&#39;, &#39;aug9&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;#5&#39;, &#39;b7&#39;, &#39;9&#39;]),
+
+    # 6/9 chord
+    ([&#39;6/9&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;6&#39;, &#39;9&#39;]),
+
+    # dominant 11th
+    ([&#39;11&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;, &#39;11&#39;]),
+
+    # major 11th
+    ([&#39;maj11&#39;, &#39;M11&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;7&#39;, &#39;9&#39;, &#39;11&#39;]),
+
+    # minor 11th
+    ([&#39;m11&#39;, &#39;min11&#39;, &#39;-11&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;, &#39;11&#39;]),
+
+    # dominant 13th
+    ([&#39;13&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;, &#39;11&#39;, &#39;13&#39;]),
+
+    # major 13th
+    ([&#39;maj13&#39;, &#39;M13&#39;],
+     [&#39;1&#39;, &#39;3&#39;, &#39;5&#39;, &#39;7&#39;, &#39;9&#39;, &#39;11&#39;, &#39;13&#39;]),
+
+    # minor 13th
+    ([&#39;m13&#39;, &#39;min13&#39;, &#39;-13&#39;],
+     [&#39;1&#39;, &#39;b3&#39;, &#39;5&#39;, &#39;b7&#39;, &#39;9&#39;, &#39;11&#39;, &#39;13&#39;]),
+
+    # suspended 2nd
+    ([&#39;sus2&#39;],
+     [&#39;1&#39;, &#39;2&#39;, &#39;5&#39;]),
+
+    # suspended 4th
+    ([&#39;sus&#39;, &#39;sus4&#39;],
+     [&#39;1&#39;, &#39;4&#39;, &#39;5&#39;]),
+
+    # suspended 4th with dominant 7th
+    ([&#39;sus7&#39;, &#39;7sus&#39;],
+     [&#39;1&#39;, &#39;4&#39;, &#39;5&#39;, &#39;b7&#39;]),
+
+    # pedal point
+    ([&#39;ped&#39;],
+     [&#39;1&#39;]),
+
+    # power chord
+    ([&#39;5&#39;],
+     [&#39;1&#39;, &#39;5&#39;])
+]
+
+# Dictionary mapping chord kind abbreviations to names and scale degrees.
+_CHORD_KINDS_BY_ABBREV = dict((abbrev, degrees)
+                              for abbrevs, degrees in _CHORD_KINDS
+                              for abbrev in abbrevs)
+
+
+# Function to add a scale degree.
+def _add_scale_degree(degrees, degree, alter):
+  if degree in degrees:
+    raise ChordSymbolError(&#39;Scale degree already in chord: %d&#39; % degree)
+  if degree == 7:
+    alter -= 1
+  degrees[degree] = alter
+
+
+# Function to remove a scale degree.
+def _subtract_scale_degree(degrees, degree, unused_alter):
+  if degree not in degrees:
+    raise ChordSymbolError(&#39;Scale degree not in chord: %d&#39; % degree)
+  del degrees[degree]
+
+
+# Function to alter (or add) a scale degree.
+def _alter_scale_degree(degrees, degree, alter):
+  if degree in degrees:
+    degrees[degree] += alter
+  else:
+    degrees[degree] = alter
+
+
+# Scale degree modifications. There are three basic types of modifications:
+# addition, subtraction, and alteration. These have been expanded into six types
+# to aid in parsing, as each of the three basic operations has its own
+# requirements on the scale degree operand:
+#
+#  - Addition can accept altered and unaltered scale degrees.
+#  - Subtraction can only accept unaltered scale degrees.
+#  - Alteration can only accept altered scale degrees.
+
+_DEGREE_MODIFICATIONS = {
+    &#39;add&#39;: (_add_scale_degree, 0),
+    &#39;add#&#39;: (_add_scale_degree, 1),
+    &#39;addb&#39;: (_add_scale_degree, -1),
+    &#39;no&#39;: (_subtract_scale_degree, 0),
+    &#39;#&#39;: (_alter_scale_degree, 1),
+    &#39;b&#39;: (_alter_scale_degree, -1)
+}
+
+# Regular expression for chord root.
+# Examples: &#39;C&#39;, &#39;G#&#39;, &#39;Ab&#39;, &#39;D######&#39;
+_ROOT_PATTERN = r&#39;[A-G](?:#*|b*)(?![#b])&#39;
+
+# Regular expression for chord kind (abbreviated).
+# Examples: &#39;&#39;, &#39;m7b5&#39;, &#39;min&#39;, &#39;-13&#39;, &#39;+&#39;, &#39;m(M7)&#39;, &#39;dim&#39;, &#39;/o7&#39;, &#39;sus2&#39;
+_CHORD_KIND_PATTERN = &#39;|&#39;.join(re.escape(abbrev)
+                               for abbrev in _CHORD_KINDS_BY_ABBREV)
+
+# Regular expression for scale degree modifications. (To keep the regex simpler,
+# parentheses are not required to match here, e.g. &#39;(#9&#39;, &#39;add2)&#39;, &#39;(b5(#9)&#39;,
+# and &#39;no5)(b9&#39; will all match.)
+# Examples: &#39;#9&#39;, &#39;add6add9&#39;, &#39;no5(b9)&#39;, &#39;(add2b5no3)&#39;, &#39;(no5)(b9)&#39;
+_MODIFICATIONS_PATTERN = r&#39;(?:\(?(?:%s)[0-9]+\)?)*&#39; % &#39;|&#39;.join(
+    re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
+
+# Regular expression for chord bass.
+# Examples: &#39;&#39;, &#39;/C&#39;, &#39;/Bb&#39;, &#39;/F##&#39;, &#39;/Dbbbb&#39;
+_BASS_PATTERN = &#39;|/%s&#39; % _ROOT_PATTERN
+
+# Regular expression for full chord symbol.
+_CHORD_SYMBOL_PATTERN = &#39;&#39;.join(&#39;(%s)&#39; % pattern for pattern in [
+    _ROOT_PATTERN,            # root pitch class
+    _CHORD_KIND_PATTERN,      # chord kind
+    _MODIFICATIONS_PATTERN,   # scale degree modifications
+    _BASS_PATTERN]) + &#39;$&#39;     # bass pitch class
+_CHORD_SYMBOL_REGEX = re.compile(_CHORD_SYMBOL_PATTERN)
+
+# Regular expression for a single pitch class.
+# Examples: &#39;C&#39;, &#39;G#&#39;, &#39;Ab&#39;, &#39;D######&#39;
+_PITCH_CLASS_PATTERN = r&#39;([A-G])(#*|b*)$&#39;
+_PITCH_CLASS_REGEX = re.compile(_PITCH_CLASS_PATTERN)
+
+# Regular expression for a single scale degree.
+# Examples: &#39;1&#39;, &#39;7&#39;, &#39;b3&#39;, &#39;#5&#39;, &#39;bb7&#39;, &#39;13&#39;
+_SCALE_DEGREE_PATTERN = r&#39;(#*|b*)([0-9]+)$&#39;
+_SCALE_DEGREE_REGEX = re.compile(_SCALE_DEGREE_PATTERN)
+
+# Regular expression for a single scale degree modification. (To keep the regex
+# simpler, parentheses are not required to match here, so open or closing paren
+# could be missing, e.g. &#39;(#9&#39; and &#39;add2)&#39; will both match.)
+# Examples: &#39;#9&#39;, &#39;add6&#39;, &#39;no5&#39;, &#39;(b5)&#39;, &#39;(add9)&#39;
+_MODIFICATION_PATTERN = r&#39;\(?(%s)([0-9]+)\)?&#39; % &#39;|&#39;.join(
+    re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
+_MODIFICATION_REGEX = re.compile(_MODIFICATION_PATTERN)
+
+
+def _parse_pitch_class(pitch_class_str):
+  &#34;&#34;&#34;Parse pitch class from string, returning scale step and alteration.&#34;&#34;&#34;
+  match = re.match(_PITCH_CLASS_REGEX, pitch_class_str)
+  step, alter = match.groups()
+  return step, len(alter) * (1 if &#39;#&#39; in alter else -1)
+
+
+def _parse_root(root_str):
+  &#34;&#34;&#34;Parse chord root from string.&#34;&#34;&#34;
+  return _parse_pitch_class(root_str)
+
+
+def _parse_degree(degree_str):
+  &#34;&#34;&#34;Parse scale degree from string (from internal kind representation).&#34;&#34;&#34;
+  match = _SCALE_DEGREE_REGEX.match(degree_str)
+  alter, degree = match.groups()
+  return int(degree), len(alter) * (1 if &#39;#&#39; in alter else -1)
+
+
+def _parse_kind(kind_str):
+  &#34;&#34;&#34;Parse chord kind from string, returning a scale degree dictionary.&#34;&#34;&#34;
+  degrees = _CHORD_KINDS_BY_ABBREV[kind_str]
+  # Here we make the assumption that each scale degree can be present in a chord
+  # at most once. This is not generally true, as e.g. a chord could contain both
+  # b9 and #9.
+  return dict(_parse_degree(degree_str) for degree_str in degrees)
+
+
+def _parse_modifications(modifications_str):
+  &#34;&#34;&#34;Parse scale degree modifications from string.
+
+  This returns a list of function-degree-alteration triples. The function, when
+  applied to the list of scale degrees, the degree to modify, and the
+  alteration, performs the modification.
+
+  Args:
+    modifications_str: A string containing the scale degree modifications to
+        apply to a chord, in standard chord symbol format.
+
+  Returns:
+    A Python list of scale degree modification tuples, each of which contains a)
+    a function that applies the modification, b) the integer scale degree to
+    which to apply the modifications, and c) the number of semitones in the
+    modification.
+  &#34;&#34;&#34;
+  modifications = []
+  while modifications_str:
+    match = _MODIFICATION_REGEX.match(modifications_str)
+    type_str, degree_str = match.groups()
+    mod_fn, alter = _DEGREE_MODIFICATIONS[type_str]
+    modifications.append((mod_fn, int(degree_str), alter))
+    modifications_str = modifications_str[match.end():]
+    assert match.end() &gt; 0
+  return modifications
+
+
+def _parse_bass(bass_str):
+  &#34;&#34;&#34;Parse bass, returning scale step and alteration or None if no bass.&#34;&#34;&#34;
+  if bass_str:
+    return _parse_pitch_class(bass_str[1:])
+  else:
+    return None
+
+
+def _apply_modifications(degrees, modifications):
+  &#34;&#34;&#34;Apply scale degree modifications to a scale degree dictionary.&#34;&#34;&#34;
+  for mod_fn, degree, alter in modifications:
+    mod_fn(degrees, degree, alter)
+
+
+def _split_chord_symbol(figure):
+  &#34;&#34;&#34;Split a chord symbol into root, kind, degree modifications, and bass.&#34;&#34;&#34;
+  match = _CHORD_SYMBOL_REGEX.match(figure)
+  if not match:
+    raise ChordSymbolError(&#39;Unable to parse chord symbol: %s&#39; % figure)
+  root_str, kind_str, modifications_str, bass_str = match.groups()
+  return root_str, kind_str, modifications_str, bass_str
+
+
+def _parse_chord_symbol(figure):
+  &#34;&#34;&#34;Parse a chord symbol string.
+
+  This converts the chord symbol string to a tuple representation with the
+  following components:
+
+    Root: A tuple containing scale step and alteration.
+    Degrees: A dictionary where the keys are integer scale degrees, and values
+        are integer alterations. For example, if 9 -&gt; -1 is in the dictionary,
+        the chord contains a b9.
+    Bass: A tuple containins scale step and alteration. If bass is unspecified,
+        the chord root is used.
+
+  Args:
+    figure: A chord symbol figure string.
+
+  Returns:
+    A tuple containing the chord root pitch class, scale degrees, and bass pitch
+    class.
+  &#34;&#34;&#34;
+  root_str, kind_str, modifications_str, bass_str = _split_chord_symbol(figure)
+
+  root = _parse_root(root_str)
+  degrees = _parse_kind(kind_str)
+  modifications = _parse_modifications(modifications_str)
+  bass = _parse_bass(bass_str)
+
+  # Apply scale degree modifications.
+  _apply_modifications(degrees, modifications)
+
+  return root, degrees, bass or root
+
+
+def _transpose_pitch_class(step, alter, transpose_amount):
+  &#34;&#34;&#34;Transposes a chord symbol figure string by the given amount.&#34;&#34;&#34;
+  transpose_amount %= 12
+
+  # Transpose up as many steps as we can.
+  while transpose_amount &gt;= _STEPS_ABOVE[step]:
+    transpose_amount -= _STEPS_ABOVE[step]
+    step = chr(ord(&#39;A&#39;) + (ord(step) - ord(&#39;A&#39;) + 1) % 7)
+
+  if transpose_amount &gt; 0:
+    if alter &gt;= 0:
+      # Transpose up one more step and remove sharps (or add flats).
+      alter -= _STEPS_ABOVE[step] - transpose_amount
+      step = chr(ord(&#39;A&#39;) + (ord(step) - ord(&#39;A&#39;) + 1) % 7)
+    else:
+      # Remove flats.
+      alter += transpose_amount
+
+  return step, alter
+
+
+def _pitch_class_to_string(step, alter):
+  &#34;&#34;&#34;Convert a pitch class scale step and alteration to string.&#34;&#34;&#34;
+  return step + abs(alter) * (&#39;#&#39; if alter &gt;= 0 else &#39;b&#39;)
+
+
+def _pitch_class_to_midi(step, alter):
+  &#34;&#34;&#34;Convert a pitch class scale step and alteration to MIDI note.&#34;&#34;&#34;
+  return (_STEPS_MIDI[step] + alter) % 12
+
+
+def _largest_chord_kind_from_degrees(degrees):
+  &#34;&#34;&#34;Find the largest chord that is contained in a set of scale degrees.&#34;&#34;&#34;
+  best_chord_abbrev = None
+  best_chord_degrees = []
+  for chord_abbrevs, chord_degrees in _CHORD_KINDS:
+    if len(chord_degrees) &lt;= len(best_chord_degrees):
+      continue
+    if not set(chord_degrees) - set(degrees):
+      best_chord_abbrev, best_chord_degrees = chord_abbrevs[0], chord_degrees
+  return best_chord_abbrev
+
+
+def _largest_chord_kind_from_relative_pitches(relative_pitches):
+  &#34;&#34;&#34;Find the largest chord contained in a set of relative pitches.&#34;&#34;&#34;
+  scale_degrees = [_SCALE_DEGREES[pitch] for pitch in relative_pitches]
+  best_chord_abbrev = None
+  best_degrees = []
+  for degrees in itertools.product(*scale_degrees):
+    degree_steps = [_parse_degree(degree_str)[0]
+                    for degree_str in degrees]
+    if len(degree_steps) &gt; len(set(degree_steps)):
+      # This set of scale degrees has duplicates, which we do not currently
+      # allow.
+      continue
+    chord_abbrev = _largest_chord_kind_from_degrees(degrees)
+    if best_chord_abbrev is None or (
+        len(_CHORD_KINDS_BY_ABBREV[chord_abbrev]) &gt;
+        len(_CHORD_KINDS_BY_ABBREV[best_chord_abbrev])):
+      # We store the chord kind with the most matches, and the scale degrees
+      # representation that led to those matches (since a set of relative
+      # pitches can be interpreted as scale degrees in multiple ways).
+      best_chord_abbrev, best_degrees = chord_abbrev, degrees
+  return best_chord_abbrev, best_degrees
+
+
+def _degrees_to_modifications(chord_degrees, target_chord_degrees):
+  &#34;&#34;&#34;Find scale degree modifications to turn chord into target chord.&#34;&#34;&#34;
+  degrees = dict(_parse_degree(degree_str) for degree_str in chord_degrees)
+  target_degrees = dict(_parse_degree(degree_str)
+                        for degree_str in target_chord_degrees)
+  modifications_str = &#39;&#39;
+  for degree in target_degrees:
+    if degree not in degrees:
+      # Add a scale degree.
+      alter = target_degrees[degree]
+      alter_str = abs(alter) * (&#39;#&#39; if alter &gt;= 0 else &#39;b&#39;)
+      if alter and degree &gt; 7:
+        modifications_str += &#39;(%s%d)&#39; % (alter_str, degree)
+      else:
+        modifications_str += &#39;(add%s%d)&#39; % (alter_str, degree)
+    elif degrees[degree] != target_degrees[degree]:
+      # Alter a scale degree. We shouldn&#39;t be altering to natural, that&#39;s a sign
+      # that we&#39;ve chosen the wrong chord kind.
+      alter = target_degrees[degree]
+      assert alter != 0
+      alter_str = abs(alter) * (&#39;#&#39; if alter &gt;= 0 else &#39;b&#39;)
+      modifications_str += &#39;(%s%d)&#39; % (alter_str, degree)
+  for degree in degrees:
+    if degree not in target_degrees:
+      # Subtract a scale degree.
+      modifications_str += &#39;(no%d)&#39; % degree
+  return modifications_str
+
+
+def transpose_chord_symbol(figure, transpose_amount):
+  &#34;&#34;&#34;Transposes a chord symbol figure string by the given amount.
+
+  Args:
+    figure: The chord symbol figure string to transpose.
+    transpose_amount: The integer number of half steps to transpose.
+
+  Returns:
+    The transposed chord symbol figure string.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  # Split chord symbol into root, kind, modifications, and bass.
+  root_str, kind_str, modifications_str, bass_str = _split_chord_symbol(figure)
+
+  # Parse and transpose the root.
+  root_step, root_alter = _parse_root(root_str)
+  transposed_root_step, transposed_root_alter = _transpose_pitch_class(
+      root_step, root_alter, transpose_amount)
+  transposed_root_str = _pitch_class_to_string(
+      transposed_root_step, transposed_root_alter)
+
+  # Parse bass.
+  bass = _parse_bass(bass_str)
+
+  if bass:
+    # Bass exists, transpose it.
+    bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
+    transposed_bass_step, transposed_bass_alter = _transpose_pitch_class(
+        bass_step, bass_alter, transpose_amount)
+    transposed_bass_str = &#39;/&#39; + _pitch_class_to_string(
+        transposed_bass_step, transposed_bass_alter)
+  else:
+    # No bass.
+    transposed_bass_str = bass_str
+
+  return &#39;%s%s%s%s&#39; % (transposed_root_str, kind_str, modifications_str,
+                       transposed_bass_str)
+
+
+def pitches_to_chord_symbol(pitches):
+  &#34;&#34;&#34;Converts a set of pitches to a chord symbol.
+
+  This is quite a complicated function and certainly imperfect, even apart from
+  the inherent ambiguity and context-dependence of chord naming. The basic logic
+  is as follows:
+
+  Consider that each pitch may be the root of the chord. For each potential
+  root, convert the other pitch classes to scale degrees (note that a single
+  pitch class may map to multiple scale degrees, e.g. b3 is the same as #9) and
+  find the chord kind that covers as many of these scale degrees as possible
+  while not including any extras. Then add any remaining scale degrees as
+  modifications.
+
+  This will not always return the most natural name for a chord, but it should
+  do something reasonable in most cases.
+
+  Args:
+    pitches: A python list of integer pitch values.
+
+  Returns:
+    A chord symbol figure string representing the chord containing the specified
+    pitches.
+
+  Raises:
+    ChordSymbolError: If no known chord symbol corresponds to the provided
+        pitches.
+  &#34;&#34;&#34;
+  if not pitches:
+    return constants.NO_CHORD
+
+  # Convert to pitch classes and dedupe.
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+
+  # Try using the bass note as root first.
+  bass = min(pitches) % 12
+  pitch_classes = [bass] + list(pitch_classes - set([bass]))
+
+  # Try each pitch class in turn as root.
+  best_root = None
+  best_abbrev = None
+  best_degrees = []
+  for root in pitch_classes:
+    relative_pitches = set((pitch - root) % 12 for pitch in pitch_classes)
+    abbrev, degrees = _largest_chord_kind_from_relative_pitches(
+        relative_pitches)
+    if abbrev is not None:
+      if best_abbrev is None or (
+          len(_CHORD_KINDS_BY_ABBREV[abbrev]) &gt;
+          len(_CHORD_KINDS_BY_ABBREV[best_abbrev])):
+        best_root = root
+        best_abbrev = abbrev
+        best_degrees = degrees
+
+  if best_root is None:
+    raise ChordSymbolError(
+        &#39;Unable to determine chord symbol from pitches: %s&#39; % str(pitches))
+
+  root_str = _pitch_class_to_string(*_transpose_pitch_class(&#39;C&#39;, 0, best_root))
+  kind_str = best_abbrev
+
+  # If the bass pitch class is not one of the scale degrees in the chosen kind,
+  # we don&#39;t need to include an explicit modification for it.
+  best_chord_degrees = _CHORD_KINDS_BY_ABBREV[best_abbrev]
+  if all(degree != bass_degree
+         for degree in best_chord_degrees
+         for bass_degree in _SCALE_DEGREES[bass]):
+    best_degrees = [degree for degree in best_degrees
+                    if all(degree != bass_degree
+                           for bass_degree in _SCALE_DEGREES[bass])]
+  modifications_str = _degrees_to_modifications(
+      best_chord_degrees, best_degrees)
+
+  if bass == best_root:
+    return &#39;%s%s%s&#39; % (root_str, kind_str, modifications_str)
+  else:
+    bass_str = _pitch_class_to_string(*_transpose_pitch_class(&#39;C&#39;, 0, bass))
+    return &#39;%s%s%s/%s&#39; % (root_str, kind_str, modifications_str, bass_str)
+
+
+def chord_symbol_pitches(figure):
+  &#34;&#34;&#34;Return the pitch classes contained in a chord.
+
+  This will generally include the root pitch class, but not the bass if it is
+  not otherwise one of the pitches in the chord.
+
+  Args:
+    figure: The chord symbol figure string for which pitches are computed.
+
+  Returns:
+    A python list of integer pitch class values.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root, degrees, _ = _parse_chord_symbol(figure)
+  root_step, root_alter = root
+  root_pitch = _pitch_class_to_midi(root_step, root_alter)
+  normalized_degrees = [((degree - 1) % 7 + 1, alter)
+                        for degree, alter in degrees.items()]
+  return [(root_pitch + _DEGREE_OFFSETS[degree] + alter) % 12
+          for degree, alter in normalized_degrees]
+
+
+def chord_symbol_root(figure):
+  &#34;&#34;&#34;Return the root pitch class of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which the root is computed.
+
+  Returns:
+    The pitch class of the chord root, an integer between 0 and 11 inclusive.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root_str, _, _, _ = _split_chord_symbol(figure)
+  root_step, root_alter = _parse_root(root_str)
+  return _pitch_class_to_midi(root_step, root_alter)
+
+
+def chord_symbol_bass(figure):
+  &#34;&#34;&#34;Return the bass pitch class of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which the bass is computed.
+
+  Returns:
+    The pitch class of the chord bass, an integer between 0 and 11 inclusive.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root_str, _, _, bass_str = _split_chord_symbol(figure)
+  bass = _parse_bass(bass_str)
+  if bass:
+    bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
+  else:
+    # Bass is the same as root.
+    bass_step, bass_alter = _parse_root(root_str)
+  return _pitch_class_to_midi(bass_step, bass_alter)
+
+
+def chord_symbol_quality(figure):
+  &#34;&#34;&#34;Return the quality (major, minor, dimished, augmented) of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which quality is computed.
+
+  Returns:
+    One of CHORD_QUALITY_MAJOR, CHORD_QUALITY_MINOR, CHORD_QUALITY_AUGMENTED,
+    CHORD_QUALITY_DIMINISHED, or CHORD_QUALITY_OTHER.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  _, degrees, _ = _parse_chord_symbol(figure)
+  if 1 not in degrees or 3 not in degrees or 5 not in degrees:
+    return CHORD_QUALITY_OTHER
+  triad = degrees[1], degrees[3], degrees[5]
+  if triad == (0, 0, 0):
+    return CHORD_QUALITY_MAJOR
+  elif triad == (0, -1, 0):
+    return CHORD_QUALITY_MINOR
+  elif triad == (0, 0, 1):
+    return CHORD_QUALITY_AUGMENTED
+  elif triad == (0, -1, -1):
+    return CHORD_QUALITY_DIMINISHED
+  else:
+    return CHORD_QUALITY_OTHER</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.chord_symbols_lib.chord_symbol_bass"><code class="name flex">
+<span>def <span class="ident">chord_symbol_bass</span></span>(<span>figure)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the bass pitch class of a chord.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>figure</code></strong></dt>
+<dd>The chord symbol figure string for which the bass is computed.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The pitch class of the chord bass, an integer between 0 and 11 inclusive.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If the given chord symbol cannot be interpreted.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def chord_symbol_bass(figure):
+  &#34;&#34;&#34;Return the bass pitch class of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which the bass is computed.
+
+  Returns:
+    The pitch class of the chord bass, an integer between 0 and 11 inclusive.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root_str, _, _, bass_str = _split_chord_symbol(figure)
+  bass = _parse_bass(bass_str)
+  if bass:
+    bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
+  else:
+    # Bass is the same as root.
+    bass_step, bass_alter = _parse_root(root_str)
+  return _pitch_class_to_midi(bass_step, bass_alter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib.chord_symbol_pitches"><code class="name flex">
+<span>def <span class="ident">chord_symbol_pitches</span></span>(<span>figure)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the pitch classes contained in a chord.</p>
+<p>This will generally include the root pitch class, but not the bass if it is
+not otherwise one of the pitches in the chord.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>figure</code></strong></dt>
+<dd>The chord symbol figure string for which pitches are computed.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A python list of integer pitch class values.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If the given chord symbol cannot be interpreted.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def chord_symbol_pitches(figure):
+  &#34;&#34;&#34;Return the pitch classes contained in a chord.
+
+  This will generally include the root pitch class, but not the bass if it is
+  not otherwise one of the pitches in the chord.
+
+  Args:
+    figure: The chord symbol figure string for which pitches are computed.
+
+  Returns:
+    A python list of integer pitch class values.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root, degrees, _ = _parse_chord_symbol(figure)
+  root_step, root_alter = root
+  root_pitch = _pitch_class_to_midi(root_step, root_alter)
+  normalized_degrees = [((degree - 1) % 7 + 1, alter)
+                        for degree, alter in degrees.items()]
+  return [(root_pitch + _DEGREE_OFFSETS[degree] + alter) % 12
+          for degree, alter in normalized_degrees]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib.chord_symbol_quality"><code class="name flex">
+<span>def <span class="ident">chord_symbol_quality</span></span>(<span>figure)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the quality (major, minor, dimished, augmented) of a chord.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>figure</code></strong></dt>
+<dd>The chord symbol figure string for which quality is computed.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>One of CHORD_QUALITY_MAJOR, CHORD_QUALITY_MINOR, CHORD_QUALITY_AUGMENTED,
+CHORD_QUALITY_DIMINISHED, or CHORD_QUALITY_OTHER.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If the given chord symbol cannot be interpreted.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def chord_symbol_quality(figure):
+  &#34;&#34;&#34;Return the quality (major, minor, dimished, augmented) of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which quality is computed.
+
+  Returns:
+    One of CHORD_QUALITY_MAJOR, CHORD_QUALITY_MINOR, CHORD_QUALITY_AUGMENTED,
+    CHORD_QUALITY_DIMINISHED, or CHORD_QUALITY_OTHER.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  _, degrees, _ = _parse_chord_symbol(figure)
+  if 1 not in degrees or 3 not in degrees or 5 not in degrees:
+    return CHORD_QUALITY_OTHER
+  triad = degrees[1], degrees[3], degrees[5]
+  if triad == (0, 0, 0):
+    return CHORD_QUALITY_MAJOR
+  elif triad == (0, -1, 0):
+    return CHORD_QUALITY_MINOR
+  elif triad == (0, 0, 1):
+    return CHORD_QUALITY_AUGMENTED
+  elif triad == (0, -1, -1):
+    return CHORD_QUALITY_DIMINISHED
+  else:
+    return CHORD_QUALITY_OTHER</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib.chord_symbol_root"><code class="name flex">
+<span>def <span class="ident">chord_symbol_root</span></span>(<span>figure)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the root pitch class of a chord.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>figure</code></strong></dt>
+<dd>The chord symbol figure string for which the root is computed.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The pitch class of the chord root, an integer between 0 and 11 inclusive.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If the given chord symbol cannot be interpreted.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def chord_symbol_root(figure):
+  &#34;&#34;&#34;Return the root pitch class of a chord.
+
+  Args:
+    figure: The chord symbol figure string for which the root is computed.
+
+  Returns:
+    The pitch class of the chord root, an integer between 0 and 11 inclusive.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  root_str, _, _, _ = _split_chord_symbol(figure)
+  root_step, root_alter = _parse_root(root_str)
+  return _pitch_class_to_midi(root_step, root_alter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib.pitches_to_chord_symbol"><code class="name flex">
+<span>def <span class="ident">pitches_to_chord_symbol</span></span>(<span>pitches)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts a set of pitches to a chord symbol.</p>
+<p>This is quite a complicated function and certainly imperfect, even apart from
+the inherent ambiguity and context-dependence of chord naming. The basic logic
+is as follows:</p>
+<p>Consider that each pitch may be the root of the chord. For each potential
+root, convert the other pitch classes to scale degrees (note that a single
+pitch class may map to multiple scale degrees, e.g. b3 is the same as #9) and
+find the chord kind that covers as many of these scale degrees as possible
+while not including any extras. Then add any remaining scale degrees as
+modifications.</p>
+<p>This will not always return the most natural name for a chord, but it should
+do something reasonable in most cases.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pitches</code></strong></dt>
+<dd>A python list of integer pitch values.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A chord symbol figure string representing the chord containing the specified
+pitches.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If no known chord symbol corresponds to the provided
+pitches.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def pitches_to_chord_symbol(pitches):
+  &#34;&#34;&#34;Converts a set of pitches to a chord symbol.
+
+  This is quite a complicated function and certainly imperfect, even apart from
+  the inherent ambiguity and context-dependence of chord naming. The basic logic
+  is as follows:
+
+  Consider that each pitch may be the root of the chord. For each potential
+  root, convert the other pitch classes to scale degrees (note that a single
+  pitch class may map to multiple scale degrees, e.g. b3 is the same as #9) and
+  find the chord kind that covers as many of these scale degrees as possible
+  while not including any extras. Then add any remaining scale degrees as
+  modifications.
+
+  This will not always return the most natural name for a chord, but it should
+  do something reasonable in most cases.
+
+  Args:
+    pitches: A python list of integer pitch values.
+
+  Returns:
+    A chord symbol figure string representing the chord containing the specified
+    pitches.
+
+  Raises:
+    ChordSymbolError: If no known chord symbol corresponds to the provided
+        pitches.
+  &#34;&#34;&#34;
+  if not pitches:
+    return constants.NO_CHORD
+
+  # Convert to pitch classes and dedupe.
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+
+  # Try using the bass note as root first.
+  bass = min(pitches) % 12
+  pitch_classes = [bass] + list(pitch_classes - set([bass]))
+
+  # Try each pitch class in turn as root.
+  best_root = None
+  best_abbrev = None
+  best_degrees = []
+  for root in pitch_classes:
+    relative_pitches = set((pitch - root) % 12 for pitch in pitch_classes)
+    abbrev, degrees = _largest_chord_kind_from_relative_pitches(
+        relative_pitches)
+    if abbrev is not None:
+      if best_abbrev is None or (
+          len(_CHORD_KINDS_BY_ABBREV[abbrev]) &gt;
+          len(_CHORD_KINDS_BY_ABBREV[best_abbrev])):
+        best_root = root
+        best_abbrev = abbrev
+        best_degrees = degrees
+
+  if best_root is None:
+    raise ChordSymbolError(
+        &#39;Unable to determine chord symbol from pitches: %s&#39; % str(pitches))
+
+  root_str = _pitch_class_to_string(*_transpose_pitch_class(&#39;C&#39;, 0, best_root))
+  kind_str = best_abbrev
+
+  # If the bass pitch class is not one of the scale degrees in the chosen kind,
+  # we don&#39;t need to include an explicit modification for it.
+  best_chord_degrees = _CHORD_KINDS_BY_ABBREV[best_abbrev]
+  if all(degree != bass_degree
+         for degree in best_chord_degrees
+         for bass_degree in _SCALE_DEGREES[bass]):
+    best_degrees = [degree for degree in best_degrees
+                    if all(degree != bass_degree
+                           for bass_degree in _SCALE_DEGREES[bass])]
+  modifications_str = _degrees_to_modifications(
+      best_chord_degrees, best_degrees)
+
+  if bass == best_root:
+    return &#39;%s%s%s&#39; % (root_str, kind_str, modifications_str)
+  else:
+    bass_str = _pitch_class_to_string(*_transpose_pitch_class(&#39;C&#39;, 0, bass))
+    return &#39;%s%s%s/%s&#39; % (root_str, kind_str, modifications_str, bass_str)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib.transpose_chord_symbol"><code class="name flex">
+<span>def <span class="ident">transpose_chord_symbol</span></span>(<span>figure, transpose_amount)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transposes a chord symbol figure string by the given amount.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>figure</code></strong></dt>
+<dd>The chord symbol figure string to transpose.</dd>
+<dt><strong><code>transpose_amount</code></strong></dt>
+<dd>The integer number of half steps to transpose.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The transposed chord symbol figure string.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></dt>
+<dd>If the given chord symbol cannot be interpreted.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transpose_chord_symbol(figure, transpose_amount):
+  &#34;&#34;&#34;Transposes a chord symbol figure string by the given amount.
+
+  Args:
+    figure: The chord symbol figure string to transpose.
+    transpose_amount: The integer number of half steps to transpose.
+
+  Returns:
+    The transposed chord symbol figure string.
+
+  Raises:
+    ChordSymbolError: If the given chord symbol cannot be interpreted.
+  &#34;&#34;&#34;
+  # Split chord symbol into root, kind, modifications, and bass.
+  root_str, kind_str, modifications_str, bass_str = _split_chord_symbol(figure)
+
+  # Parse and transpose the root.
+  root_step, root_alter = _parse_root(root_str)
+  transposed_root_step, transposed_root_alter = _transpose_pitch_class(
+      root_step, root_alter, transpose_amount)
+  transposed_root_str = _pitch_class_to_string(
+      transposed_root_step, transposed_root_alter)
+
+  # Parse bass.
+  bass = _parse_bass(bass_str)
+
+  if bass:
+    # Bass exists, transpose it.
+    bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
+    transposed_bass_step, transposed_bass_alter = _transpose_pitch_class(
+        bass_step, bass_alter, transpose_amount)
+    transposed_bass_str = &#39;/&#39; + _pitch_class_to_string(
+        transposed_bass_step, transposed_bass_alter)
+  else:
+    # No bass.
+    transposed_bass_str = bass_str
+
+  return &#39;%s%s%s%s&#39; % (transposed_root_str, kind_str, modifications_str,
+                       transposed_bass_str)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chord_symbols_lib.ChordSymbolError"><code class="flex name class">
+<span>class <span class="ident">ChordSymbolError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordSymbolError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.chord_symbols_lib.chord_symbol_bass" href="#note_seq.chord_symbols_lib.chord_symbol_bass">chord_symbol_bass</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib.chord_symbol_pitches" href="#note_seq.chord_symbols_lib.chord_symbol_pitches">chord_symbol_pitches</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib.chord_symbol_quality" href="#note_seq.chord_symbols_lib.chord_symbol_quality">chord_symbol_quality</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib.chord_symbol_root" href="#note_seq.chord_symbols_lib.chord_symbol_root">chord_symbol_root</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib.pitches_to_chord_symbol" href="#note_seq.chord_symbols_lib.pitches_to_chord_symbol">pitches_to_chord_symbol</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib.transpose_chord_symbol" href="#note_seq.chord_symbols_lib.transpose_chord_symbol">transpose_chord_symbol</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chord_symbols_lib.ChordSymbolError" href="#note_seq.chord_symbols_lib.ChordSymbolError">ChordSymbolError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chord_symbols_lib_test.html
+++ b/docs/chord_symbols_lib_test.html
@@ -1,0 +1,769 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chord_symbols_lib_test API documentation</title>
+<meta name="description" content="Tests for chord_symbols_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chord_symbols_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for chord_symbols_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for chord_symbols_lib.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import chord_symbols_lib
+
+CHORD_QUALITY_MAJOR = chord_symbols_lib.CHORD_QUALITY_MAJOR
+CHORD_QUALITY_MINOR = chord_symbols_lib.CHORD_QUALITY_MINOR
+CHORD_QUALITY_AUGMENTED = chord_symbols_lib.CHORD_QUALITY_AUGMENTED
+CHORD_QUALITY_DIMINISHED = chord_symbols_lib.CHORD_QUALITY_DIMINISHED
+CHORD_QUALITY_OTHER = chord_symbols_lib.CHORD_QUALITY_OTHER
+
+
+class ChordSymbolFunctionsTest(absltest.TestCase):
+
+  def testTransposeChordSymbol(self):
+    # Test basic triads.
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;C&#39;, 2)
+    self.assertEqual(&#39;D&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Abm&#39;, -3)
+    self.assertEqual(&#39;Fm&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;F#&#39;, 0)
+    self.assertEqual(&#39;F#&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Cbb&#39;, 6)
+    self.assertEqual(&#39;Fb&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;C#&#39;, -5)
+    self.assertEqual(&#39;G#&#39;, figure)
+
+    # Test more complex chords.
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Co7&#39;, 7)
+    self.assertEqual(&#39;Go7&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;D+&#39;, -3)
+    self.assertEqual(&#39;B+&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Fb9/Ab&#39;, 2)
+    self.assertEqual(&#39;Gb9/Bb&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;A6/9&#39;, -7)
+    self.assertEqual(&#39;D6/9&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;E7(add#9)&#39;, 0)
+    self.assertEqual(&#39;E7(add#9)&#39;, figure)
+
+  def testPitchesToChordSymbol(self):
+    # Test basic triads.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 64, 67])
+    self.assertEqual(&#39;C&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [45, 48, 52])
+    self.assertEqual(&#39;Am&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [63, 66, 69])
+    self.assertEqual(&#39;Ebo&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [71, 75, 79])
+    self.assertEqual(&#39;B+&#39;, figure)
+
+    # Test basic inversions.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [59, 62, 67])
+    self.assertEqual(&#39;G/B&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [65, 70, 73])
+    self.assertEqual(&#39;Bbm/F&#39;, figure)
+
+    # Test suspended chords.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [62, 67, 69])
+    self.assertEqual(&#39;Dsus&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [55, 60, 62, 65])
+    self.assertEqual(&#39;Gsus7&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [67, 69, 74])
+    self.assertEqual(&#39;Gsus2&#39;, figure)
+
+    # Test more complex chords.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [45, 46, 50, 53])
+    self.assertEqual(&#39;Bbmaj7/A&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [63, 67, 70, 72, 74])
+    self.assertEqual(&#39;Cm9/Eb&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [53, 60, 64, 67, 70])
+    self.assertEqual(&#39;C7/F&#39;, figure)
+
+    # Test chords with modifications.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [67, 71, 72, 74, 77])
+    self.assertEqual(&#39;G7(add4)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [64, 68, 71, 74, 79])
+    self.assertEqual(&#39;E7(#9)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 62, 64, 67])
+    self.assertEqual(&#39;C(add2)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 64, 68, 70, 75])
+    self.assertEqual(&#39;C+7(#9)&#39;, figure)
+
+    # Test invalid chord.
+    with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+      chord_symbols_lib.pitches_to_chord_symbol(
+          [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71])
+
+  def testChordSymbolPitches(self):
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;Am&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 4, 9]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;D7b9&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 2, 3, 6, 9]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;F/o&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([3, 5, 8, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;C-(M7)&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 3, 7, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;E##13&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([1, 3, 4, 6, 8, 10, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;G(add2)(#5)&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([3, 7, 9, 11]), pitch_classes)
+
+  def testChordSymbolRoot(self):
+    root = chord_symbols_lib.chord_symbol_root(&#39;Dm9&#39;)
+    self.assertEqual(2, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;E/G#&#39;)
+    self.assertEqual(4, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;Bsus2&#39;)
+    self.assertEqual(11, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;Abmaj7&#39;)
+    self.assertEqual(8, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;D##5(add6)&#39;)
+    self.assertEqual(4, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;F(b7)(#9)(b13)&#39;)
+    self.assertEqual(5, root)
+
+  def testChordSymbolBass(self):
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Dm9&#39;)
+    self.assertEqual(2, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;E/G#&#39;)
+    self.assertEqual(8, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Bsus2/A&#39;)
+    self.assertEqual(9, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Abm7/Cb&#39;)
+    self.assertEqual(11, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;C#6/9/E#&#39;)
+    self.assertEqual(5, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;G/o&#39;)
+    self.assertEqual(7, bass)
+
+  def testChordSymbolQuality(self):
+    # Test major chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;B13&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;E7#9&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Fadd2/Eb&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;C6/9/Bb&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Gmaj13&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+
+    # Test minor chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;C#-9&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Gm7/Bb&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Cbmmaj7&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;A-(M7)&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbmin&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+
+    # Test augmented chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;D+/A#&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;A+&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;G7(#5)&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Faug(add2)&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+
+    # Test diminished chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Am7b5&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Edim7&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bb/o&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Fo&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+
+    # Test other chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;G5&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbsus2&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Dsus&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;E(no3)&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest"><code class="flex name class">
+<span>class <span class="ident">ChordSymbolFunctionsTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordSymbolFunctionsTest(absltest.TestCase):
+
+  def testTransposeChordSymbol(self):
+    # Test basic triads.
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;C&#39;, 2)
+    self.assertEqual(&#39;D&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Abm&#39;, -3)
+    self.assertEqual(&#39;Fm&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;F#&#39;, 0)
+    self.assertEqual(&#39;F#&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Cbb&#39;, 6)
+    self.assertEqual(&#39;Fb&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;C#&#39;, -5)
+    self.assertEqual(&#39;G#&#39;, figure)
+
+    # Test more complex chords.
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Co7&#39;, 7)
+    self.assertEqual(&#39;Go7&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;D+&#39;, -3)
+    self.assertEqual(&#39;B+&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;Fb9/Ab&#39;, 2)
+    self.assertEqual(&#39;Gb9/Bb&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;A6/9&#39;, -7)
+    self.assertEqual(&#39;D6/9&#39;, figure)
+    figure = chord_symbols_lib.transpose_chord_symbol(&#39;E7(add#9)&#39;, 0)
+    self.assertEqual(&#39;E7(add#9)&#39;, figure)
+
+  def testPitchesToChordSymbol(self):
+    # Test basic triads.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 64, 67])
+    self.assertEqual(&#39;C&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [45, 48, 52])
+    self.assertEqual(&#39;Am&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [63, 66, 69])
+    self.assertEqual(&#39;Ebo&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [71, 75, 79])
+    self.assertEqual(&#39;B+&#39;, figure)
+
+    # Test basic inversions.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [59, 62, 67])
+    self.assertEqual(&#39;G/B&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [65, 70, 73])
+    self.assertEqual(&#39;Bbm/F&#39;, figure)
+
+    # Test suspended chords.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [62, 67, 69])
+    self.assertEqual(&#39;Dsus&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [55, 60, 62, 65])
+    self.assertEqual(&#39;Gsus7&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [67, 69, 74])
+    self.assertEqual(&#39;Gsus2&#39;, figure)
+
+    # Test more complex chords.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [45, 46, 50, 53])
+    self.assertEqual(&#39;Bbmaj7/A&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [63, 67, 70, 72, 74])
+    self.assertEqual(&#39;Cm9/Eb&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [53, 60, 64, 67, 70])
+    self.assertEqual(&#39;C7/F&#39;, figure)
+
+    # Test chords with modifications.
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [67, 71, 72, 74, 77])
+    self.assertEqual(&#39;G7(add4)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [64, 68, 71, 74, 79])
+    self.assertEqual(&#39;E7(#9)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 62, 64, 67])
+    self.assertEqual(&#39;C(add2)&#39;, figure)
+    figure = chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 64, 68, 70, 75])
+    self.assertEqual(&#39;C+7(#9)&#39;, figure)
+
+    # Test invalid chord.
+    with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+      chord_symbols_lib.pitches_to_chord_symbol(
+          [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71])
+
+  def testChordSymbolPitches(self):
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;Am&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 4, 9]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;D7b9&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 2, 3, 6, 9]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;F/o&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([3, 5, 8, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;C-(M7)&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 3, 7, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;E##13&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([1, 3, 4, 6, 8, 10, 11]), pitch_classes)
+    pitches = chord_symbols_lib.chord_symbol_pitches(&#39;G(add2)(#5)&#39;)
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([3, 7, 9, 11]), pitch_classes)
+
+  def testChordSymbolRoot(self):
+    root = chord_symbols_lib.chord_symbol_root(&#39;Dm9&#39;)
+    self.assertEqual(2, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;E/G#&#39;)
+    self.assertEqual(4, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;Bsus2&#39;)
+    self.assertEqual(11, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;Abmaj7&#39;)
+    self.assertEqual(8, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;D##5(add6)&#39;)
+    self.assertEqual(4, root)
+    root = chord_symbols_lib.chord_symbol_root(&#39;F(b7)(#9)(b13)&#39;)
+    self.assertEqual(5, root)
+
+  def testChordSymbolBass(self):
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Dm9&#39;)
+    self.assertEqual(2, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;E/G#&#39;)
+    self.assertEqual(8, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Bsus2/A&#39;)
+    self.assertEqual(9, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;Abm7/Cb&#39;)
+    self.assertEqual(11, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;C#6/9/E#&#39;)
+    self.assertEqual(5, bass)
+    bass = chord_symbols_lib.chord_symbol_bass(&#39;G/o&#39;)
+    self.assertEqual(7, bass)
+
+  def testChordSymbolQuality(self):
+    # Test major chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;B13&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;E7#9&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Fadd2/Eb&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;C6/9/Bb&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Gmaj13&#39;)
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+
+    # Test minor chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;C#-9&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Gm7/Bb&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Cbmmaj7&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;A-(M7)&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbmin&#39;)
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+
+    # Test augmented chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;D+/A#&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;A+&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;G7(#5)&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Faug(add2)&#39;)
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+
+    # Test diminished chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Am7b5&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Edim7&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bb/o&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Fo&#39;)
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+
+    # Test other chords.
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;G5&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbsus2&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;Dsus&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = chord_symbols_lib.chord_symbol_quality(&#39;E(no3)&#39;)
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolBass"><code class="name flex">
+<span>def <span class="ident">testChordSymbolBass</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChordSymbolBass(self):
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;Dm9&#39;)
+  self.assertEqual(2, bass)
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;E/G#&#39;)
+  self.assertEqual(8, bass)
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;Bsus2/A&#39;)
+  self.assertEqual(9, bass)
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;Abm7/Cb&#39;)
+  self.assertEqual(11, bass)
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;C#6/9/E#&#39;)
+  self.assertEqual(5, bass)
+  bass = chord_symbols_lib.chord_symbol_bass(&#39;G/o&#39;)
+  self.assertEqual(7, bass)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolPitches"><code class="name flex">
+<span>def <span class="ident">testChordSymbolPitches</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChordSymbolPitches(self):
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;Am&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([0, 4, 9]), pitch_classes)
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;D7b9&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([0, 2, 3, 6, 9]), pitch_classes)
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;F/o&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([3, 5, 8, 11]), pitch_classes)
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;C-(M7)&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([0, 3, 7, 11]), pitch_classes)
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;E##13&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([1, 3, 4, 6, 8, 10, 11]), pitch_classes)
+  pitches = chord_symbols_lib.chord_symbol_pitches(&#39;G(add2)(#5)&#39;)
+  pitch_classes = set(pitch % 12 for pitch in pitches)
+  self.assertEqual(set([3, 7, 9, 11]), pitch_classes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolQuality"><code class="name flex">
+<span>def <span class="ident">testChordSymbolQuality</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChordSymbolQuality(self):
+  # Test major chords.
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;B13&#39;)
+  self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;E7#9&#39;)
+  self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Fadd2/Eb&#39;)
+  self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;C6/9/Bb&#39;)
+  self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Gmaj13&#39;)
+  self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+
+  # Test minor chords.
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;C#-9&#39;)
+  self.assertEqual(CHORD_QUALITY_MINOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Gm7/Bb&#39;)
+  self.assertEqual(CHORD_QUALITY_MINOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Cbmmaj7&#39;)
+  self.assertEqual(CHORD_QUALITY_MINOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;A-(M7)&#39;)
+  self.assertEqual(CHORD_QUALITY_MINOR, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbmin&#39;)
+  self.assertEqual(CHORD_QUALITY_MINOR, quality)
+
+  # Test augmented chords.
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;D+/A#&#39;)
+  self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;A+&#39;)
+  self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;G7(#5)&#39;)
+  self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Faug(add2)&#39;)
+  self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+
+  # Test diminished chords.
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Am7b5&#39;)
+  self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Edim7&#39;)
+  self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Bb/o&#39;)
+  self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Fo&#39;)
+  self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+
+  # Test other chords.
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;G5&#39;)
+  self.assertEqual(CHORD_QUALITY_OTHER, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Bbsus2&#39;)
+  self.assertEqual(CHORD_QUALITY_OTHER, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;Dsus&#39;)
+  self.assertEqual(CHORD_QUALITY_OTHER, quality)
+  quality = chord_symbols_lib.chord_symbol_quality(&#39;E(no3)&#39;)
+  self.assertEqual(CHORD_QUALITY_OTHER, quality)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolRoot"><code class="name flex">
+<span>def <span class="ident">testChordSymbolRoot</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testChordSymbolRoot(self):
+  root = chord_symbols_lib.chord_symbol_root(&#39;Dm9&#39;)
+  self.assertEqual(2, root)
+  root = chord_symbols_lib.chord_symbol_root(&#39;E/G#&#39;)
+  self.assertEqual(4, root)
+  root = chord_symbols_lib.chord_symbol_root(&#39;Bsus2&#39;)
+  self.assertEqual(11, root)
+  root = chord_symbols_lib.chord_symbol_root(&#39;Abmaj7&#39;)
+  self.assertEqual(8, root)
+  root = chord_symbols_lib.chord_symbol_root(&#39;D##5(add6)&#39;)
+  self.assertEqual(4, root)
+  root = chord_symbols_lib.chord_symbol_root(&#39;F(b7)(#9)(b13)&#39;)
+  self.assertEqual(5, root)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testPitchesToChordSymbol"><code class="name flex">
+<span>def <span class="ident">testPitchesToChordSymbol</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPitchesToChordSymbol(self):
+  # Test basic triads.
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [60, 64, 67])
+  self.assertEqual(&#39;C&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [45, 48, 52])
+  self.assertEqual(&#39;Am&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [63, 66, 69])
+  self.assertEqual(&#39;Ebo&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [71, 75, 79])
+  self.assertEqual(&#39;B+&#39;, figure)
+
+  # Test basic inversions.
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [59, 62, 67])
+  self.assertEqual(&#39;G/B&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [65, 70, 73])
+  self.assertEqual(&#39;Bbm/F&#39;, figure)
+
+  # Test suspended chords.
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [62, 67, 69])
+  self.assertEqual(&#39;Dsus&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [55, 60, 62, 65])
+  self.assertEqual(&#39;Gsus7&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [67, 69, 74])
+  self.assertEqual(&#39;Gsus2&#39;, figure)
+
+  # Test more complex chords.
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [45, 46, 50, 53])
+  self.assertEqual(&#39;Bbmaj7/A&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [63, 67, 70, 72, 74])
+  self.assertEqual(&#39;Cm9/Eb&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [53, 60, 64, 67, 70])
+  self.assertEqual(&#39;C7/F&#39;, figure)
+
+  # Test chords with modifications.
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [67, 71, 72, 74, 77])
+  self.assertEqual(&#39;G7(add4)&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [64, 68, 71, 74, 79])
+  self.assertEqual(&#39;E7(#9)&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [60, 62, 64, 67])
+  self.assertEqual(&#39;C(add2)&#39;, figure)
+  figure = chord_symbols_lib.pitches_to_chord_symbol(
+      [60, 64, 68, 70, 75])
+  self.assertEqual(&#39;C+7(#9)&#39;, figure)
+
+  # Test invalid chord.
+  with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+    chord_symbols_lib.pitches_to_chord_symbol(
+        [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testTransposeChordSymbol"><code class="name flex">
+<span>def <span class="ident">testTransposeChordSymbol</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTransposeChordSymbol(self):
+  # Test basic triads.
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;C&#39;, 2)
+  self.assertEqual(&#39;D&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;Abm&#39;, -3)
+  self.assertEqual(&#39;Fm&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;F#&#39;, 0)
+  self.assertEqual(&#39;F#&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;Cbb&#39;, 6)
+  self.assertEqual(&#39;Fb&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;C#&#39;, -5)
+  self.assertEqual(&#39;G#&#39;, figure)
+
+  # Test more complex chords.
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;Co7&#39;, 7)
+  self.assertEqual(&#39;Go7&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;D+&#39;, -3)
+  self.assertEqual(&#39;B+&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;Fb9/Ab&#39;, 2)
+  self.assertEqual(&#39;Gb9/Bb&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;A6/9&#39;, -7)
+  self.assertEqual(&#39;D6/9&#39;, figure)
+  figure = chord_symbols_lib.transpose_chord_symbol(&#39;E7(add#9)&#39;, 0)
+  self.assertEqual(&#39;E7(add#9)&#39;, figure)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest">ChordSymbolFunctionsTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolBass" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolBass">testChordSymbolBass</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolPitches" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolPitches">testChordSymbolPitches</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolQuality" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolQuality">testChordSymbolQuality</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolRoot" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testChordSymbolRoot">testChordSymbolRoot</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testPitchesToChordSymbol" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testPitchesToChordSymbol">testPitchesToChordSymbol</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testTransposeChordSymbol" href="#note_seq.chord_symbols_lib_test.ChordSymbolFunctionsTest.testTransposeChordSymbol">testTransposeChordSymbol</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chords_encoder_decoder.html
+++ b/docs/chords_encoder_decoder.html
@@ -1,0 +1,622 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chords_encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between chord progressions and models inputs/outputs …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chords_encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between chord progressions and models inputs/outputs.</p>
+<p>MajorMinorChordOneHotEncoding is an encoding.OneHotEncoding that specifies a
+one-hot encoding for ChordProgression events, i.e. chord symbol strings. This
+encoding has 25 classes, all 12 major and minor triads plus "no chord".</p>
+<p>TriadChordOneHotEncoding is another encoding.OneHotEncoding that specifies a
+one-hot encoding for ChordProgression events, i.e. chord symbol strings. This
+encoding has 49 classes, all 12 major/minor/augmented/diminished triads plus
+"no chord".</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between chord progressions and models inputs/outputs.
+
+MajorMinorChordOneHotEncoding is an encoding.OneHotEncoding that specifies a
+one-hot encoding for ChordProgression events, i.e. chord symbol strings. This
+encoding has 25 classes, all 12 major and minor triads plus &#34;no chord&#34;.
+
+TriadChordOneHotEncoding is another encoding.OneHotEncoding that specifies a
+one-hot encoding for ChordProgression events, i.e. chord symbol strings. This
+encoding has 49 classes, all 12 major/minor/augmented/diminished triads plus
+&#34;no chord&#34;.
+&#34;&#34;&#34;
+
+from note_seq import chord_symbols_lib
+from note_seq import constants
+from note_seq import encoder_decoder
+
+NOTES_PER_OCTAVE = constants.NOTES_PER_OCTAVE
+NO_CHORD = constants.NO_CHORD
+
+# Mapping from pitch class index to name.
+_PITCH_CLASS_MAPPING = [&#39;C&#39;, &#39;C#&#39;, &#39;D&#39;, &#39;Eb&#39;, &#39;E&#39;, &#39;F&#39;,
+                        &#39;F#&#39;, &#39;G&#39;, &#39;Ab&#39;, &#39;A&#39;, &#39;Bb&#39;, &#39;B&#39;]
+
+
+class ChordEncodingError(Exception):
+  pass
+
+
+class MajorMinorChordOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes chords as root + major/minor, with zero index for &#34;no chord&#34;.
+
+  Encodes chords as follows:
+    0:     &#34;no chord&#34;
+    1-12:  chords with a major triad, where 1 is C major, 2 is C# major, etc.
+    13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.
+  &#34;&#34;&#34;
+
+  @property
+  def num_classes(self):
+    return 2 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def default_event(self):
+    return NO_CHORD
+
+  def encode_event(self, event):
+    if event == NO_CHORD:
+      return 0
+
+    root = chord_symbols_lib.chord_symbol_root(event)
+    quality = chord_symbols_lib.chord_symbol_quality(event)
+
+    if quality == chord_symbols_lib.CHORD_QUALITY_MAJOR:
+      return root + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_MINOR:
+      return root + NOTES_PER_OCTAVE + 1
+    else:
+      raise ChordEncodingError(&#39;chord is neither major nor minor: %s&#39; % event)
+
+  def decode_event(self, index):
+    if index == 0:
+      return NO_CHORD
+    elif index - 1 &lt; 12:
+      # major
+      return _PITCH_CLASS_MAPPING[index - 1]
+    else:
+      # minor
+      return _PITCH_CLASS_MAPPING[index - NOTES_PER_OCTAVE - 1] + &#39;m&#39;
+
+
+class TriadChordOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes chords as root + triad type, with zero index for &#34;no chord&#34;.
+
+  Encodes chords as follows:
+    0:     &#34;no chord&#34;
+    1-12:  chords with a major triad, where 1 is C major, 2 is C# major, etc.
+    13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.
+    25-36: chords with an augmented triad, where 25 is C augmented, etc.
+    37-48: chords with a diminished triad, where 37 is C diminished, etc.
+  &#34;&#34;&#34;
+
+  @property
+  def num_classes(self):
+    return 4 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def default_event(self):
+    return NO_CHORD
+
+  def encode_event(self, event):
+    if event == NO_CHORD:
+      return 0
+
+    root = chord_symbols_lib.chord_symbol_root(event)
+    quality = chord_symbols_lib.chord_symbol_quality(event)
+
+    if quality == chord_symbols_lib.CHORD_QUALITY_MAJOR:
+      return root + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_MINOR:
+      return root + NOTES_PER_OCTAVE + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_AUGMENTED:
+      return root + 2 * NOTES_PER_OCTAVE + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_DIMINISHED:
+      return root + 3 * NOTES_PER_OCTAVE + 1
+    else:
+      raise ChordEncodingError(&#39;chord is not a standard triad: %s&#39; % event)
+
+  def decode_event(self, index):
+    if index == 0:
+      return NO_CHORD
+    elif index - 1 &lt; 12:
+      # major
+      return _PITCH_CLASS_MAPPING[index - 1]
+    elif index - NOTES_PER_OCTAVE - 1 &lt; 12:
+      # minor
+      return _PITCH_CLASS_MAPPING[index - NOTES_PER_OCTAVE - 1] + &#39;m&#39;
+    elif index - 2 * NOTES_PER_OCTAVE - 1 &lt; 12:
+      # augmented
+      return _PITCH_CLASS_MAPPING[index - 2 * NOTES_PER_OCTAVE - 1] + &#39;aug&#39;
+    else:
+      # diminished
+      return _PITCH_CLASS_MAPPING[index - 3 * NOTES_PER_OCTAVE - 1] + &#39;dim&#39;
+
+
+class PitchChordsEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder/decoder for chords that encodes chord root, pitches, and bass.
+
+  This class has no label encoding and can only be used to encode chords as
+  model input vectors. It can be used to help generate another type of event
+  sequence (e.g. melody) conditioned on chords.
+  &#34;&#34;&#34;
+
+  @property
+  def input_size(self):
+    return 3 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the chord progression.
+
+    Indices [0, 36]:
+    [0]: Whether or not this chord is &#34;no chord&#34;.
+    [1, 12]: A one-hot encoding of the chord root pitch class.
+    [13, 24]: Whether or not each pitch class is present in the chord.
+    [25, 36]: A one-hot encoding of the chord bass pitch class.
+
+    Args:
+      events: A note_seq.ChordProgression object.
+      position: An integer event position in the chord progression.
+
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    chord = events[position]
+    input_ = [0.0] * self.input_size
+
+    if chord == NO_CHORD:
+      input_[0] = 1.0
+      return input_
+
+    root = chord_symbols_lib.chord_symbol_root(chord)
+    input_[1 + root] = 1.0
+
+    pitches = chord_symbols_lib.chord_symbol_pitches(chord)
+    for pitch in pitches:
+      input_[1 + NOTES_PER_OCTAVE + pitch] = 1.0
+
+    bass = chord_symbols_lib.chord_symbol_bass(chord)
+    input_[1 + 2 * NOTES_PER_OCTAVE + bass] = 1.0
+
+    return input_
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chords_encoder_decoder.ChordEncodingError"><code class="flex name class">
+<span>class <span class="ident">ChordEncodingError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordEncodingError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_encoder_decoder.MajorMinorChordOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">MajorMinorChordOneHotEncoding</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Encodes chords as root + major/minor, with zero index for "no chord".</p>
+<p>Encodes chords as follows:
+0:
+"no chord"
+1-12:
+chords with a major triad, where 1 is C major, 2 is C# major, etc.
+13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MajorMinorChordOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes chords as root + major/minor, with zero index for &#34;no chord&#34;.
+
+  Encodes chords as follows:
+    0:     &#34;no chord&#34;
+    1-12:  chords with a major triad, where 1 is C major, 2 is C# major, etc.
+    13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.
+  &#34;&#34;&#34;
+
+  @property
+  def num_classes(self):
+    return 2 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def default_event(self):
+    return NO_CHORD
+
+  def encode_event(self, event):
+    if event == NO_CHORD:
+      return 0
+
+    root = chord_symbols_lib.chord_symbol_root(event)
+    quality = chord_symbols_lib.chord_symbol_quality(event)
+
+    if quality == chord_symbols_lib.CHORD_QUALITY_MAJOR:
+      return root + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_MINOR:
+      return root + NOTES_PER_OCTAVE + 1
+    else:
+      raise ChordEncodingError(&#39;chord is neither major nor minor: %s&#39; % event)
+
+  def decode_event(self, index):
+    if index == 0:
+      return NO_CHORD
+    elif index - 1 &lt; 12:
+      # major
+      return _PITCH_CLASS_MAPPING[index - 1]
+    else:
+      # minor
+      return _PITCH_CLASS_MAPPING[index - NOTES_PER_OCTAVE - 1] + &#39;m&#39;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">PitchChordsEncoderDecoder</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>An encoder/decoder for chords that encodes chord root, pitches, and bass.</p>
+<p>This class has no label encoding and can only be used to encode chords as
+model input vectors. It can be used to help generate another type of event
+sequence (e.g. melody) conditioned on chords.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PitchChordsEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder/decoder for chords that encodes chord root, pitches, and bass.
+
+  This class has no label encoding and can only be used to encode chords as
+  model input vectors. It can be used to help generate another type of event
+  sequence (e.g. melody) conditioned on chords.
+  &#34;&#34;&#34;
+
+  @property
+  def input_size(self):
+    return 3 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the chord progression.
+
+    Indices [0, 36]:
+    [0]: Whether or not this chord is &#34;no chord&#34;.
+    [1, 12]: A one-hot encoding of the chord root pitch class.
+    [13, 24]: Whether or not each pitch class is present in the chord.
+    [25, 36]: A one-hot encoding of the chord bass pitch class.
+
+    Args:
+      events: A note_seq.ChordProgression object.
+      position: An integer event position in the chord progression.
+
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    chord = events[position]
+    input_ = [0.0] * self.input_size
+
+    if chord == NO_CHORD:
+      input_[0] = 1.0
+      return input_
+
+    root = chord_symbols_lib.chord_symbol_root(chord)
+    input_[1 + root] = 1.0
+
+    pitches = chord_symbols_lib.chord_symbol_pitches(chord)
+    for pitch in pitches:
+      input_[1 + NOTES_PER_OCTAVE + pitch] = 1.0
+
+    bass = chord_symbols_lib.chord_symbol_bass(chord)
+    input_[1 + 2 * NOTES_PER_OCTAVE + bass] = 1.0
+
+    return input_
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the chord progression.</p>
+<p>Indices [0, 36]:
+[0]: Whether or not this chord is "no chord".
+[1, 12]: A one-hot encoding of the chord root pitch class.
+[13, 24]: Whether or not each pitch class is present in the chord.
+[25, 36]: A one-hot encoding of the chord bass pitch class.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A note_seq.ChordProgression object.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the chord progression.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, an self.input_size length list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the chord progression.
+
+  Indices [0, 36]:
+  [0]: Whether or not this chord is &#34;no chord&#34;.
+  [1, 12]: A one-hot encoding of the chord root pitch class.
+  [13, 24]: Whether or not each pitch class is present in the chord.
+  [25, 36]: A one-hot encoding of the chord bass pitch class.
+
+  Args:
+    events: A note_seq.ChordProgression object.
+    position: An integer event position in the chord progression.
+
+  Returns:
+    An input vector, an self.input_size length list of floats.
+  &#34;&#34;&#34;
+  chord = events[position]
+  input_ = [0.0] * self.input_size
+
+  if chord == NO_CHORD:
+    input_[0] = 1.0
+    return input_
+
+  root = chord_symbols_lib.chord_symbol_root(chord)
+  input_[1 + root] = 1.0
+
+  pitches = chord_symbols_lib.chord_symbol_pitches(chord)
+  for pitch in pitches:
+    input_[1 + NOTES_PER_OCTAVE + pitch] = 1.0
+
+  bass = chord_symbols_lib.chord_symbol_bass(chord)
+  input_[1 + 2 * NOTES_PER_OCTAVE + bass] = 1.0
+
+  return input_</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_encoder_decoder.TriadChordOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">TriadChordOneHotEncoding</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Encodes chords as root + triad type, with zero index for "no chord".</p>
+<p>Encodes chords as follows:
+0:
+"no chord"
+1-12:
+chords with a major triad, where 1 is C major, 2 is C# major, etc.
+13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.
+25-36: chords with an augmented triad, where 25 is C augmented, etc.
+37-48: chords with a diminished triad, where 37 is C diminished, etc.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TriadChordOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes chords as root + triad type, with zero index for &#34;no chord&#34;.
+
+  Encodes chords as follows:
+    0:     &#34;no chord&#34;
+    1-12:  chords with a major triad, where 1 is C major, 2 is C# major, etc.
+    13-24: chords with a minor triad, where 13 is C minor, 14 is C# minor, etc.
+    25-36: chords with an augmented triad, where 25 is C augmented, etc.
+    37-48: chords with a diminished triad, where 37 is C diminished, etc.
+  &#34;&#34;&#34;
+
+  @property
+  def num_classes(self):
+    return 4 * NOTES_PER_OCTAVE + 1
+
+  @property
+  def default_event(self):
+    return NO_CHORD
+
+  def encode_event(self, event):
+    if event == NO_CHORD:
+      return 0
+
+    root = chord_symbols_lib.chord_symbol_root(event)
+    quality = chord_symbols_lib.chord_symbol_quality(event)
+
+    if quality == chord_symbols_lib.CHORD_QUALITY_MAJOR:
+      return root + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_MINOR:
+      return root + NOTES_PER_OCTAVE + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_AUGMENTED:
+      return root + 2 * NOTES_PER_OCTAVE + 1
+    elif quality == chord_symbols_lib.CHORD_QUALITY_DIMINISHED:
+      return root + 3 * NOTES_PER_OCTAVE + 1
+    else:
+      raise ChordEncodingError(&#39;chord is not a standard triad: %s&#39; % event)
+
+  def decode_event(self, index):
+    if index == 0:
+      return NO_CHORD
+    elif index - 1 &lt; 12:
+      # major
+      return _PITCH_CLASS_MAPPING[index - 1]
+    elif index - NOTES_PER_OCTAVE - 1 &lt; 12:
+      # minor
+      return _PITCH_CLASS_MAPPING[index - NOTES_PER_OCTAVE - 1] + &#39;m&#39;
+    elif index - 2 * NOTES_PER_OCTAVE - 1 &lt; 12:
+      # augmented
+      return _PITCH_CLASS_MAPPING[index - 2 * NOTES_PER_OCTAVE - 1] + &#39;aug&#39;
+    else:
+      # diminished
+      return _PITCH_CLASS_MAPPING[index - 3 * NOTES_PER_OCTAVE - 1] + &#39;dim&#39;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder.ChordEncodingError" href="#note_seq.chords_encoder_decoder.ChordEncodingError">ChordEncodingError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder.MajorMinorChordOneHotEncoding" href="#note_seq.chords_encoder_decoder.MajorMinorChordOneHotEncoding">MajorMinorChordOneHotEncoding</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder" href="#note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder">PitchChordsEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder.events_to_input" href="#note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder.events_to_input">events_to_input</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder.TriadChordOneHotEncoding" href="#note_seq.chords_encoder_decoder.TriadChordOneHotEncoding">TriadChordOneHotEncoding</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chords_encoder_decoder_test.html
+++ b/docs/chords_encoder_decoder_test.html
@@ -1,0 +1,819 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chords_encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for chords_encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chords_encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for chords_encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for chords_encoder_decoder.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import chords_encoder_decoder
+from note_seq import constants
+
+NO_CHORD = constants.NO_CHORD
+
+
+class MajorMinorChordOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.MajorMinorChordOneHotEncoding()
+
+  def testEncodeNoChord(self):
+    index = self.enc.encode_event(NO_CHORD)
+    self.assertEqual(0, index)
+
+  def testEncodeChord(self):
+    # major triad
+    index = self.enc.encode_event(&#39;C&#39;)
+    self.assertEqual(1, index)
+
+    # minor triad
+    index = self.enc.encode_event(&#39;Cm&#39;)
+    self.assertEqual(13, index)
+
+    # dominant 7th
+    index = self.enc.encode_event(&#39;F7&#39;)
+    self.assertEqual(6, index)
+
+    # minor 9th
+    index = self.enc.encode_event(&#39;Abm9&#39;)
+    self.assertEqual(21, index)
+
+  def testEncodeThirdlessChord(self):
+    # suspended chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Gsus4&#39;)
+
+    # power chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Bb5&#39;)
+
+  def testDecodeNoChord(self):
+    figure = self.enc.decode_event(0)
+    self.assertEqual(NO_CHORD, figure)
+
+  def testDecodeChord(self):
+    # major chord
+    figure = self.enc.decode_event(3)
+    self.assertEqual(&#39;D&#39;, figure)
+
+    # minor chord
+    figure = self.enc.decode_event(17)
+    self.assertEqual(&#39;Em&#39;, figure)
+
+
+class TriadChordOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.TriadChordOneHotEncoding()
+
+  def testEncodeNoChord(self):
+    index = self.enc.encode_event(NO_CHORD)
+    self.assertEqual(0, index)
+
+  def testEncodeChord(self):
+    # major triad
+    index = self.enc.encode_event(&#39;C13&#39;)
+    self.assertEqual(1, index)
+
+    # minor triad
+    index = self.enc.encode_event(&#39;Cm(maj7)&#39;)
+    self.assertEqual(13, index)
+
+    # augmented triad
+    index = self.enc.encode_event(&#39;Faug7&#39;)
+    self.assertEqual(30, index)
+
+    # diminished triad
+    index = self.enc.encode_event(&#39;Abm7b5&#39;)
+    self.assertEqual(45, index)
+
+  def testEncodeThirdlessChord(self):
+    # suspended chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Gsus4&#39;)
+
+    # power chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Bb5&#39;)
+
+  def testDecodeNoChord(self):
+    figure = self.enc.decode_event(0)
+    self.assertEqual(NO_CHORD, figure)
+
+  def testDecodeChord(self):
+    # major chord
+    figure = self.enc.decode_event(3)
+    self.assertEqual(&#39;D&#39;, figure)
+
+    # minor chord
+    figure = self.enc.decode_event(17)
+    self.assertEqual(&#39;Em&#39;, figure)
+
+    # augmented chord
+    figure = self.enc.decode_event(33)
+    self.assertEqual(&#39;Abaug&#39;, figure)
+
+    # diminished chord
+    figure = self.enc.decode_event(42)
+    self.assertEqual(&#39;Fdim&#39;, figure)
+
+
+class PitchChordsEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.PitchChordsEncoderDecoder()
+
+  def testInputSize(self):
+    self.assertEqual(37, self.enc.input_size)
+
+  def testEncodeNoChord(self):
+    input_ = self.enc.events_to_input([NO_CHORD], 0)
+    self.assertEqual([1.0] + [0.0] * 36, input_)
+
+  def testEncodeChord(self):
+    # major triad
+    input_ = self.enc.events_to_input([&#39;C&#39;], 0)
+    expected = [0.0,
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # minor triad
+    input_ = self.enc.events_to_input([&#39;F#m&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # major triad with dominant 7th in bass
+    input_ = self.enc.events_to_input([&#39;G/F&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # 13th chord
+    input_ = self.enc.events_to_input([&#39;E13&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+                0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # minor triad with major 7th
+    input_ = self.enc.events_to_input([&#39;Fm(maj7)&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest"><code class="flex name class">
+<span>class <span class="ident">MajorMinorChordOneHotEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MajorMinorChordOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.MajorMinorChordOneHotEncoding()
+
+  def testEncodeNoChord(self):
+    index = self.enc.encode_event(NO_CHORD)
+    self.assertEqual(0, index)
+
+  def testEncodeChord(self):
+    # major triad
+    index = self.enc.encode_event(&#39;C&#39;)
+    self.assertEqual(1, index)
+
+    # minor triad
+    index = self.enc.encode_event(&#39;Cm&#39;)
+    self.assertEqual(13, index)
+
+    # dominant 7th
+    index = self.enc.encode_event(&#39;F7&#39;)
+    self.assertEqual(6, index)
+
+    # minor 9th
+    index = self.enc.encode_event(&#39;Abm9&#39;)
+    self.assertEqual(21, index)
+
+  def testEncodeThirdlessChord(self):
+    # suspended chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Gsus4&#39;)
+
+    # power chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Bb5&#39;)
+
+  def testDecodeNoChord(self):
+    figure = self.enc.decode_event(0)
+    self.assertEqual(NO_CHORD, figure)
+
+  def testDecodeChord(self):
+    # major chord
+    figure = self.enc.decode_event(3)
+    self.assertEqual(&#39;D&#39;, figure)
+
+    # minor chord
+    figure = self.enc.decode_event(17)
+    self.assertEqual(&#39;Em&#39;, figure)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = chords_encoder_decoder.MajorMinorChordOneHotEncoding()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeChord"><code class="name flex">
+<span>def <span class="ident">testDecodeChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeChord(self):
+  # major chord
+  figure = self.enc.decode_event(3)
+  self.assertEqual(&#39;D&#39;, figure)
+
+  # minor chord
+  figure = self.enc.decode_event(17)
+  self.assertEqual(&#39;Em&#39;, figure)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeNoChord"><code class="name flex">
+<span>def <span class="ident">testDecodeNoChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeNoChord(self):
+  figure = self.enc.decode_event(0)
+  self.assertEqual(NO_CHORD, figure)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeChord"><code class="name flex">
+<span>def <span class="ident">testEncodeChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeChord(self):
+  # major triad
+  index = self.enc.encode_event(&#39;C&#39;)
+  self.assertEqual(1, index)
+
+  # minor triad
+  index = self.enc.encode_event(&#39;Cm&#39;)
+  self.assertEqual(13, index)
+
+  # dominant 7th
+  index = self.enc.encode_event(&#39;F7&#39;)
+  self.assertEqual(6, index)
+
+  # minor 9th
+  index = self.enc.encode_event(&#39;Abm9&#39;)
+  self.assertEqual(21, index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeNoChord"><code class="name flex">
+<span>def <span class="ident">testEncodeNoChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeNoChord(self):
+  index = self.enc.encode_event(NO_CHORD)
+  self.assertEqual(0, index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeThirdlessChord"><code class="name flex">
+<span>def <span class="ident">testEncodeThirdlessChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeThirdlessChord(self):
+  # suspended chord
+  with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+    self.enc.encode_event(&#39;Gsus4&#39;)
+
+  # power chord
+  with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+    self.enc.encode_event(&#39;Bb5&#39;)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">PitchChordsEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PitchChordsEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.PitchChordsEncoderDecoder()
+
+  def testInputSize(self):
+    self.assertEqual(37, self.enc.input_size)
+
+  def testEncodeNoChord(self):
+    input_ = self.enc.events_to_input([NO_CHORD], 0)
+    self.assertEqual([1.0] + [0.0] * 36, input_)
+
+  def testEncodeChord(self):
+    # major triad
+    input_ = self.enc.events_to_input([&#39;C&#39;], 0)
+    expected = [0.0,
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # minor triad
+    input_ = self.enc.events_to_input([&#39;F#m&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # major triad with dominant 7th in bass
+    input_ = self.enc.events_to_input([&#39;G/F&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # 13th chord
+    input_ = self.enc.events_to_input([&#39;E13&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+                0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)
+
+    # minor triad with major 7th
+    input_ = self.enc.events_to_input([&#39;Fm(maj7)&#39;], 0)
+    expected = [0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    self.assertEqual(expected, input_)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = chords_encoder_decoder.PitchChordsEncoderDecoder()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeChord"><code class="name flex">
+<span>def <span class="ident">testEncodeChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeChord(self):
+  # major triad
+  input_ = self.enc.events_to_input([&#39;C&#39;], 0)
+  expected = [0.0,
+              1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+              1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  self.assertEqual(expected, input_)
+
+  # minor triad
+  input_ = self.enc.events_to_input([&#39;F#m&#39;], 0)
+  expected = [0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  self.assertEqual(expected, input_)
+
+  # major triad with dominant 7th in bass
+  input_ = self.enc.events_to_input([&#39;G/F&#39;], 0)
+  expected = [0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  self.assertEqual(expected, input_)
+
+  # 13th chord
+  input_ = self.enc.events_to_input([&#39;E13&#39;], 0)
+  expected = [0.0,
+              0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+              0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  self.assertEqual(expected, input_)
+
+  # minor triad with major 7th
+  input_ = self.enc.events_to_input([&#39;Fm(maj7)&#39;], 0)
+  expected = [0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  self.assertEqual(expected, input_)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeNoChord"><code class="name flex">
+<span>def <span class="ident">testEncodeNoChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeNoChord(self):
+  input_ = self.enc.events_to_input([NO_CHORD], 0)
+  self.assertEqual([1.0] + [0.0] * 36, input_)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(37, self.enc.input_size)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest"><code class="flex name class">
+<span>class <span class="ident">TriadChordOneHotEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TriadChordOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = chords_encoder_decoder.TriadChordOneHotEncoding()
+
+  def testEncodeNoChord(self):
+    index = self.enc.encode_event(NO_CHORD)
+    self.assertEqual(0, index)
+
+  def testEncodeChord(self):
+    # major triad
+    index = self.enc.encode_event(&#39;C13&#39;)
+    self.assertEqual(1, index)
+
+    # minor triad
+    index = self.enc.encode_event(&#39;Cm(maj7)&#39;)
+    self.assertEqual(13, index)
+
+    # augmented triad
+    index = self.enc.encode_event(&#39;Faug7&#39;)
+    self.assertEqual(30, index)
+
+    # diminished triad
+    index = self.enc.encode_event(&#39;Abm7b5&#39;)
+    self.assertEqual(45, index)
+
+  def testEncodeThirdlessChord(self):
+    # suspended chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Gsus4&#39;)
+
+    # power chord
+    with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+      self.enc.encode_event(&#39;Bb5&#39;)
+
+  def testDecodeNoChord(self):
+    figure = self.enc.decode_event(0)
+    self.assertEqual(NO_CHORD, figure)
+
+  def testDecodeChord(self):
+    # major chord
+    figure = self.enc.decode_event(3)
+    self.assertEqual(&#39;D&#39;, figure)
+
+    # minor chord
+    figure = self.enc.decode_event(17)
+    self.assertEqual(&#39;Em&#39;, figure)
+
+    # augmented chord
+    figure = self.enc.decode_event(33)
+    self.assertEqual(&#39;Abaug&#39;, figure)
+
+    # diminished chord
+    figure = self.enc.decode_event(42)
+    self.assertEqual(&#39;Fdim&#39;, figure)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = chords_encoder_decoder.TriadChordOneHotEncoding()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeChord"><code class="name flex">
+<span>def <span class="ident">testDecodeChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeChord(self):
+  # major chord
+  figure = self.enc.decode_event(3)
+  self.assertEqual(&#39;D&#39;, figure)
+
+  # minor chord
+  figure = self.enc.decode_event(17)
+  self.assertEqual(&#39;Em&#39;, figure)
+
+  # augmented chord
+  figure = self.enc.decode_event(33)
+  self.assertEqual(&#39;Abaug&#39;, figure)
+
+  # diminished chord
+  figure = self.enc.decode_event(42)
+  self.assertEqual(&#39;Fdim&#39;, figure)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeNoChord"><code class="name flex">
+<span>def <span class="ident">testDecodeNoChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeNoChord(self):
+  figure = self.enc.decode_event(0)
+  self.assertEqual(NO_CHORD, figure)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeChord"><code class="name flex">
+<span>def <span class="ident">testEncodeChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeChord(self):
+  # major triad
+  index = self.enc.encode_event(&#39;C13&#39;)
+  self.assertEqual(1, index)
+
+  # minor triad
+  index = self.enc.encode_event(&#39;Cm(maj7)&#39;)
+  self.assertEqual(13, index)
+
+  # augmented triad
+  index = self.enc.encode_event(&#39;Faug7&#39;)
+  self.assertEqual(30, index)
+
+  # diminished triad
+  index = self.enc.encode_event(&#39;Abm7b5&#39;)
+  self.assertEqual(45, index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeNoChord"><code class="name flex">
+<span>def <span class="ident">testEncodeNoChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeNoChord(self):
+  index = self.enc.encode_event(NO_CHORD)
+  self.assertEqual(0, index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeThirdlessChord"><code class="name flex">
+<span>def <span class="ident">testEncodeThirdlessChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeThirdlessChord(self):
+  # suspended chord
+  with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+    self.enc.encode_event(&#39;Gsus4&#39;)
+
+  # power chord
+  with self.assertRaises(chords_encoder_decoder.ChordEncodingError):
+    self.enc.encode_event(&#39;Bb5&#39;)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest">MajorMinorChordOneHotEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.setUp" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeChord" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeChord">testDecodeChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeNoChord" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testDecodeNoChord">testDecodeNoChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeChord" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeChord">testEncodeChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeNoChord" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeNoChord">testEncodeNoChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeThirdlessChord" href="#note_seq.chords_encoder_decoder_test.MajorMinorChordOneHotEncodingTest.testEncodeThirdlessChord">testEncodeThirdlessChord</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest" href="#note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest">PitchChordsEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.setUp" href="#note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeChord" href="#note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeChord">testEncodeChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeNoChord" href="#note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testEncodeNoChord">testEncodeNoChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testInputSize" href="#note_seq.chords_encoder_decoder_test.PitchChordsEncoderDecoderTest.testInputSize">testInputSize</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest">TriadChordOneHotEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.setUp" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeChord" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeChord">testDecodeChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeNoChord" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testDecodeNoChord">testDecodeNoChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeChord" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeChord">testEncodeChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeNoChord" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeNoChord">testEncodeNoChord</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeThirdlessChord" href="#note_seq.chords_encoder_decoder_test.TriadChordOneHotEncodingTest.testEncodeThirdlessChord">testEncodeThirdlessChord</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chords_lib.html
+++ b/docs/chords_lib.html
@@ -1,0 +1,1493 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chords_lib API documentation</title>
+<meta name="description" content="Utility functions for working with chord progressions …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chords_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with chord progressions.</p>
+<p>Use extract_chords_for_melodies to extract chord progressions from a
+quantized NoteSequence object, aligned with already-extracted melodies.</p>
+<p>Use ChordProgression.to_sequence to write a chord progression to a
+NoteSequence proto, encoding the chords as text annotations.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with chord progressions.
+
+Use extract_chords_for_melodies to extract chord progressions from a
+quantized NoteSequence object, aligned with already-extracted melodies.
+
+Use ChordProgression.to_sequence to write a chord progression to a
+NoteSequence proto, encoding the chords as text annotations.
+&#34;&#34;&#34;
+
+import abc
+import bisect
+
+from note_seq import chord_symbols_lib
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+
+STANDARD_PPQ = constants.STANDARD_PPQ
+NOTES_PER_OCTAVE = constants.NOTES_PER_OCTAVE
+NO_CHORD = constants.NO_CHORD
+
+# Shortcut to CHORD_SYMBOL annotation type.
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+class CoincidentChordsError(Exception):
+  pass
+
+
+class BadChordError(Exception):
+  pass
+
+
+class ChordProgression(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of chord events.
+
+  ChordProgression is an intermediate representation that all chord or lead
+  sheet models can use. Chords are represented here by a chord symbol string;
+  model-specific code is responsible for converting this representation to
+  SequenceExample protos for TensorFlow.
+
+  ChordProgression implements an iterable object. Simply iterate to retrieve
+  the chord events.
+
+  ChordProgression events are chord symbol strings like &#34;Cm7&#34;, with special
+  event NO_CHORD to indicate no chordal harmony. When a chord lasts for longer
+  than a single step, the chord symbol event is repeated multiple times. Note
+  that this is different from Melody, where the special MELODY_NO_EVENT is used
+  for subsequent steps of sustained notes; in the case of harmony, there&#39;s no
+  distinction between a repeated chord and a sustained chord.
+
+  Chords must be inserted in ascending order by start time.
+
+  Attributes:
+    start_step: The offset of the first step of the progression relative to the
+        beginning of the source sequence.
+    end_step: The offset to the beginning of the bar following the last step
+       of the progression relative to the beginning of the source sequence.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a ChordProgression.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(ChordProgression, self).__init__(pad_event=NO_CHORD,
+                                           events=events, **kwargs)
+
+  def _add_chord(self, figure, start_step, end_step):
+    &#34;&#34;&#34;Adds the given chord to the `events` list.
+
+    `start_step` is set to the given chord. Everything after `start_step` in
+    `events` is deleted before the chord is added. `events`&#39;s length will be
+     changed so that the last event has index `end_step` - 1.
+
+    Args:
+      figure: Chord symbol figure. A string like &#34;Cm9&#34; representing the chord.
+      start_step: A non-negative integer step that the chord begins on.
+      end_step: An integer step that the chord ends on. The chord is considered
+          to end at the onset of the end step. `end_step` must be greater than
+          `start_step`.
+
+    Raises:
+      BadChordError: If `start_step` does not precede `end_step`.
+    &#34;&#34;&#34;
+    if start_step &gt;= end_step:
+      raise BadChordError(
+          &#39;Start step does not precede end step: start=%d, end=%d&#39; %
+          (start_step, end_step))
+
+    self.set_length(end_step)
+
+    for i in range(start_step, end_step):
+      self._events[i] = figure
+
+  def from_quantized_sequence(self, quantized_sequence, start_step, end_step):
+    &#34;&#34;&#34;Populate self with the chords from the given quantized NoteSequence.
+
+    A chord progression is extracted from the given sequence starting at time
+    step `start_step` and ending at time step `end_step`.
+
+    The number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start populating chords at this time step.
+      end_step: Stop populating chords at this time step.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+      CoincidentChordsError: If any of the chords start on the same step.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signature.numerator,
+           quantized_sequence.time_signature.denominator))
+    self._steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Sort track by chord times.
+    chords = sorted([a for a in quantized_sequence.text_annotations
+                     if a.annotation_type == CHORD_SYMBOL],
+                    key=lambda chord: chord.quantized_step)
+
+    prev_step = None
+    prev_figure = NO_CHORD
+
+    for chord in chords:
+      if chord.quantized_step &gt;= end_step:
+        # No more chords within range.
+        break
+
+      elif chord.quantized_step &lt; start_step:
+        # Chord is before start of range.
+        prev_step = chord.quantized_step
+        prev_figure = chord.text
+        continue
+
+      if chord.quantized_step == prev_step:
+        if chord.text == prev_figure:
+          # Identical coincident chords, just skip.
+          continue
+        else:
+          # Two different chords start at the same time step.
+          self._reset()
+          raise CoincidentChordsError(
+              &#39;chords %s and %s are coincident&#39; % (prev_figure, chord.text))
+
+      if chord.quantized_step &gt; start_step:
+        # Add the previous chord.
+        if prev_step is None:
+          start_index = 0
+        else:
+          start_index = max(prev_step, start_step) - start_step
+        end_index = chord.quantized_step - start_step
+        self._add_chord(prev_figure, start_index, end_index)
+
+      prev_step = chord.quantized_step
+      prev_figure = chord.text
+
+    if prev_step is None or prev_step &lt; end_step:
+      # Add the last chord active before end_step.
+      if prev_step is None:
+        start_index = 0
+      else:
+        start_index = max(prev_step, start_step) - start_step
+      end_index = end_step - start_step
+      self._add_chord(prev_figure, start_index, end_index)
+
+    self._start_step = start_step
+    self._end_step = end_step
+
+  def to_sequence(self,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the ChordProgression to NoteSequence proto.
+
+    This doesn&#39;t generate actual notes, but text annotations specifying the
+    chord changes when they occur.
+
+    Args:
+      sequence_start_time: A time in seconds (float) that the first chord in
+          the sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given chords as text annotations.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    current_figure = NO_CHORD
+    for step, figure in enumerate(self):
+      if figure != current_figure:
+        current_figure = figure
+        chord = sequence.text_annotations.add()
+        chord.time = step * seconds_per_step + sequence_start_time
+        chord.text = figure
+        chord.annotation_type = CHORD_SYMBOL
+
+    return sequence
+
+  def transpose(self, transpose_amount):
+    &#34;&#34;&#34;Transpose chords in this ChordProgression.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this
+          ChordProgression. Positive values transpose up. Negative values
+          transpose down.
+
+    Raises:
+      ChordSymbolError: If a chord (other than &#34;no chord&#34;) fails to be
+          interpreted by the `chord_symbols_lib` module.
+    &#34;&#34;&#34;
+    for i in range(len(self._events)):
+      if self._events[i] != NO_CHORD:
+        self._events[i] = chord_symbols_lib.transpose_chord_symbol(
+            self._events[i], transpose_amount % NOTES_PER_OCTAVE)
+
+
+def event_list_chords(quantized_sequence, event_lists):
+  &#34;&#34;&#34;Extract corresponding chords for multiple EventSequences.
+
+  Args:
+    quantized_sequence: The underlying quantized NoteSequence from which to
+        extract the chords. It is assumed that the step numbering in this
+        sequence matches the step numbering in each EventSequence in
+        `event_lists`.
+    event_lists: A list of EventSequence objects.
+
+  Returns:
+    A nested list of chord the same length as `event_lists`, where each list is
+    the same length as the corresponding EventSequence (in events, not steps).
+  &#34;&#34;&#34;
+  sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+
+  chords = ChordProgression()
+  if quantized_sequence.total_quantized_steps &gt; 0:
+    chords.from_quantized_sequence(
+        quantized_sequence, 0, quantized_sequence.total_quantized_steps)
+
+  pad_chord = chords[-1] if chords else NO_CHORD
+
+  chord_lists = []
+  for e in event_lists:
+    chord_lists.append([chords[step] if step &lt; len(chords) else pad_chord
+                        for step in e.steps])
+
+  return chord_lists
+
+
+def event_list_keys(sequence, event_lists, steps_per_second):
+  &#34;&#34;&#34;Extract corresponding keys for multiple EventSequences.
+
+  Args:
+    sequence: The underlying NoteSequence from which to extract the keys.
+    event_lists: A list of EventSequence objects.
+    steps_per_second: The number of quantized steps per second in the event
+        lists.
+
+  Returns:
+    A nested list of keys (integers 0-11 indicating the key signature) the same
+    length as `event_lists`, where each list is the same length as the
+    corresponding EventSequence (in events, not necessarily steps).
+  &#34;&#34;&#34;
+  if not sequence.key_signatures:
+    raise ValueError(&#39;Sequence has no key signatures.&#39;)
+
+  key_changes = sorted((steps_per_second * ks.time, ks.key)
+                       for ks in sequence.key_signatures)
+  key_change_steps = [step for (step, _) in key_changes]
+
+  def step_to_key(step):
+    index = bisect.bisect(key_change_steps, step)
+    if index == 0:
+      # Step is before first key signature; just use that key.
+      return key_changes[0][1]
+    else:
+      return key_changes[index - 1][1]
+
+  key_lists = []
+  for e in event_lists:
+    key_lists.append([step_to_key(step) for step in e.steps])
+
+  return key_lists
+
+
+def add_chords_to_sequence(note_sequence, chords, chord_times):
+  &#34;&#34;&#34;Add chords to a NoteSequence (in place) at specified times.
+
+  Args:
+    note_sequence: The NoteSequence proto to which chords will be added (in
+        place). Should not already have chords.
+    chords: A Python list of chord figure strings to add to `note_sequence` as
+        text annotations.
+    chord_times: A Python list containing the time in seconds at which to add
+        each chord. Should be the same length as `chords` and nondecreasing.
+
+  Raises:
+    ValueError: If `note_sequence` already has chords, or if `chord_times` is
+        not sorted in ascending order.
+  &#34;&#34;&#34;
+  if any(ta.annotation_type == CHORD_SYMBOL
+         for ta in note_sequence.text_annotations):
+    raise ValueError(&#39;NoteSequence already has chords.&#39;)
+  if any(t1 &gt; t2 for t1, t2 in zip(chord_times[:-1], chord_times[1:])):
+    raise ValueError(&#39;Chord times not sorted in ascending order.&#39;)
+
+  current_chord = None
+  for chord, time in zip(chords, chord_times):
+    if chord != current_chord:
+      current_chord = chord
+      ta = note_sequence.text_annotations.add()
+      ta.annotation_type = CHORD_SYMBOL
+      ta.time = time
+      ta.text = chord
+
+
+def add_keys_to_sequence(note_sequence, keys, key_times):
+  &#34;&#34;&#34;Add key signatures to a NoteSequence (in place) at specified times.
+
+  Args:
+    note_sequence: The NoteSequence proto to which key signatures will be added
+        (in place). Should not already have key signatures.
+    keys: A Python list of keys (integers 0-11) to add to `note_sequence` as
+        KeySignature fields.
+    key_times: A Python list containing the time in seconds at which to add
+        each key signature. Should be the same length as `keys` and
+        nondecreasing.
+
+  Raises:
+    ValueError: If `note_sequence` already has key signatures, or if `key_times`
+        is not sorted in ascending order.
+  &#34;&#34;&#34;
+  if note_sequence.key_signatures:
+    raise ValueError(&#39;NoteSequence already has keys.&#39;)
+  if any(t1 &gt; t2 for t1, t2 in zip(key_times[:-1], key_times[1:])):
+    raise ValueError(&#39;Key times not sorted in ascending order.&#39;)
+
+  current_key = None
+  for key, time in zip(keys, key_times):
+    if key != current_key:
+      current_key = key
+      ks = note_sequence.key_signatures.add()
+      ks.time = time
+      ks.key = key
+
+
+class ChordRenderer(object):
+  &#34;&#34;&#34;An abstract class for rendering NoteSequence chord symbols as notes.&#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def render(self, sequence):
+    &#34;&#34;&#34;Renders the chord symbols of a NoteSequence.
+
+    This function renders chord symbol annotations in a NoteSequence as actual
+    notes. Notes are added to the NoteSequence object, and the chord symbols
+    remain also.
+
+    Args:
+      sequence: The NoteSequence for which to render chord symbols.
+    &#34;&#34;&#34;
+    pass
+
+
+class BasicChordRenderer(ChordRenderer):
+  &#34;&#34;&#34;A chord renderer that holds each note for the duration of the chord.&#34;&#34;&#34;
+
+  def __init__(self,
+               velocity=100,
+               instrument=1,
+               program=88,
+               octave=4,
+               bass_octave=3):
+    &#34;&#34;&#34;Initialize a BasicChordRenderer object.
+
+    Args:
+      velocity: The MIDI note velocity to use.
+      instrument: The MIDI instrument to use.
+      program: The MIDI program to use.
+      octave: The octave in which to render chord notes. If the bass note is not
+          otherwise part of the chord, it will not be rendered in this octave.
+      bass_octave: The octave in which to render chord bass notes.
+    &#34;&#34;&#34;
+    self._velocity = velocity
+    self._instrument = instrument
+    self._program = program
+    self._octave = octave
+    self._bass_octave = bass_octave
+
+  def _render_notes(self, sequence, pitches, bass_pitch, start_time, end_time):
+    &#34;&#34;&#34;Renders notes.&#34;&#34;&#34;
+    all_pitches = []
+    for pitch in pitches:
+      all_pitches.append(12 * self._octave + pitch % 12)
+    all_pitches.append(12 * self._bass_octave + bass_pitch % 12)
+
+    for pitch in all_pitches:
+      # Add a note.
+      note = sequence.notes.add()
+      note.start_time = start_time
+      note.end_time = end_time
+      note.pitch = pitch
+      note.velocity = self._velocity
+      note.instrument = self._instrument
+      note.program = self._program
+
+  def render(self, sequence):
+    # Sort text annotations by time.
+    annotations = sorted(sequence.text_annotations, key=lambda a: a.time)
+
+    prev_time = 0.0
+    prev_figure = NO_CHORD
+
+    for annotation in annotations:
+      if annotation.time &gt;= sequence.total_time:
+        break
+
+      if annotation.annotation_type == CHORD_SYMBOL:
+        if prev_figure != NO_CHORD:
+          # Render the previous chord.
+          pitches = chord_symbols_lib.chord_symbol_pitches(prev_figure)
+          bass_pitch = chord_symbols_lib.chord_symbol_bass(prev_figure)
+          self._render_notes(sequence=sequence,
+                             pitches=pitches,
+                             bass_pitch=bass_pitch,
+                             start_time=prev_time,
+                             end_time=annotation.time)
+
+        prev_time = annotation.time
+        prev_figure = annotation.text
+
+    if (prev_time &lt; sequence.total_time and
+        prev_figure != NO_CHORD):
+      # Render the last chord.
+      pitches = chord_symbols_lib.chord_symbol_pitches(prev_figure)
+      bass_pitch = chord_symbols_lib.chord_symbol_bass(prev_figure)
+      self._render_notes(sequence=sequence,
+                         pitches=pitches,
+                         bass_pitch=bass_pitch,
+                         start_time=prev_time,
+                         end_time=sequence.total_time)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.chords_lib.add_chords_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_chords_to_sequence</span></span>(<span>note_sequence, chords, chord_times)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Add chords to a NoteSequence (in place) at specified times.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence proto to which chords will be added (in
+place). Should not already have chords.</dd>
+<dt><strong><code>chords</code></strong></dt>
+<dd>A Python list of chord figure strings to add to <code>note_sequence</code> as
+text annotations.</dd>
+<dt><strong><code>chord_times</code></strong></dt>
+<dd>A Python list containing the time in seconds at which to add
+each chord. Should be the same length as <code>chords</code> and nondecreasing.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>note_sequence</code> already has chords, or if <code>chord_times</code> is
+not sorted in ascending order.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_chords_to_sequence(note_sequence, chords, chord_times):
+  &#34;&#34;&#34;Add chords to a NoteSequence (in place) at specified times.
+
+  Args:
+    note_sequence: The NoteSequence proto to which chords will be added (in
+        place). Should not already have chords.
+    chords: A Python list of chord figure strings to add to `note_sequence` as
+        text annotations.
+    chord_times: A Python list containing the time in seconds at which to add
+        each chord. Should be the same length as `chords` and nondecreasing.
+
+  Raises:
+    ValueError: If `note_sequence` already has chords, or if `chord_times` is
+        not sorted in ascending order.
+  &#34;&#34;&#34;
+  if any(ta.annotation_type == CHORD_SYMBOL
+         for ta in note_sequence.text_annotations):
+    raise ValueError(&#39;NoteSequence already has chords.&#39;)
+  if any(t1 &gt; t2 for t1, t2 in zip(chord_times[:-1], chord_times[1:])):
+    raise ValueError(&#39;Chord times not sorted in ascending order.&#39;)
+
+  current_chord = None
+  for chord, time in zip(chords, chord_times):
+    if chord != current_chord:
+      current_chord = chord
+      ta = note_sequence.text_annotations.add()
+      ta.annotation_type = CHORD_SYMBOL
+      ta.time = time
+      ta.text = chord</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib.add_keys_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_keys_to_sequence</span></span>(<span>note_sequence, keys, key_times)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Add key signatures to a NoteSequence (in place) at specified times.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence proto to which key signatures will be added
+(in place). Should not already have key signatures.</dd>
+<dt><strong><code>keys</code></strong></dt>
+<dd>A Python list of keys (integers 0-11) to add to <code>note_sequence</code> as
+KeySignature fields.</dd>
+<dt><strong><code>key_times</code></strong></dt>
+<dd>A Python list containing the time in seconds at which to add
+each key signature. Should be the same length as <code>keys</code> and
+nondecreasing.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>note_sequence</code> already has key signatures, or if <code>key_times</code>
+is not sorted in ascending order.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_keys_to_sequence(note_sequence, keys, key_times):
+  &#34;&#34;&#34;Add key signatures to a NoteSequence (in place) at specified times.
+
+  Args:
+    note_sequence: The NoteSequence proto to which key signatures will be added
+        (in place). Should not already have key signatures.
+    keys: A Python list of keys (integers 0-11) to add to `note_sequence` as
+        KeySignature fields.
+    key_times: A Python list containing the time in seconds at which to add
+        each key signature. Should be the same length as `keys` and
+        nondecreasing.
+
+  Raises:
+    ValueError: If `note_sequence` already has key signatures, or if `key_times`
+        is not sorted in ascending order.
+  &#34;&#34;&#34;
+  if note_sequence.key_signatures:
+    raise ValueError(&#39;NoteSequence already has keys.&#39;)
+  if any(t1 &gt; t2 for t1, t2 in zip(key_times[:-1], key_times[1:])):
+    raise ValueError(&#39;Key times not sorted in ascending order.&#39;)
+
+  current_key = None
+  for key, time in zip(keys, key_times):
+    if key != current_key:
+      current_key = key
+      ks = note_sequence.key_signatures.add()
+      ks.time = time
+      ks.key = key</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib.event_list_chords"><code class="name flex">
+<span>def <span class="ident">event_list_chords</span></span>(<span>quantized_sequence, event_lists)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract corresponding chords for multiple EventSequences.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>The underlying quantized NoteSequence from which to
+extract the chords. It is assumed that the step numbering in this
+sequence matches the step numbering in each EventSequence in
+<code>event_lists</code>.</dd>
+<dt><strong><code>event_lists</code></strong></dt>
+<dd>A list of EventSequence objects.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A nested list of chord the same length as <code>event_lists</code>, where each list is
+the same length as the corresponding EventSequence (in events, not steps).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def event_list_chords(quantized_sequence, event_lists):
+  &#34;&#34;&#34;Extract corresponding chords for multiple EventSequences.
+
+  Args:
+    quantized_sequence: The underlying quantized NoteSequence from which to
+        extract the chords. It is assumed that the step numbering in this
+        sequence matches the step numbering in each EventSequence in
+        `event_lists`.
+    event_lists: A list of EventSequence objects.
+
+  Returns:
+    A nested list of chord the same length as `event_lists`, where each list is
+    the same length as the corresponding EventSequence (in events, not steps).
+  &#34;&#34;&#34;
+  sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+
+  chords = ChordProgression()
+  if quantized_sequence.total_quantized_steps &gt; 0:
+    chords.from_quantized_sequence(
+        quantized_sequence, 0, quantized_sequence.total_quantized_steps)
+
+  pad_chord = chords[-1] if chords else NO_CHORD
+
+  chord_lists = []
+  for e in event_lists:
+    chord_lists.append([chords[step] if step &lt; len(chords) else pad_chord
+                        for step in e.steps])
+
+  return chord_lists</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib.event_list_keys"><code class="name flex">
+<span>def <span class="ident">event_list_keys</span></span>(<span>sequence, event_lists, steps_per_second)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract corresponding keys for multiple EventSequences.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The underlying NoteSequence from which to extract the keys.</dd>
+<dt><strong><code>event_lists</code></strong></dt>
+<dd>A list of EventSequence objects.</dd>
+<dt><strong><code>steps_per_second</code></strong></dt>
+<dd>The number of quantized steps per second in the event
+lists.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A nested list of keys (integers 0-11 indicating the key signature) the same
+length as <code>event_lists</code>, where each list is the same length as the
+corresponding EventSequence (in events, not necessarily steps).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def event_list_keys(sequence, event_lists, steps_per_second):
+  &#34;&#34;&#34;Extract corresponding keys for multiple EventSequences.
+
+  Args:
+    sequence: The underlying NoteSequence from which to extract the keys.
+    event_lists: A list of EventSequence objects.
+    steps_per_second: The number of quantized steps per second in the event
+        lists.
+
+  Returns:
+    A nested list of keys (integers 0-11 indicating the key signature) the same
+    length as `event_lists`, where each list is the same length as the
+    corresponding EventSequence (in events, not necessarily steps).
+  &#34;&#34;&#34;
+  if not sequence.key_signatures:
+    raise ValueError(&#39;Sequence has no key signatures.&#39;)
+
+  key_changes = sorted((steps_per_second * ks.time, ks.key)
+                       for ks in sequence.key_signatures)
+  key_change_steps = [step for (step, _) in key_changes]
+
+  def step_to_key(step):
+    index = bisect.bisect(key_change_steps, step)
+    if index == 0:
+      # Step is before first key signature; just use that key.
+      return key_changes[0][1]
+    else:
+      return key_changes[index - 1][1]
+
+  key_lists = []
+  for e in event_lists:
+    key_lists.append([step_to_key(step) for step in e.steps])
+
+  return key_lists</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chords_lib.BadChordError"><code class="flex name class">
+<span>class <span class="ident">BadChordError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BadChordError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_lib.BasicChordRenderer"><code class="flex name class">
+<span>class <span class="ident">BasicChordRenderer</span></span>
+<span>(</span><span>velocity=100, instrument=1, program=88, octave=4, bass_octave=3)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A chord renderer that holds each note for the duration of the chord.</p>
+<p>Initialize a BasicChordRenderer object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>The MIDI note velocity to use.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>The MIDI instrument to use.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>The MIDI program to use.</dd>
+<dt><strong><code>octave</code></strong></dt>
+<dd>The octave in which to render chord notes. If the bass note is not
+otherwise part of the chord, it will not be rendered in this octave.</dd>
+<dt><strong><code>bass_octave</code></strong></dt>
+<dd>The octave in which to render chord bass notes.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BasicChordRenderer(ChordRenderer):
+  &#34;&#34;&#34;A chord renderer that holds each note for the duration of the chord.&#34;&#34;&#34;
+
+  def __init__(self,
+               velocity=100,
+               instrument=1,
+               program=88,
+               octave=4,
+               bass_octave=3):
+    &#34;&#34;&#34;Initialize a BasicChordRenderer object.
+
+    Args:
+      velocity: The MIDI note velocity to use.
+      instrument: The MIDI instrument to use.
+      program: The MIDI program to use.
+      octave: The octave in which to render chord notes. If the bass note is not
+          otherwise part of the chord, it will not be rendered in this octave.
+      bass_octave: The octave in which to render chord bass notes.
+    &#34;&#34;&#34;
+    self._velocity = velocity
+    self._instrument = instrument
+    self._program = program
+    self._octave = octave
+    self._bass_octave = bass_octave
+
+  def _render_notes(self, sequence, pitches, bass_pitch, start_time, end_time):
+    &#34;&#34;&#34;Renders notes.&#34;&#34;&#34;
+    all_pitches = []
+    for pitch in pitches:
+      all_pitches.append(12 * self._octave + pitch % 12)
+    all_pitches.append(12 * self._bass_octave + bass_pitch % 12)
+
+    for pitch in all_pitches:
+      # Add a note.
+      note = sequence.notes.add()
+      note.start_time = start_time
+      note.end_time = end_time
+      note.pitch = pitch
+      note.velocity = self._velocity
+      note.instrument = self._instrument
+      note.program = self._program
+
+  def render(self, sequence):
+    # Sort text annotations by time.
+    annotations = sorted(sequence.text_annotations, key=lambda a: a.time)
+
+    prev_time = 0.0
+    prev_figure = NO_CHORD
+
+    for annotation in annotations:
+      if annotation.time &gt;= sequence.total_time:
+        break
+
+      if annotation.annotation_type == CHORD_SYMBOL:
+        if prev_figure != NO_CHORD:
+          # Render the previous chord.
+          pitches = chord_symbols_lib.chord_symbol_pitches(prev_figure)
+          bass_pitch = chord_symbols_lib.chord_symbol_bass(prev_figure)
+          self._render_notes(sequence=sequence,
+                             pitches=pitches,
+                             bass_pitch=bass_pitch,
+                             start_time=prev_time,
+                             end_time=annotation.time)
+
+        prev_time = annotation.time
+        prev_figure = annotation.text
+
+    if (prev_time &lt; sequence.total_time and
+        prev_figure != NO_CHORD):
+      # Render the last chord.
+      pitches = chord_symbols_lib.chord_symbol_pitches(prev_figure)
+      bass_pitch = chord_symbols_lib.chord_symbol_bass(prev_figure)
+      self._render_notes(sequence=sequence,
+                         pitches=pitches,
+                         bass_pitch=bass_pitch,
+                         start_time=prev_time,
+                         end_time=sequence.total_time)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.chords_lib.ChordRenderer" href="#note_seq.chords_lib.ChordRenderer">ChordRenderer</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.chords_lib.ChordRenderer" href="#note_seq.chords_lib.ChordRenderer">ChordRenderer</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.chords_lib.ChordRenderer.render" href="#note_seq.chords_lib.ChordRenderer.render">render</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_lib.ChordProgression"><code class="flex name class">
+<span>class <span class="ident">ChordProgression</span></span>
+<span>(</span><span>events=None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a quantized stream of chord events.</p>
+<p>ChordProgression is an intermediate representation that all chord or lead
+sheet models can use. Chords are represented here by a chord symbol string;
+model-specific code is responsible for converting this representation to
+SequenceExample protos for TensorFlow.</p>
+<p>ChordProgression implements an iterable object. Simply iterate to retrieve
+the chord events.</p>
+<p>ChordProgression events are chord symbol strings like "Cm7", with special
+event NO_CHORD to indicate no chordal harmony. When a chord lasts for longer
+than a single step, the chord symbol event is repeated multiple times. Note
+that this is different from Melody, where the special MELODY_NO_EVENT is used
+for subsequent steps of sustained notes; in the case of harmony, there's no
+distinction between a repeated chord and a sustained chord.</p>
+<p>Chords must be inserted in ascending order by start time.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of the first step of the progression relative to the
+beginning of the source sequence.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>The offset to the beginning of the bar following the last step
+of the progression relative to the beginning of the source sequence.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Number of steps in in a quarter note.</dd>
+<dt><strong><code>steps_per_bar</code></strong></dt>
+<dd>Number of steps in a bar (measure) of music.</dd>
+</dl>
+<p>Construct a ChordProgression.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordProgression(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of chord events.
+
+  ChordProgression is an intermediate representation that all chord or lead
+  sheet models can use. Chords are represented here by a chord symbol string;
+  model-specific code is responsible for converting this representation to
+  SequenceExample protos for TensorFlow.
+
+  ChordProgression implements an iterable object. Simply iterate to retrieve
+  the chord events.
+
+  ChordProgression events are chord symbol strings like &#34;Cm7&#34;, with special
+  event NO_CHORD to indicate no chordal harmony. When a chord lasts for longer
+  than a single step, the chord symbol event is repeated multiple times. Note
+  that this is different from Melody, where the special MELODY_NO_EVENT is used
+  for subsequent steps of sustained notes; in the case of harmony, there&#39;s no
+  distinction between a repeated chord and a sustained chord.
+
+  Chords must be inserted in ascending order by start time.
+
+  Attributes:
+    start_step: The offset of the first step of the progression relative to the
+        beginning of the source sequence.
+    end_step: The offset to the beginning of the bar following the last step
+       of the progression relative to the beginning of the source sequence.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a ChordProgression.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(ChordProgression, self).__init__(pad_event=NO_CHORD,
+                                           events=events, **kwargs)
+
+  def _add_chord(self, figure, start_step, end_step):
+    &#34;&#34;&#34;Adds the given chord to the `events` list.
+
+    `start_step` is set to the given chord. Everything after `start_step` in
+    `events` is deleted before the chord is added. `events`&#39;s length will be
+     changed so that the last event has index `end_step` - 1.
+
+    Args:
+      figure: Chord symbol figure. A string like &#34;Cm9&#34; representing the chord.
+      start_step: A non-negative integer step that the chord begins on.
+      end_step: An integer step that the chord ends on. The chord is considered
+          to end at the onset of the end step. `end_step` must be greater than
+          `start_step`.
+
+    Raises:
+      BadChordError: If `start_step` does not precede `end_step`.
+    &#34;&#34;&#34;
+    if start_step &gt;= end_step:
+      raise BadChordError(
+          &#39;Start step does not precede end step: start=%d, end=%d&#39; %
+          (start_step, end_step))
+
+    self.set_length(end_step)
+
+    for i in range(start_step, end_step):
+      self._events[i] = figure
+
+  def from_quantized_sequence(self, quantized_sequence, start_step, end_step):
+    &#34;&#34;&#34;Populate self with the chords from the given quantized NoteSequence.
+
+    A chord progression is extracted from the given sequence starting at time
+    step `start_step` and ending at time step `end_step`.
+
+    The number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start populating chords at this time step.
+      end_step: Stop populating chords at this time step.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+      CoincidentChordsError: If any of the chords start on the same step.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signature.numerator,
+           quantized_sequence.time_signature.denominator))
+    self._steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Sort track by chord times.
+    chords = sorted([a for a in quantized_sequence.text_annotations
+                     if a.annotation_type == CHORD_SYMBOL],
+                    key=lambda chord: chord.quantized_step)
+
+    prev_step = None
+    prev_figure = NO_CHORD
+
+    for chord in chords:
+      if chord.quantized_step &gt;= end_step:
+        # No more chords within range.
+        break
+
+      elif chord.quantized_step &lt; start_step:
+        # Chord is before start of range.
+        prev_step = chord.quantized_step
+        prev_figure = chord.text
+        continue
+
+      if chord.quantized_step == prev_step:
+        if chord.text == prev_figure:
+          # Identical coincident chords, just skip.
+          continue
+        else:
+          # Two different chords start at the same time step.
+          self._reset()
+          raise CoincidentChordsError(
+              &#39;chords %s and %s are coincident&#39; % (prev_figure, chord.text))
+
+      if chord.quantized_step &gt; start_step:
+        # Add the previous chord.
+        if prev_step is None:
+          start_index = 0
+        else:
+          start_index = max(prev_step, start_step) - start_step
+        end_index = chord.quantized_step - start_step
+        self._add_chord(prev_figure, start_index, end_index)
+
+      prev_step = chord.quantized_step
+      prev_figure = chord.text
+
+    if prev_step is None or prev_step &lt; end_step:
+      # Add the last chord active before end_step.
+      if prev_step is None:
+        start_index = 0
+      else:
+        start_index = max(prev_step, start_step) - start_step
+      end_index = end_step - start_step
+      self._add_chord(prev_figure, start_index, end_index)
+
+    self._start_step = start_step
+    self._end_step = end_step
+
+  def to_sequence(self,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the ChordProgression to NoteSequence proto.
+
+    This doesn&#39;t generate actual notes, but text annotations specifying the
+    chord changes when they occur.
+
+    Args:
+      sequence_start_time: A time in seconds (float) that the first chord in
+          the sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given chords as text annotations.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    current_figure = NO_CHORD
+    for step, figure in enumerate(self):
+      if figure != current_figure:
+        current_figure = figure
+        chord = sequence.text_annotations.add()
+        chord.time = step * seconds_per_step + sequence_start_time
+        chord.text = figure
+        chord.annotation_type = CHORD_SYMBOL
+
+    return sequence
+
+  def transpose(self, transpose_amount):
+    &#34;&#34;&#34;Transpose chords in this ChordProgression.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this
+          ChordProgression. Positive values transpose up. Negative values
+          transpose down.
+
+    Raises:
+      ChordSymbolError: If a chord (other than &#34;no chord&#34;) fails to be
+          interpreted by the `chord_symbols_lib` module.
+    &#34;&#34;&#34;
+    for i in range(len(self._events)):
+      if self._events[i] != NO_CHORD:
+        self._events[i] = chord_symbols_lib.transpose_chord_symbol(
+            self._events[i], transpose_amount % NOTES_PER_OCTAVE)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.SimpleEventSequence" href="events_lib.html#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_lib.ChordProgression.from_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">from_quantized_sequence</span></span>(<span>self, quantized_sequence, start_step, end_step)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Populate self with the chords from the given quantized NoteSequence.</p>
+<p>A chord progression is extracted from the given sequence starting at time
+step <code>start_step</code> and ending at time step <code>end_step</code>.</p>
+<p>The number of time steps per bar is computed from the time signature in
+<code>quantized_sequence</code>.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A quantized NoteSequence instance.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>Start populating chords at this time step.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>Stop populating chords at this time step.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NonIntegerStepsPerBarError</code></dt>
+<dd>If <code>quantized_sequence</code>'s bar length
+(derived from its time signature) is not an integer number of time
+steps.</dd>
+<dt><code><a title="note_seq.chords_lib.CoincidentChordsError" href="#note_seq.chords_lib.CoincidentChordsError">CoincidentChordsError</a></code></dt>
+<dd>If any of the chords start on the same step.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def from_quantized_sequence(self, quantized_sequence, start_step, end_step):
+  &#34;&#34;&#34;Populate self with the chords from the given quantized NoteSequence.
+
+  A chord progression is extracted from the given sequence starting at time
+  step `start_step` and ending at time step `end_step`.
+
+  The number of time steps per bar is computed from the time signature in
+  `quantized_sequence`.
+
+  Args:
+    quantized_sequence: A quantized NoteSequence instance.
+    start_step: Start populating chords at this time step.
+    end_step: Stop populating chords at this time step.
+
+  Raises:
+    NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+        (derived from its time signature) is not an integer number of time
+        steps.
+    CoincidentChordsError: If any of the chords start on the same step.
+  &#34;&#34;&#34;
+  sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+  self._reset()
+
+  steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+      quantized_sequence)
+  if steps_per_bar_float % 1 != 0:
+    raise events_lib.NonIntegerStepsPerBarError(
+        &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+        (steps_per_bar_float, quantized_sequence.time_signature.numerator,
+         quantized_sequence.time_signature.denominator))
+  self._steps_per_bar = int(steps_per_bar_float)
+  self._steps_per_quarter = (
+      quantized_sequence.quantization_info.steps_per_quarter)
+
+  # Sort track by chord times.
+  chords = sorted([a for a in quantized_sequence.text_annotations
+                   if a.annotation_type == CHORD_SYMBOL],
+                  key=lambda chord: chord.quantized_step)
+
+  prev_step = None
+  prev_figure = NO_CHORD
+
+  for chord in chords:
+    if chord.quantized_step &gt;= end_step:
+      # No more chords within range.
+      break
+
+    elif chord.quantized_step &lt; start_step:
+      # Chord is before start of range.
+      prev_step = chord.quantized_step
+      prev_figure = chord.text
+      continue
+
+    if chord.quantized_step == prev_step:
+      if chord.text == prev_figure:
+        # Identical coincident chords, just skip.
+        continue
+      else:
+        # Two different chords start at the same time step.
+        self._reset()
+        raise CoincidentChordsError(
+            &#39;chords %s and %s are coincident&#39; % (prev_figure, chord.text))
+
+    if chord.quantized_step &gt; start_step:
+      # Add the previous chord.
+      if prev_step is None:
+        start_index = 0
+      else:
+        start_index = max(prev_step, start_step) - start_step
+      end_index = chord.quantized_step - start_step
+      self._add_chord(prev_figure, start_index, end_index)
+
+    prev_step = chord.quantized_step
+    prev_figure = chord.text
+
+  if prev_step is None or prev_step &lt; end_step:
+    # Add the last chord active before end_step.
+    if prev_step is None:
+      start_index = 0
+    else:
+      start_index = max(prev_step, start_step) - start_step
+    end_index = end_step - start_step
+    self._add_chord(prev_figure, start_index, end_index)
+
+  self._start_step = start_step
+  self._end_step = end_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib.ChordProgression.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, sequence_start_time=0.0, qpm=120.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the ChordProgression to NoteSequence proto.</p>
+<p>This doesn't generate actual notes, but text annotations specifying the
+chord changes when they occur.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence_start_time</code></strong></dt>
+<dd>A time in seconds (float) that the first chord in
+the sequence will land on.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Quarter notes per minute (float).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto encoding the given chords as text annotations.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                sequence_start_time=0.0,
+                qpm=120.0):
+  &#34;&#34;&#34;Converts the ChordProgression to NoteSequence proto.
+
+  This doesn&#39;t generate actual notes, but text annotations specifying the
+  chord changes when they occur.
+
+  Args:
+    sequence_start_time: A time in seconds (float) that the first chord in
+        the sequence will land on.
+    qpm: Quarter notes per minute (float).
+
+  Returns:
+    A NoteSequence proto encoding the given chords as text annotations.
+  &#34;&#34;&#34;
+  seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = STANDARD_PPQ
+
+  current_figure = NO_CHORD
+  for step, figure in enumerate(self):
+    if figure != current_figure:
+      current_figure = figure
+      chord = sequence.text_annotations.add()
+      chord.time = step * seconds_per_step + sequence_start_time
+      chord.text = figure
+      chord.annotation_type = CHORD_SYMBOL
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib.ChordProgression.transpose"><code class="name flex">
+<span>def <span class="ident">transpose</span></span>(<span>self, transpose_amount)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transpose chords in this ChordProgression.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>transpose_amount</code></strong></dt>
+<dd>The number of half steps to transpose this
+ChordProgression. Positive values transpose up. Negative values
+transpose down.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ChordSymbolError</code></dt>
+<dd>If a chord (other than "no chord") fails to be
+interpreted by the <code>chord_symbols_lib</code> module.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transpose(self, transpose_amount):
+  &#34;&#34;&#34;Transpose chords in this ChordProgression.
+
+  Args:
+    transpose_amount: The number of half steps to transpose this
+        ChordProgression. Positive values transpose up. Negative values
+        transpose down.
+
+  Raises:
+    ChordSymbolError: If a chord (other than &#34;no chord&#34;) fails to be
+        interpreted by the `chord_symbols_lib` module.
+  &#34;&#34;&#34;
+  for i in range(len(self._events)):
+    if self._events[i] != NO_CHORD:
+      self._events[i] = chord_symbols_lib.transpose_chord_symbol(
+          self._events[i], transpose_amount % NOTES_PER_OCTAVE)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.events_lib.SimpleEventSequence" href="events_lib.html#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.append" href="events_lib.html#note_seq.events_lib.SimpleEventSequence.append">append</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.increase_resolution" href="events_lib.html#note_seq.events_lib.SimpleEventSequence.increase_resolution">increase_resolution</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.set_length" href="events_lib.html#note_seq.events_lib.SimpleEventSequence.set_length">set_length</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.chords_lib.ChordRenderer"><code class="flex name class">
+<span>class <span class="ident">ChordRenderer</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>An abstract class for rendering NoteSequence chord symbols as notes.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordRenderer(object):
+  &#34;&#34;&#34;An abstract class for rendering NoteSequence chord symbols as notes.&#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def render(self, sequence):
+    &#34;&#34;&#34;Renders the chord symbols of a NoteSequence.
+
+    This function renders chord symbol annotations in a NoteSequence as actual
+    notes. Notes are added to the NoteSequence object, and the chord symbols
+    remain also.
+
+    Args:
+      sequence: The NoteSequence for which to render chord symbols.
+    &#34;&#34;&#34;
+    pass</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.chords_lib.BasicChordRenderer" href="#note_seq.chords_lib.BasicChordRenderer">BasicChordRenderer</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_lib.ChordRenderer.render"><code class="name flex">
+<span>def <span class="ident">render</span></span>(<span>self, sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Renders the chord symbols of a NoteSequence.</p>
+<p>This function renders chord symbol annotations in a NoteSequence as actual
+notes. Notes are added to the NoteSequence object, and the chord symbols
+remain also.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to render chord symbols.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def render(self, sequence):
+  &#34;&#34;&#34;Renders the chord symbols of a NoteSequence.
+
+  This function renders chord symbol annotations in a NoteSequence as actual
+  notes. Notes are added to the NoteSequence object, and the chord symbols
+  remain also.
+
+  Args:
+    sequence: The NoteSequence for which to render chord symbols.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.chords_lib.CoincidentChordsError"><code class="flex name class">
+<span>class <span class="ident">CoincidentChordsError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class CoincidentChordsError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.chords_lib.add_chords_to_sequence" href="#note_seq.chords_lib.add_chords_to_sequence">add_chords_to_sequence</a></code></li>
+<li><code><a title="note_seq.chords_lib.add_keys_to_sequence" href="#note_seq.chords_lib.add_keys_to_sequence">add_keys_to_sequence</a></code></li>
+<li><code><a title="note_seq.chords_lib.event_list_chords" href="#note_seq.chords_lib.event_list_chords">event_list_chords</a></code></li>
+<li><code><a title="note_seq.chords_lib.event_list_keys" href="#note_seq.chords_lib.event_list_keys">event_list_keys</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chords_lib.BadChordError" href="#note_seq.chords_lib.BadChordError">BadChordError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_lib.BasicChordRenderer" href="#note_seq.chords_lib.BasicChordRenderer">BasicChordRenderer</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_lib.ChordProgression" href="#note_seq.chords_lib.ChordProgression">ChordProgression</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_lib.ChordProgression.from_quantized_sequence" href="#note_seq.chords_lib.ChordProgression.from_quantized_sequence">from_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.chords_lib.ChordProgression.to_sequence" href="#note_seq.chords_lib.ChordProgression.to_sequence">to_sequence</a></code></li>
+<li><code><a title="note_seq.chords_lib.ChordProgression.transpose" href="#note_seq.chords_lib.ChordProgression.transpose">transpose</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_lib.ChordRenderer" href="#note_seq.chords_lib.ChordRenderer">ChordRenderer</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_lib.ChordRenderer.render" href="#note_seq.chords_lib.ChordRenderer.render">render</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.chords_lib.CoincidentChordsError" href="#note_seq.chords_lib.CoincidentChordsError">CoincidentChordsError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/chords_lib_test.html
+++ b/docs/chords_lib_test.html
@@ -1,0 +1,783 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.chords_lib_test API documentation</title>
+<meta name="description" content="Tests for chords_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.chords_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for chords_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for chords_lib.&#34;&#34;&#34;
+
+import copy
+
+from absl.testing import absltest
+from note_seq import chord_symbols_lib
+from note_seq import chords_lib
+from note_seq import constants
+from note_seq import melodies_lib
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+NO_CHORD = constants.NO_CHORD
+
+
+class ChordsLibTest(testing_lib.ProtoTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.steps_per_quarter = 1
+
+  def testTranspose(self):
+    # Transpose ChordProgression with basic triads.
+    events = [&#39;Cm&#39;, &#39;F&#39;, &#39;Bb&#39;, &#39;Eb&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=7)
+    expected = [&#39;Gm&#39;, &#39;C&#39;, &#39;F&#39;, &#39;Bb&#39;]
+    self.assertEqual(expected, list(chords))
+
+    # Transpose ChordProgression with more complex chords.
+    events = [&#39;Esus2&#39;, &#39;B13&#39;, &#39;A7/B&#39;, &#39;F#dim&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=-2)
+    expected = [&#39;Dsus2&#39;, &#39;A13&#39;, &#39;G7/A&#39;, &#39;Edim&#39;]
+    self.assertEqual(expected, list(chords))
+
+    # Transpose ChordProgression containing NO_CHORD.
+    events = [&#39;C&#39;, &#39;Bb&#39;, NO_CHORD, &#39;F&#39;, &#39;C&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=4)
+    expected = [&#39;E&#39;, &#39;D&#39;, NO_CHORD, &#39;A&#39;, &#39;E&#39;]
+    self.assertEqual(expected, list(chords))
+
+  def testTransposeUnknownChordSymbol(self):
+    # Attempt to transpose ChordProgression with unknown chord symbol.
+    events = [&#39;Cm&#39;, &#39;G7&#39;, &#39;P#13&#39;, &#39;F&#39;]
+    chords = chords_lib.ChordProgression(events)
+    with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+      chords.transpose(transpose_amount=-4)
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 14)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=0, end_step=16)
+    expected = [NO_CHORD, NO_CHORD, NO_CHORD, NO_CHORD,
+                &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;,
+                &#39;G13&#39;, &#39;G13&#39;, &#39;Csus&#39;, &#39;Csus&#39;]
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithinSingleChord(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence, [(&#39;F&#39;, 0), (&#39;Gm&#39;, 8)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=4, end_step=6)
+    expected = [&#39;F&#39;] * 2
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithNoChords(self):
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=0, end_step=16)
+    expected = [NO_CHORD] * 16
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithCoincidentChords(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 12)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    with self.assertRaises(chords_lib.CoincidentChordsError):
+      chords.from_quantized_sequence(
+          quantized_sequence, start_step=0, end_step=16)
+
+  def testToSequence(self):
+    chords = chords_lib.ChordProgression(
+        [NO_CHORD, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;Am7b5&#39;, &#39;F6&#39;, &#39;F6&#39;, NO_CHORD])
+    sequence = chords.to_sequence(sequence_start_time=2, qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;C7&#34; time: 2.25 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;Am7b5&#34; time: 3.25 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;F6&#34; time: 3.5 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;N.C.&#34; time: 4.0 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testEventListChordsWithMelodies(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_chords_to_sequence(
+        note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+    note_sequence.total_time = 8.0
+
+    melodies = [
+        melodies_lib.Melody([60, -2, -2, -1],
+                            start_step=0, steps_per_quarter=1, steps_per_bar=4),
+        melodies_lib.Melody([62, -2, -2, -1],
+                            start_step=4, steps_per_quarter=1, steps_per_bar=4),
+    ]
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        note_sequence, steps_per_quarter=1)
+    chords = chords_lib.event_list_chords(quantized_sequence, melodies)
+
+    expected_chords = [
+        [NO_CHORD, NO_CHORD, &#39;C&#39;, &#39;C&#39;],
+        [&#39;C&#39;, &#39;C&#39;, &#39;G7&#39;, &#39;G7&#39;]
+    ]
+
+    self.assertEqual(expected_chords, chords)
+
+  def testEventListKeysWithMelodies(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_key_signatures_to_sequence(note_sequence, [(6, 2), (0, 6)])
+    note_sequence.total_time = 8.0
+
+    melodies = [
+        melodies_lib.Melody([60, -2, -2, -1],
+                            start_step=0, steps_per_quarter=1, steps_per_bar=4),
+        melodies_lib.Melody([62, -2, -2, -1],
+                            start_step=4, steps_per_quarter=1, steps_per_bar=4),
+    ]
+
+    keys = chords_lib.event_list_keys(
+        note_sequence, melodies, steps_per_second=1)
+    expected_keys = [[6, 6, 6, 6], [6, 6, 0, 0]]
+
+    self.assertEqual(expected_keys, keys)
+
+  def testAddChordsToSequence(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_chords_to_sequence(
+        note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+    note_sequence.total_time = 8.0
+
+    expected_sequence = copy.deepcopy(note_sequence)
+    del note_sequence.text_annotations[:]
+
+    chords = [NO_CHORD, &#39;C&#39;, &#39;C&#39;, &#39;G7&#39;]
+    chord_times = [0.0, 2.0, 4.0, 6.0]
+    chords_lib.add_chords_to_sequence(note_sequence, chords, chord_times)
+
+    self.assertEqual(expected_sequence, note_sequence)
+
+  def testAddKeysToSequence(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_key_signatures_to_sequence(note_sequence, [(0, 2), (7, 6)])
+    note_sequence.total_time = 8.0
+
+    expected_sequence = copy.deepcopy(note_sequence)
+    del note_sequence.key_signatures[:]
+
+    keys = [0, 0, 7]
+    key_times = [2.0, 4.0, 6.0]
+    chords_lib.add_keys_to_sequence(note_sequence, keys, key_times)
+
+    self.assertEqual(expected_sequence, note_sequence)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.chords_lib_test.ChordsLibTest"><code class="flex name class">
+<span>class <span class="ident">ChordsLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordsLibTest(testing_lib.ProtoTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.steps_per_quarter = 1
+
+  def testTranspose(self):
+    # Transpose ChordProgression with basic triads.
+    events = [&#39;Cm&#39;, &#39;F&#39;, &#39;Bb&#39;, &#39;Eb&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=7)
+    expected = [&#39;Gm&#39;, &#39;C&#39;, &#39;F&#39;, &#39;Bb&#39;]
+    self.assertEqual(expected, list(chords))
+
+    # Transpose ChordProgression with more complex chords.
+    events = [&#39;Esus2&#39;, &#39;B13&#39;, &#39;A7/B&#39;, &#39;F#dim&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=-2)
+    expected = [&#39;Dsus2&#39;, &#39;A13&#39;, &#39;G7/A&#39;, &#39;Edim&#39;]
+    self.assertEqual(expected, list(chords))
+
+    # Transpose ChordProgression containing NO_CHORD.
+    events = [&#39;C&#39;, &#39;Bb&#39;, NO_CHORD, &#39;F&#39;, &#39;C&#39;]
+    chords = chords_lib.ChordProgression(events)
+    chords.transpose(transpose_amount=4)
+    expected = [&#39;E&#39;, &#39;D&#39;, NO_CHORD, &#39;A&#39;, &#39;E&#39;]
+    self.assertEqual(expected, list(chords))
+
+  def testTransposeUnknownChordSymbol(self):
+    # Attempt to transpose ChordProgression with unknown chord symbol.
+    events = [&#39;Cm&#39;, &#39;G7&#39;, &#39;P#13&#39;, &#39;F&#39;]
+    chords = chords_lib.ChordProgression(events)
+    with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+      chords.transpose(transpose_amount=-4)
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 14)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=0, end_step=16)
+    expected = [NO_CHORD, NO_CHORD, NO_CHORD, NO_CHORD,
+                &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;,
+                &#39;G13&#39;, &#39;G13&#39;, &#39;Csus&#39;, &#39;Csus&#39;]
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithinSingleChord(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence, [(&#39;F&#39;, 0), (&#39;Gm&#39;, 8)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=4, end_step=6)
+    expected = [&#39;F&#39;] * 2
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithNoChords(self):
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=0, end_step=16)
+    expected = [NO_CHORD] * 16
+    self.assertEqual(expected, list(chords))
+
+  def testFromQuantizedNoteSequenceWithCoincidentChords(self):
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 12)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    chords = chords_lib.ChordProgression()
+    with self.assertRaises(chords_lib.CoincidentChordsError):
+      chords.from_quantized_sequence(
+          quantized_sequence, start_step=0, end_step=16)
+
+  def testToSequence(self):
+    chords = chords_lib.ChordProgression(
+        [NO_CHORD, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;Am7b5&#39;, &#39;F6&#39;, &#39;F6&#39;, NO_CHORD])
+    sequence = chords.to_sequence(sequence_start_time=2, qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;C7&#34; time: 2.25 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;Am7b5&#34; time: 3.25 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;F6&#34; time: 3.5 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;
+        &#39;text_annotations &lt; &#39;
+        &#39;  text: &#34;N.C.&#34; time: 4.0 annotation_type: CHORD_SYMBOL &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testEventListChordsWithMelodies(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_chords_to_sequence(
+        note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+    note_sequence.total_time = 8.0
+
+    melodies = [
+        melodies_lib.Melody([60, -2, -2, -1],
+                            start_step=0, steps_per_quarter=1, steps_per_bar=4),
+        melodies_lib.Melody([62, -2, -2, -1],
+                            start_step=4, steps_per_quarter=1, steps_per_bar=4),
+    ]
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        note_sequence, steps_per_quarter=1)
+    chords = chords_lib.event_list_chords(quantized_sequence, melodies)
+
+    expected_chords = [
+        [NO_CHORD, NO_CHORD, &#39;C&#39;, &#39;C&#39;],
+        [&#39;C&#39;, &#39;C&#39;, &#39;G7&#39;, &#39;G7&#39;]
+    ]
+
+    self.assertEqual(expected_chords, chords)
+
+  def testEventListKeysWithMelodies(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_key_signatures_to_sequence(note_sequence, [(6, 2), (0, 6)])
+    note_sequence.total_time = 8.0
+
+    melodies = [
+        melodies_lib.Melody([60, -2, -2, -1],
+                            start_step=0, steps_per_quarter=1, steps_per_bar=4),
+        melodies_lib.Melody([62, -2, -2, -1],
+                            start_step=4, steps_per_quarter=1, steps_per_bar=4),
+    ]
+
+    keys = chords_lib.event_list_keys(
+        note_sequence, melodies, steps_per_second=1)
+    expected_keys = [[6, 6, 6, 6], [6, 6, 0, 0]]
+
+    self.assertEqual(expected_keys, keys)
+
+  def testAddChordsToSequence(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_chords_to_sequence(
+        note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+    note_sequence.total_time = 8.0
+
+    expected_sequence = copy.deepcopy(note_sequence)
+    del note_sequence.text_annotations[:]
+
+    chords = [NO_CHORD, &#39;C&#39;, &#39;C&#39;, &#39;G7&#39;]
+    chord_times = [0.0, 2.0, 4.0, 6.0]
+    chords_lib.add_chords_to_sequence(note_sequence, chords, chord_times)
+
+    self.assertEqual(expected_sequence, note_sequence)
+
+  def testAddKeysToSequence(self):
+    note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+    note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_key_signatures_to_sequence(note_sequence, [(0, 2), (7, 6)])
+    note_sequence.total_time = 8.0
+
+    expected_sequence = copy.deepcopy(note_sequence)
+    del note_sequence.key_signatures[:]
+
+    keys = [0, 0, 7]
+    key_times = [2.0, 4.0, 6.0]
+    chords_lib.add_keys_to_sequence(note_sequence, keys, key_times)
+
+    self.assertEqual(expected_sequence, note_sequence)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testAddChordsToSequence"><code class="name flex">
+<span>def <span class="ident">testAddChordsToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAddChordsToSequence(self):
+  note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+  note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_chords_to_sequence(
+      note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+  note_sequence.total_time = 8.0
+
+  expected_sequence = copy.deepcopy(note_sequence)
+  del note_sequence.text_annotations[:]
+
+  chords = [NO_CHORD, &#39;C&#39;, &#39;C&#39;, &#39;G7&#39;]
+  chord_times = [0.0, 2.0, 4.0, 6.0]
+  chords_lib.add_chords_to_sequence(note_sequence, chords, chord_times)
+
+  self.assertEqual(expected_sequence, note_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testAddKeysToSequence"><code class="name flex">
+<span>def <span class="ident">testAddKeysToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAddKeysToSequence(self):
+  note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+  note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_key_signatures_to_sequence(note_sequence, [(0, 2), (7, 6)])
+  note_sequence.total_time = 8.0
+
+  expected_sequence = copy.deepcopy(note_sequence)
+  del note_sequence.key_signatures[:]
+
+  keys = [0, 0, 7]
+  key_times = [2.0, 4.0, 6.0]
+  chords_lib.add_keys_to_sequence(note_sequence, keys, key_times)
+
+  self.assertEqual(expected_sequence, note_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testEventListChordsWithMelodies"><code class="name flex">
+<span>def <span class="ident">testEventListChordsWithMelodies</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventListChordsWithMelodies(self):
+  note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+  note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_chords_to_sequence(
+      note_sequence, [(&#39;N.C.&#39;, 0), (&#39;C&#39;, 2), (&#39;G7&#39;, 6)])
+  note_sequence.total_time = 8.0
+
+  melodies = [
+      melodies_lib.Melody([60, -2, -2, -1],
+                          start_step=0, steps_per_quarter=1, steps_per_bar=4),
+      melodies_lib.Melody([62, -2, -2, -1],
+                          start_step=4, steps_per_quarter=1, steps_per_bar=4),
+  ]
+
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      note_sequence, steps_per_quarter=1)
+  chords = chords_lib.event_list_chords(quantized_sequence, melodies)
+
+  expected_chords = [
+      [NO_CHORD, NO_CHORD, &#39;C&#39;, &#39;C&#39;],
+      [&#39;C&#39;, &#39;C&#39;, &#39;G7&#39;, &#39;G7&#39;]
+  ]
+
+  self.assertEqual(expected_chords, chords)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testEventListKeysWithMelodies"><code class="name flex">
+<span>def <span class="ident">testEventListKeysWithMelodies</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventListKeysWithMelodies(self):
+  note_sequence = music_pb2.NoteSequence(ticks_per_quarter=220)
+  note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_key_signatures_to_sequence(note_sequence, [(6, 2), (0, 6)])
+  note_sequence.total_time = 8.0
+
+  melodies = [
+      melodies_lib.Melody([60, -2, -2, -1],
+                          start_step=0, steps_per_quarter=1, steps_per_bar=4),
+      melodies_lib.Melody([62, -2, -2, -1],
+                          start_step=4, steps_per_quarter=1, steps_per_bar=4),
+  ]
+
+  keys = chords_lib.event_list_keys(
+      note_sequence, melodies, steps_per_second=1)
+  expected_keys = [[6, 6, 6, 6], [6, 6, 0, 0]]
+
+  self.assertEqual(expected_keys, keys)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence(self):
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence,
+      [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 14)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  chords = chords_lib.ChordProgression()
+  chords.from_quantized_sequence(
+      quantized_sequence, start_step=0, end_step=16)
+  expected = [NO_CHORD, NO_CHORD, NO_CHORD, NO_CHORD,
+              &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;Am&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;, &#39;D7&#39;,
+              &#39;G13&#39;, &#39;G13&#39;, &#39;Csus&#39;, &#39;Csus&#39;]
+  self.assertEqual(expected, list(chords))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithCoincidentChords"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceWithCoincidentChords</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceWithCoincidentChords(self):
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence,
+      [(&#39;Am&#39;, 4), (&#39;D7&#39;, 8), (&#39;G13&#39;, 12), (&#39;Csus&#39;, 12)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  chords = chords_lib.ChordProgression()
+  with self.assertRaises(chords_lib.CoincidentChordsError):
+    chords.from_quantized_sequence(
+        quantized_sequence, start_step=0, end_step=16)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithNoChords"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceWithNoChords</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceWithNoChords(self):
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  chords = chords_lib.ChordProgression()
+  chords.from_quantized_sequence(
+      quantized_sequence, start_step=0, end_step=16)
+  expected = [NO_CHORD] * 16
+  self.assertEqual(expected, list(chords))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithinSingleChord"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceWithinSingleChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceWithinSingleChord(self):
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence, [(&#39;F&#39;, 0), (&#39;Gm&#39;, 8)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  chords = chords_lib.ChordProgression()
+  chords.from_quantized_sequence(
+      quantized_sequence, start_step=4, end_step=6)
+  expected = [&#39;F&#39;] * 2
+  self.assertEqual(expected, list(chords))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testToSequence"><code class="name flex">
+<span>def <span class="ident">testToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequence(self):
+  chords = chords_lib.ChordProgression(
+      [NO_CHORD, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;C7&#39;, &#39;Am7b5&#39;, &#39;F6&#39;, &#39;F6&#39;, NO_CHORD])
+  sequence = chords.to_sequence(sequence_start_time=2, qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;text_annotations &lt; &#39;
+      &#39;  text: &#34;C7&#34; time: 2.25 annotation_type: CHORD_SYMBOL &#39;
+      &#39;&gt; &#39;
+      &#39;text_annotations &lt; &#39;
+      &#39;  text: &#34;Am7b5&#34; time: 3.25 annotation_type: CHORD_SYMBOL &#39;
+      &#39;&gt; &#39;
+      &#39;text_annotations &lt; &#39;
+      &#39;  text: &#34;F6&#34; time: 3.5 annotation_type: CHORD_SYMBOL &#39;
+      &#39;&gt; &#39;
+      &#39;text_annotations &lt; &#39;
+      &#39;  text: &#34;N.C.&#34; time: 4.0 annotation_type: CHORD_SYMBOL &#39;
+      &#39;&gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testTranspose"><code class="name flex">
+<span>def <span class="ident">testTranspose</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTranspose(self):
+  # Transpose ChordProgression with basic triads.
+  events = [&#39;Cm&#39;, &#39;F&#39;, &#39;Bb&#39;, &#39;Eb&#39;]
+  chords = chords_lib.ChordProgression(events)
+  chords.transpose(transpose_amount=7)
+  expected = [&#39;Gm&#39;, &#39;C&#39;, &#39;F&#39;, &#39;Bb&#39;]
+  self.assertEqual(expected, list(chords))
+
+  # Transpose ChordProgression with more complex chords.
+  events = [&#39;Esus2&#39;, &#39;B13&#39;, &#39;A7/B&#39;, &#39;F#dim&#39;]
+  chords = chords_lib.ChordProgression(events)
+  chords.transpose(transpose_amount=-2)
+  expected = [&#39;Dsus2&#39;, &#39;A13&#39;, &#39;G7/A&#39;, &#39;Edim&#39;]
+  self.assertEqual(expected, list(chords))
+
+  # Transpose ChordProgression containing NO_CHORD.
+  events = [&#39;C&#39;, &#39;Bb&#39;, NO_CHORD, &#39;F&#39;, &#39;C&#39;]
+  chords = chords_lib.ChordProgression(events)
+  chords.transpose(transpose_amount=4)
+  expected = [&#39;E&#39;, &#39;D&#39;, NO_CHORD, &#39;A&#39;, &#39;E&#39;]
+  self.assertEqual(expected, list(chords))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.chords_lib_test.ChordsLibTest.testTransposeUnknownChordSymbol"><code class="name flex">
+<span>def <span class="ident">testTransposeUnknownChordSymbol</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTransposeUnknownChordSymbol(self):
+  # Attempt to transpose ChordProgression with unknown chord symbol.
+  events = [&#39;Cm&#39;, &#39;G7&#39;, &#39;P#13&#39;, &#39;F&#39;]
+  chords = chords_lib.ChordProgression(events)
+  with self.assertRaises(chord_symbols_lib.ChordSymbolError):
+    chords.transpose(transpose_amount=-4)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.chords_lib_test.ChordsLibTest" href="#note_seq.chords_lib_test.ChordsLibTest">ChordsLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testAddChordsToSequence" href="#note_seq.chords_lib_test.ChordsLibTest.testAddChordsToSequence">testAddChordsToSequence</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testAddKeysToSequence" href="#note_seq.chords_lib_test.ChordsLibTest.testAddKeysToSequence">testAddKeysToSequence</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testEventListChordsWithMelodies" href="#note_seq.chords_lib_test.ChordsLibTest.testEventListChordsWithMelodies">testEventListChordsWithMelodies</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testEventListKeysWithMelodies" href="#note_seq.chords_lib_test.ChordsLibTest.testEventListKeysWithMelodies">testEventListKeysWithMelodies</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequence" href="#note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequence">testFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithCoincidentChords" href="#note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithCoincidentChords">testFromQuantizedNoteSequenceWithCoincidentChords</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithNoChords" href="#note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithNoChords">testFromQuantizedNoteSequenceWithNoChords</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithinSingleChord" href="#note_seq.chords_lib_test.ChordsLibTest.testFromQuantizedNoteSequenceWithinSingleChord">testFromQuantizedNoteSequenceWithinSingleChord</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testToSequence" href="#note_seq.chords_lib_test.ChordsLibTest.testToSequence">testToSequence</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testTranspose" href="#note_seq.chords_lib_test.ChordsLibTest.testTranspose">testTranspose</a></code></li>
+<li><code><a title="note_seq.chords_lib_test.ChordsLibTest.testTransposeUnknownChordSymbol" href="#note_seq.chords_lib_test.ChordsLibTest.testTransposeUnknownChordSymbol">testTransposeUnknownChordSymbol</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/constants.html
+++ b/docs/constants.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.constants API documentation</title>
+<meta name="description" content="Constants for music processing in Magenta." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.constants</code></h1>
+</header>
+<section id="section-intro">
+<p>Constants for music processing in Magenta.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Constants for music processing in Magenta.&#34;&#34;&#34;
+
+# Meter-related constants.
+DEFAULT_QUARTERS_PER_MINUTE = 120.0
+DEFAULT_STEPS_PER_BAR = 16  # 4/4 music sampled at 4 steps per quarter note.
+DEFAULT_STEPS_PER_QUARTER = 4
+
+# Default absolute quantization.
+DEFAULT_STEPS_PER_SECOND = 100
+
+# Standard pulses per quarter.
+# https://en.wikipedia.org/wiki/Pulses_per_quarter_note
+STANDARD_PPQ = 220
+
+# Special melody events.
+NUM_SPECIAL_MELODY_EVENTS = 2
+MELODY_NOTE_OFF = -1
+MELODY_NO_EVENT = -2
+
+# Other melody-related constants.
+MIN_MELODY_EVENT = -2
+MAX_MELODY_EVENT = 127
+MIN_MIDI_PITCH = 0  # Inclusive.
+MAX_MIDI_PITCH = 127  # Inclusive.
+NUM_MIDI_PITCHES = MAX_MIDI_PITCH - MIN_MIDI_PITCH + 1
+NOTES_PER_OCTAVE = 12
+
+# Velocity-related constants.
+MIN_MIDI_VELOCITY = 1  # Inclusive.
+MAX_MIDI_VELOCITY = 127  # Inclusive.
+
+# Program-related constants.
+MIN_MIDI_PROGRAM = 0
+MAX_MIDI_PROGRAM = 127
+
+# MIDI programs that typically sound unpitched.
+UNPITCHED_PROGRAMS = (
+    list(range(96, 104)) + list(range(112, 120)) + list(range(120, 128)))
+
+# Chord symbol for &#34;no chord&#34;.
+NO_CHORD = &#39;N.C.&#39;
+
+# The indices of the pitch classes in a major scale.
+MAJOR_SCALE = [0, 2, 4, 5, 7, 9, 11]
+
+# NOTE_KEYS[note] = The major keys that note belongs to.
+# ex. NOTE_KEYS[0] lists all the major keys that contain the note C,
+# which are:
+# [0, 1, 3, 5, 7, 8, 10]
+# [C, C#, D#, F, G, G#, A#]
+#
+# 0 = C
+# 1 = C#
+# 2 = D
+# 3 = D#
+# 4 = E
+# 5 = F
+# 6 = F#
+# 7 = G
+# 8 = G#
+# 9 = A
+# 10 = A#
+# 11 = B
+#
+# NOTE_KEYS can be generated using the code below, but is explicitly declared
+# for readability:
+# NOTE_KEYS = [[j for j in range(12) if (i - j) % 12 in MAJOR_SCALE]
+#              for i in range(12)]
+NOTE_KEYS = [
+    [0, 1, 3, 5, 7, 8, 10],
+    [1, 2, 4, 6, 8, 9, 11],
+    [0, 2, 3, 5, 7, 9, 10],
+    [1, 3, 4, 6, 8, 10, 11],
+    [0, 2, 4, 5, 7, 9, 11],
+    [0, 1, 3, 5, 6, 8, 10],
+    [1, 2, 4, 6, 7, 9, 11],
+    [0, 2, 3, 5, 7, 8, 10],
+    [1, 3, 4, 6, 8, 9, 11],
+    [0, 2, 4, 5, 7, 9, 10],
+    [1, 3, 5, 6, 8, 10, 11],
+    [0, 2, 4, 6, 7, 9, 11]
+]</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/drums_encoder_decoder.html
+++ b/docs/drums_encoder_decoder.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.drums_encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between drum tracks and models inputs/outputs." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.drums_encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between drum tracks and models inputs/outputs.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between drum tracks and models inputs/outputs.&#34;&#34;&#34;
+
+from note_seq import encoder_decoder
+
+# Default list of 9 drum types, where each type is represented by a list of
+# MIDI pitches for drum sounds belonging to that type. This default list
+# attempts to map all GM1 and GM2 drums onto a much smaller standard drum kit
+# based on drum sound and function.
+DEFAULT_DRUM_TYPE_PITCHES = [
+    # kick drum
+    [36, 35],
+
+    # snare drum
+    [38, 27, 28, 31, 32, 33, 34, 37, 39, 40, 56, 65, 66, 75, 85],
+
+    # closed hi-hat
+    [42, 44, 54, 68, 69, 70, 71, 73, 78, 80, 22],
+
+    # open hi-hat
+    [46, 67, 72, 74, 79, 81, 26],
+
+    # low tom
+    [45, 29, 41, 43, 61, 64, 84],
+
+    # mid tom
+    [48, 47, 60, 63, 77, 86, 87],
+
+    # high tom
+    [50, 30, 62, 76, 83],
+
+    # crash cymbal
+    [49, 52, 55, 57, 58],
+
+    # ride cymbal
+    [51, 53, 59, 82]
+]
+
+
+class DrumsEncodingError(Exception):
+  pass
+
+
+class MultiDrumOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes drum events as binary where each bit is a different drum type.
+
+  Each event consists of multiple simultaneous drum &#34;pitches&#34;. This encoding
+  converts each pitch to a drum type, e.g. bass drum, hi-hat, etc. Each drum
+  type is mapped to a single bit of a binary integer representation, where the
+  bit has value 0 if the drum type is not present, and 1 if it is present.
+
+  If multiple &#34;pitches&#34; corresponding to the same drum type (e.g. two different
+  ride cymbals) are present, the encoding is the same as if only one of them
+  were present.
+  &#34;&#34;&#34;
+
+  def __init__(self, drum_type_pitches=None, ignore_unknown_drums=True):
+    &#34;&#34;&#34;Initializes the MultiDrumOneHotEncoding.
+
+    Args:
+      drum_type_pitches: A Python list of the MIDI pitch values for each drum
+          type. If None, `DEFAULT_DRUM_TYPE_PITCHES` will be used.
+      ignore_unknown_drums: If True, unknown drum pitches will not be encoded.
+          If False, a DrumsEncodingError will be raised when unknown drum
+          pitches are encountered.
+    &#34;&#34;&#34;
+    if drum_type_pitches is None:
+      drum_type_pitches = DEFAULT_DRUM_TYPE_PITCHES
+    self._drum_map = dict(enumerate(drum_type_pitches))
+    self._inverse_drum_map = dict((pitch, index)
+                                  for index, pitches in self._drum_map.items()
+                                  for pitch in pitches)
+    self._ignore_unknown_drums = ignore_unknown_drums
+
+  @property
+  def num_classes(self):
+    return 2 ** len(self._drum_map)
+
+  @property
+  def default_event(self):
+    return frozenset()
+
+  def encode_event(self, event):
+    drum_type_indices = set()
+    for pitch in event:
+      if pitch in self._inverse_drum_map:
+        drum_type_indices.add(self._inverse_drum_map[pitch])
+      elif not self._ignore_unknown_drums:
+        raise DrumsEncodingError(&#39;unknown drum pitch: %d&#39; % pitch)
+    return sum(2 ** i for i in drum_type_indices)
+
+  def decode_event(self, index):
+    bits = reversed(str(bin(index)))
+    # Use the first &#34;pitch&#34; for each drum type.
+    return frozenset(self._drum_map[i][0]
+                     for i, b in enumerate(bits)
+                     if b == &#39;1&#39;)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.drums_encoder_decoder.DrumsEncodingError"><code class="flex name class">
+<span>class <span class="ident">DrumsEncodingError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DrumsEncodingError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.drums_encoder_decoder.MultiDrumOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">MultiDrumOneHotEncoding</span></span>
+<span>(</span><span>drum_type_pitches=None, ignore_unknown_drums=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Encodes drum events as binary where each bit is a different drum type.</p>
+<p>Each event consists of multiple simultaneous drum "pitches". This encoding
+converts each pitch to a drum type, e.g. bass drum, hi-hat, etc. Each drum
+type is mapped to a single bit of a binary integer representation, where the
+bit has value 0 if the drum type is not present, and 1 if it is present.</p>
+<p>If multiple "pitches" corresponding to the same drum type (e.g. two different
+ride cymbals) are present, the encoding is the same as if only one of them
+were present.</p>
+<p>Initializes the MultiDrumOneHotEncoding.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>drum_type_pitches</code></strong></dt>
+<dd>A Python list of the MIDI pitch values for each drum
+type. If None, <code>DEFAULT_DRUM_TYPE_PITCHES</code> will be used.</dd>
+<dt><strong><code>ignore_unknown_drums</code></strong></dt>
+<dd>If True, unknown drum pitches will not be encoded.
+If False, a DrumsEncodingError will be raised when unknown drum
+pitches are encountered.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultiDrumOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Encodes drum events as binary where each bit is a different drum type.
+
+  Each event consists of multiple simultaneous drum &#34;pitches&#34;. This encoding
+  converts each pitch to a drum type, e.g. bass drum, hi-hat, etc. Each drum
+  type is mapped to a single bit of a binary integer representation, where the
+  bit has value 0 if the drum type is not present, and 1 if it is present.
+
+  If multiple &#34;pitches&#34; corresponding to the same drum type (e.g. two different
+  ride cymbals) are present, the encoding is the same as if only one of them
+  were present.
+  &#34;&#34;&#34;
+
+  def __init__(self, drum_type_pitches=None, ignore_unknown_drums=True):
+    &#34;&#34;&#34;Initializes the MultiDrumOneHotEncoding.
+
+    Args:
+      drum_type_pitches: A Python list of the MIDI pitch values for each drum
+          type. If None, `DEFAULT_DRUM_TYPE_PITCHES` will be used.
+      ignore_unknown_drums: If True, unknown drum pitches will not be encoded.
+          If False, a DrumsEncodingError will be raised when unknown drum
+          pitches are encountered.
+    &#34;&#34;&#34;
+    if drum_type_pitches is None:
+      drum_type_pitches = DEFAULT_DRUM_TYPE_PITCHES
+    self._drum_map = dict(enumerate(drum_type_pitches))
+    self._inverse_drum_map = dict((pitch, index)
+                                  for index, pitches in self._drum_map.items()
+                                  for pitch in pitches)
+    self._ignore_unknown_drums = ignore_unknown_drums
+
+  @property
+  def num_classes(self):
+    return 2 ** len(self._drum_map)
+
+  @property
+  def default_event(self):
+    return frozenset()
+
+  def encode_event(self, event):
+    drum_type_indices = set()
+    for pitch in event:
+      if pitch in self._inverse_drum_map:
+        drum_type_indices.add(self._inverse_drum_map[pitch])
+      elif not self._ignore_unknown_drums:
+        raise DrumsEncodingError(&#39;unknown drum pitch: %d&#39; % pitch)
+    return sum(2 ** i for i in drum_type_indices)
+
+  def decode_event(self, index):
+    bits = reversed(str(bin(index)))
+    # Use the first &#34;pitch&#34; for each drum type.
+    return frozenset(self._drum_map[i][0]
+                     for i, b in enumerate(bits)
+                     if b == &#39;1&#39;)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.drums_encoder_decoder.DrumsEncodingError" href="#note_seq.drums_encoder_decoder.DrumsEncodingError">DrumsEncodingError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.drums_encoder_decoder.MultiDrumOneHotEncoding" href="#note_seq.drums_encoder_decoder.MultiDrumOneHotEncoding">MultiDrumOneHotEncoding</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/drums_encoder_decoder_test.html
+++ b/docs/drums_encoder_decoder_test.html
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.drums_encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for drums_encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.drums_encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for drums_encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for drums_encoder_decoder.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import drums_encoder_decoder
+
+
+DRUMS = lambda *args: frozenset(args)
+NO_DRUMS = frozenset()
+
+
+def _index_to_binary(index):
+  fmt = &#39;%%0%dd&#39; % len(drums_encoder_decoder.DEFAULT_DRUM_TYPE_PITCHES)
+  return fmt % int(bin(index)[2:])
+
+
+class MultiDrumOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = drums_encoder_decoder.MultiDrumOneHotEncoding()
+
+  def testEncode(self):
+    # No drums should encode to zero.
+    index = self.enc.encode_event(NO_DRUMS)
+    self.assertEqual(0, index)
+
+    # Single drum should encode to single bit active, different for different
+    # drum types.
+    index1 = self.enc.encode_event(DRUMS(35))
+    index2 = self.enc.encode_event(DRUMS(44))
+    self.assertEqual(1, _index_to_binary(index1).count(&#39;1&#39;))
+    self.assertEqual(1, _index_to_binary(index2).count(&#39;1&#39;))
+    self.assertNotEqual(index1, index2)
+
+    # Multiple drums should encode to multiple bits active, one for each drum
+    # type.
+    index = self.enc.encode_event(DRUMS(40, 44))
+    self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))
+    index = self.enc.encode_event(DRUMS(35, 51, 59))
+    self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))
+
+  def testDecode(self):
+    # Zero should decode to no drums.
+    event = self.enc.decode_event(0)
+    self.assertEqual(NO_DRUMS, event)
+
+    # Single bit active should encode to single drum, different for different
+    # bits.
+    event1 = self.enc.decode_event(1)
+    event2 = self.enc.decode_event(
+        2 ** (len(drums_encoder_decoder.DEFAULT_DRUM_TYPE_PITCHES) // 2))
+    self.assertEqual(frozenset, type(event1))
+    self.assertEqual(frozenset, type(event2))
+    self.assertLen(event1, 1)
+    self.assertLen(event2, 1)
+    self.assertNotEqual(event1, event2)
+
+    # Multiple bits active should encode to multiple drums.
+    event = self.enc.decode_event(7)
+    self.assertEqual(frozenset, type(event))
+    self.assertLen(event, 3)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.drums_encoder_decoder_test.DRUMS"><code class="name flex">
+<span>def <span class="ident">DRUMS</span></span>(<span>*args)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">DRUMS = lambda *args: frozenset(args)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest"><code class="flex name class">
+<span>class <span class="ident">MultiDrumOneHotEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultiDrumOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = drums_encoder_decoder.MultiDrumOneHotEncoding()
+
+  def testEncode(self):
+    # No drums should encode to zero.
+    index = self.enc.encode_event(NO_DRUMS)
+    self.assertEqual(0, index)
+
+    # Single drum should encode to single bit active, different for different
+    # drum types.
+    index1 = self.enc.encode_event(DRUMS(35))
+    index2 = self.enc.encode_event(DRUMS(44))
+    self.assertEqual(1, _index_to_binary(index1).count(&#39;1&#39;))
+    self.assertEqual(1, _index_to_binary(index2).count(&#39;1&#39;))
+    self.assertNotEqual(index1, index2)
+
+    # Multiple drums should encode to multiple bits active, one for each drum
+    # type.
+    index = self.enc.encode_event(DRUMS(40, 44))
+    self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))
+    index = self.enc.encode_event(DRUMS(35, 51, 59))
+    self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))
+
+  def testDecode(self):
+    # Zero should decode to no drums.
+    event = self.enc.decode_event(0)
+    self.assertEqual(NO_DRUMS, event)
+
+    # Single bit active should encode to single drum, different for different
+    # bits.
+    event1 = self.enc.decode_event(1)
+    event2 = self.enc.decode_event(
+        2 ** (len(drums_encoder_decoder.DEFAULT_DRUM_TYPE_PITCHES) // 2))
+    self.assertEqual(frozenset, type(event1))
+    self.assertEqual(frozenset, type(event2))
+    self.assertLen(event1, 1)
+    self.assertLen(event2, 1)
+    self.assertNotEqual(event1, event2)
+
+    # Multiple bits active should encode to multiple drums.
+    event = self.enc.decode_event(7)
+    self.assertEqual(frozenset, type(event))
+    self.assertLen(event, 3)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = drums_encoder_decoder.MultiDrumOneHotEncoding()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testDecode"><code class="name flex">
+<span>def <span class="ident">testDecode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecode(self):
+  # Zero should decode to no drums.
+  event = self.enc.decode_event(0)
+  self.assertEqual(NO_DRUMS, event)
+
+  # Single bit active should encode to single drum, different for different
+  # bits.
+  event1 = self.enc.decode_event(1)
+  event2 = self.enc.decode_event(
+      2 ** (len(drums_encoder_decoder.DEFAULT_DRUM_TYPE_PITCHES) // 2))
+  self.assertEqual(frozenset, type(event1))
+  self.assertEqual(frozenset, type(event2))
+  self.assertLen(event1, 1)
+  self.assertLen(event2, 1)
+  self.assertNotEqual(event1, event2)
+
+  # Multiple bits active should encode to multiple drums.
+  event = self.enc.decode_event(7)
+  self.assertEqual(frozenset, type(event))
+  self.assertLen(event, 3)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testEncode"><code class="name flex">
+<span>def <span class="ident">testEncode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncode(self):
+  # No drums should encode to zero.
+  index = self.enc.encode_event(NO_DRUMS)
+  self.assertEqual(0, index)
+
+  # Single drum should encode to single bit active, different for different
+  # drum types.
+  index1 = self.enc.encode_event(DRUMS(35))
+  index2 = self.enc.encode_event(DRUMS(44))
+  self.assertEqual(1, _index_to_binary(index1).count(&#39;1&#39;))
+  self.assertEqual(1, _index_to_binary(index2).count(&#39;1&#39;))
+  self.assertNotEqual(index1, index2)
+
+  # Multiple drums should encode to multiple bits active, one for each drum
+  # type.
+  index = self.enc.encode_event(DRUMS(40, 44))
+  self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))
+  index = self.enc.encode_event(DRUMS(35, 51, 59))
+  self.assertEqual(2, _index_to_binary(index).count(&#39;1&#39;))</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.drums_encoder_decoder_test.DRUMS" href="#note_seq.drums_encoder_decoder_test.DRUMS">DRUMS</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest" href="#note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest">MultiDrumOneHotEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.setUp" href="#note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testDecode" href="#note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testDecode">testDecode</a></code></li>
+<li><code><a title="note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testEncode" href="#note_seq.drums_encoder_decoder_test.MultiDrumOneHotEncodingTest.testEncode">testEncode</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/drums_lib.html
+++ b/docs/drums_lib.html
@@ -1,0 +1,965 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.drums_lib API documentation</title>
+<meta name="description" content="Utility functions for working with drums …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.drums_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with drums.</p>
+<p>Use extract_drum_tracks to extract drum tracks from a quantized NoteSequence.</p>
+<p>Use DrumTrack.to_sequence to write a drum track to a NoteSequence proto. Then
+use midi_io.sequence_proto_to_midi_file to write that NoteSequence to a midi
+file.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with drums.
+
+Use extract_drum_tracks to extract drum tracks from a quantized NoteSequence.
+
+Use DrumTrack.to_sequence to write a drum track to a NoteSequence proto. Then
+use midi_io.sequence_proto_to_midi_file to write that NoteSequence to a midi
+file.
+&#34;&#34;&#34;
+
+import collections
+import operator
+
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import midi_io
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+
+MIN_MIDI_PITCH = constants.MIN_MIDI_PITCH
+MAX_MIDI_PITCH = constants.MAX_MIDI_PITCH
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+STANDARD_PPQ = constants.STANDARD_PPQ
+
+
+class DrumTrack(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of drum events.
+
+  DrumTrack is an intermediate representation that all drum models can use.
+  Quantized sequence to DrumTrack code will do work to align drum notes and
+  extract drum tracks. Model-specific code then needs to convert DrumTrack
+  to SequenceExample protos for TensorFlow.
+
+  DrumTrack implements an iterable object. Simply iterate to retrieve the drum
+  events.
+
+  DrumTrack events are Python frozensets of simultaneous MIDI drum &#34;pitches&#34;,
+  where each pitch indicates a type of drum. An empty frozenset indicates no
+  drum notes. Unlike melody notes, drum notes are not considered to have
+  durations.
+
+  Drum tracks can start at any non-negative time, and are shifted left so that
+  the bar containing the first drum event is the first bar.
+
+  Attributes:
+    start_step: The offset of the first step of the drum track relative to the
+        beginning of the source sequence. Will always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the drum track relative the beginning of the source sequence. Will
+       always be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a DrumTrack.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(DrumTrack, self).__init__(pad_event=frozenset(),
+                                    events=events, **kwargs)
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.
+
+    Args:
+      events: List of drum events to set drum track to.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+
+    Raises:
+      ValueError: If `events` contains an event that is not a valid drum event.
+    &#34;&#34;&#34;
+    for event in events:
+      if not isinstance(event, frozenset):
+        raise ValueError(&#39;Invalid drum event: %s&#39; % event)
+      if not all(MIN_MIDI_PITCH &lt;= drum &lt;= MAX_MIDI_PITCH for drum in event):
+        raise ValueError(&#39;Drum event contains invalid note: %s&#39; % event)
+    super(DrumTrack, self)._from_event_list(
+        events, start_step=start_step, steps_per_bar=steps_per_bar,
+        steps_per_quarter=steps_per_quarter)
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the drums and increments the end step.
+
+    Args:
+      event: The drum event to append to the end.
+    Raises:
+      ValueError: If `event` is not a valid drum event.
+    &#34;&#34;&#34;
+    if not isinstance(event, frozenset):
+      raise ValueError(&#39;Invalid drum event: %s&#39; % event)
+    if not all(MIN_MIDI_PITCH &lt;= drum &lt;= MAX_MIDI_PITCH for drum in event):
+      raise ValueError(&#39;Drum event contains invalid note: %s&#39; % event)
+    super(DrumTrack, self).append(event)
+
+  def from_quantized_sequence(self,
+                              quantized_sequence,
+                              search_start_step=0,
+                              gap_bars=1,
+                              pad_end=False,
+                              ignore_is_drum=False):
+    &#34;&#34;&#34;Populate self with drums from the given quantized NoteSequence object.
+
+    A drum track is extracted from the given quantized sequence starting at time
+    step `start_step`. `start_step` can be used to drive extraction of multiple
+    drum tracks from the same quantized sequence. The end step of the extracted
+    drum track will be stored in `self._end_step`.
+
+    0 velocity notes are ignored. The drum extraction is ended when there are
+    no drums for a time stretch of `gap_bars` in bars (measures) of music. The
+    number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    Each drum event is a Python frozenset of simultaneous (after quantization)
+    drum &#34;pitches&#34;, or an empty frozenset to indicate no drums are played.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      search_start_step: Start searching for drums at this time step. Assumed to
+          be the beginning of a bar.
+      gap_bars: If this many bars or more follow a non-empty drum event, the
+          drum track is ended.
+      pad_end: If True, the end of the drums will be padded with empty events so
+          that it will end at a bar boundary.
+      ignore_is_drum: Whether accept notes where `is_drum` is False.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+           quantized_sequence.time_signatures[0].denominator))
+    self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Group all drum notes that start at the same step.
+    all_notes = [note for note in quantized_sequence.notes
+                 if ((note.is_drum or ignore_is_drum)  # drums only
+                     and note.velocity  # no zero-velocity notes
+                     # after start_step only
+                     and note.quantized_start_step &gt;= search_start_step)]
+    grouped_notes = collections.defaultdict(list)
+    for note in all_notes:
+      grouped_notes[note.quantized_start_step].append(note)
+
+    # Sort by note start times.
+    notes = sorted(grouped_notes.items(), key=operator.itemgetter(0))
+
+    if not notes:
+      return
+
+    gap_start_index = 0
+
+    track_start_step = (
+        notes[0][0] - (notes[0][0] - search_start_step) % steps_per_bar)
+    for start, group in notes:
+
+      start_index = start - track_start_step
+      pitches = frozenset(note.pitch for note in group)
+
+      # If a gap of `gap` or more steps is found, end the drum track.
+      note_distance = start_index - gap_start_index
+      if len(self) and note_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+        break
+
+      # Add a drum event, a set of drum &#34;pitches&#34;.
+      self.set_length(start_index + 1)
+      self._events[start_index] = pitches
+
+      gap_start_index = start_index + 1
+
+    if not self._events:
+      # If no drum events were added, don&#39;t set `_start_step` and `_end_step`.
+      return
+
+    self._start_step = track_start_step
+
+    length = len(self)
+    # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+    if pad_end:
+      length += -len(self) % steps_per_bar
+    self.set_length(length)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=9,
+                  program=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the DrumTrack to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      sequence_start_time: A time in seconds (float) that the first event in the
+          sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given drum track.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    sequence_start_time += self.start_step * seconds_per_step
+    for step, event in enumerate(self):
+      for pitch in event:
+        # Add a note. All drum notes last a single step.
+        note = sequence.notes.add()
+        note.start_time = step * seconds_per_step + sequence_start_time
+        note.end_time = (step + 1) * seconds_per_step + sequence_start_time
+        note.pitch = pitch
+        note.velocity = velocity
+        note.instrument = instrument
+        note.program = program
+        note.is_drum = True
+
+    if sequence.notes:
+      sequence.total_time = sequence.notes[-1].end_time
+
+    return sequence
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a DrumTrack.
+
+    Increases the resolution of a DrumTrack object by a factor of `k`. This uses
+    empty events to extend each event in the drum track to be `k` steps long.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          drum track.
+    &#34;&#34;&#34;
+    super(DrumTrack, self).increase_resolution(
+        k, fill_event=frozenset())
+
+
+def midi_file_to_drum_track(midi_file, steps_per_quarter=4):
+  &#34;&#34;&#34;Loads a drum track from a MIDI file.
+
+  Args:
+    midi_file: Absolute path to MIDI file.
+    steps_per_quarter: Quantization of DrumTrack. For example, 4 = 16th notes.
+
+  Returns:
+    A DrumTrack object extracted from the MIDI file.
+  &#34;&#34;&#34;
+  sequence = midi_io.midi_file_to_sequence_proto(midi_file)
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=steps_per_quarter)
+  drum_track = DrumTrack()
+  drum_track.from_quantized_sequence(quantized_sequence)
+  return drum_track</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.drums_lib.midi_file_to_drum_track"><code class="name flex">
+<span>def <span class="ident">midi_file_to_drum_track</span></span>(<span>midi_file, steps_per_quarter=4)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Loads a drum track from a MIDI file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>midi_file</code></strong></dt>
+<dd>Absolute path to MIDI file.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Quantization of DrumTrack. For example, 4 = 16th notes.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A DrumTrack object extracted from the MIDI file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_file_to_drum_track(midi_file, steps_per_quarter=4):
+  &#34;&#34;&#34;Loads a drum track from a MIDI file.
+
+  Args:
+    midi_file: Absolute path to MIDI file.
+    steps_per_quarter: Quantization of DrumTrack. For example, 4 = 16th notes.
+
+  Returns:
+    A DrumTrack object extracted from the MIDI file.
+  &#34;&#34;&#34;
+  sequence = midi_io.midi_file_to_sequence_proto(midi_file)
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=steps_per_quarter)
+  drum_track = DrumTrack()
+  drum_track.from_quantized_sequence(quantized_sequence)
+  return drum_track</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.drums_lib.DrumTrack"><code class="flex name class">
+<span>class <span class="ident">DrumTrack</span></span>
+<span>(</span><span>events=None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a quantized stream of drum events.</p>
+<p>DrumTrack is an intermediate representation that all drum models can use.
+Quantized sequence to DrumTrack code will do work to align drum notes and
+extract drum tracks. Model-specific code then needs to convert DrumTrack
+to SequenceExample protos for TensorFlow.</p>
+<p>DrumTrack implements an iterable object. Simply iterate to retrieve the drum
+events.</p>
+<p>DrumTrack events are Python frozensets of simultaneous MIDI drum "pitches",
+where each pitch indicates a type of drum. An empty frozenset indicates no
+drum notes. Unlike melody notes, drum notes are not considered to have
+durations.</p>
+<p>Drum tracks can start at any non-negative time, and are shifted left so that
+the bar containing the first drum event is the first bar.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of the first step of the drum track relative to the
+beginning of the source sequence. Will always be the first step of a
+bar.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>The offset to the beginning of the bar following the last step
+of the drum track relative the beginning of the source sequence. Will
+always be the first step of a bar.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Number of steps in in a quarter note.</dd>
+<dt><strong><code>steps_per_bar</code></strong></dt>
+<dd>Number of steps in a bar (measure) of music.</dd>
+</dl>
+<p>Construct a DrumTrack.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DrumTrack(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of drum events.
+
+  DrumTrack is an intermediate representation that all drum models can use.
+  Quantized sequence to DrumTrack code will do work to align drum notes and
+  extract drum tracks. Model-specific code then needs to convert DrumTrack
+  to SequenceExample protos for TensorFlow.
+
+  DrumTrack implements an iterable object. Simply iterate to retrieve the drum
+  events.
+
+  DrumTrack events are Python frozensets of simultaneous MIDI drum &#34;pitches&#34;,
+  where each pitch indicates a type of drum. An empty frozenset indicates no
+  drum notes. Unlike melody notes, drum notes are not considered to have
+  durations.
+
+  Drum tracks can start at any non-negative time, and are shifted left so that
+  the bar containing the first drum event is the first bar.
+
+  Attributes:
+    start_step: The offset of the first step of the drum track relative to the
+        beginning of the source sequence. Will always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the drum track relative the beginning of the source sequence. Will
+       always be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a DrumTrack.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(DrumTrack, self).__init__(pad_event=frozenset(),
+                                    events=events, **kwargs)
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.
+
+    Args:
+      events: List of drum events to set drum track to.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+
+    Raises:
+      ValueError: If `events` contains an event that is not a valid drum event.
+    &#34;&#34;&#34;
+    for event in events:
+      if not isinstance(event, frozenset):
+        raise ValueError(&#39;Invalid drum event: %s&#39; % event)
+      if not all(MIN_MIDI_PITCH &lt;= drum &lt;= MAX_MIDI_PITCH for drum in event):
+        raise ValueError(&#39;Drum event contains invalid note: %s&#39; % event)
+    super(DrumTrack, self)._from_event_list(
+        events, start_step=start_step, steps_per_bar=steps_per_bar,
+        steps_per_quarter=steps_per_quarter)
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the drums and increments the end step.
+
+    Args:
+      event: The drum event to append to the end.
+    Raises:
+      ValueError: If `event` is not a valid drum event.
+    &#34;&#34;&#34;
+    if not isinstance(event, frozenset):
+      raise ValueError(&#39;Invalid drum event: %s&#39; % event)
+    if not all(MIN_MIDI_PITCH &lt;= drum &lt;= MAX_MIDI_PITCH for drum in event):
+      raise ValueError(&#39;Drum event contains invalid note: %s&#39; % event)
+    super(DrumTrack, self).append(event)
+
+  def from_quantized_sequence(self,
+                              quantized_sequence,
+                              search_start_step=0,
+                              gap_bars=1,
+                              pad_end=False,
+                              ignore_is_drum=False):
+    &#34;&#34;&#34;Populate self with drums from the given quantized NoteSequence object.
+
+    A drum track is extracted from the given quantized sequence starting at time
+    step `start_step`. `start_step` can be used to drive extraction of multiple
+    drum tracks from the same quantized sequence. The end step of the extracted
+    drum track will be stored in `self._end_step`.
+
+    0 velocity notes are ignored. The drum extraction is ended when there are
+    no drums for a time stretch of `gap_bars` in bars (measures) of music. The
+    number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    Each drum event is a Python frozenset of simultaneous (after quantization)
+    drum &#34;pitches&#34;, or an empty frozenset to indicate no drums are played.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      search_start_step: Start searching for drums at this time step. Assumed to
+          be the beginning of a bar.
+      gap_bars: If this many bars or more follow a non-empty drum event, the
+          drum track is ended.
+      pad_end: If True, the end of the drums will be padded with empty events so
+          that it will end at a bar boundary.
+      ignore_is_drum: Whether accept notes where `is_drum` is False.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+           quantized_sequence.time_signatures[0].denominator))
+    self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Group all drum notes that start at the same step.
+    all_notes = [note for note in quantized_sequence.notes
+                 if ((note.is_drum or ignore_is_drum)  # drums only
+                     and note.velocity  # no zero-velocity notes
+                     # after start_step only
+                     and note.quantized_start_step &gt;= search_start_step)]
+    grouped_notes = collections.defaultdict(list)
+    for note in all_notes:
+      grouped_notes[note.quantized_start_step].append(note)
+
+    # Sort by note start times.
+    notes = sorted(grouped_notes.items(), key=operator.itemgetter(0))
+
+    if not notes:
+      return
+
+    gap_start_index = 0
+
+    track_start_step = (
+        notes[0][0] - (notes[0][0] - search_start_step) % steps_per_bar)
+    for start, group in notes:
+
+      start_index = start - track_start_step
+      pitches = frozenset(note.pitch for note in group)
+
+      # If a gap of `gap` or more steps is found, end the drum track.
+      note_distance = start_index - gap_start_index
+      if len(self) and note_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+        break
+
+      # Add a drum event, a set of drum &#34;pitches&#34;.
+      self.set_length(start_index + 1)
+      self._events[start_index] = pitches
+
+      gap_start_index = start_index + 1
+
+    if not self._events:
+      # If no drum events were added, don&#39;t set `_start_step` and `_end_step`.
+      return
+
+    self._start_step = track_start_step
+
+    length = len(self)
+    # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+    if pad_end:
+      length += -len(self) % steps_per_bar
+    self.set_length(length)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=9,
+                  program=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the DrumTrack to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      sequence_start_time: A time in seconds (float) that the first event in the
+          sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given drum track.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    sequence_start_time += self.start_step * seconds_per_step
+    for step, event in enumerate(self):
+      for pitch in event:
+        # Add a note. All drum notes last a single step.
+        note = sequence.notes.add()
+        note.start_time = step * seconds_per_step + sequence_start_time
+        note.end_time = (step + 1) * seconds_per_step + sequence_start_time
+        note.pitch = pitch
+        note.velocity = velocity
+        note.instrument = instrument
+        note.program = program
+        note.is_drum = True
+
+    if sequence.notes:
+      sequence.total_time = sequence.notes[-1].end_time
+
+    return sequence
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a DrumTrack.
+
+    Increases the resolution of a DrumTrack object by a factor of `k`. This uses
+    empty events to extend each event in the drum track to be `k` steps long.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          drum track.
+    &#34;&#34;&#34;
+    super(DrumTrack, self).increase_resolution(
+        k, fill_event=frozenset())</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.SimpleEventSequence" href="events_lib.html#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.drums_lib.DrumTrack.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends the event to the end of the drums and increments the end step.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The drum event to append to the end.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is not a valid drum event.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends the event to the end of the drums and increments the end step.
+
+  Args:
+    event: The drum event to append to the end.
+  Raises:
+    ValueError: If `event` is not a valid drum event.
+  &#34;&#34;&#34;
+  if not isinstance(event, frozenset):
+    raise ValueError(&#39;Invalid drum event: %s&#39; % event)
+  if not all(MIN_MIDI_PITCH &lt;= drum &lt;= MAX_MIDI_PITCH for drum in event):
+    raise ValueError(&#39;Drum event contains invalid note: %s&#39; % event)
+  super(DrumTrack, self).append(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib.DrumTrack.from_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">from_quantized_sequence</span></span>(<span>self, quantized_sequence, search_start_step=0, gap_bars=1, pad_end=False, ignore_is_drum=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Populate self with drums from the given quantized NoteSequence object.</p>
+<p>A drum track is extracted from the given quantized sequence starting at time
+step <code>start_step</code>. <code>start_step</code> can be used to drive extraction of multiple
+drum tracks from the same quantized sequence. The end step of the extracted
+drum track will be stored in <code>self._end_step</code>.</p>
+<p>0 velocity notes are ignored. The drum extraction is ended when there are
+no drums for a time stretch of <code>gap_bars</code> in bars (measures) of music. The
+number of time steps per bar is computed from the time signature in
+<code>quantized_sequence</code>.</p>
+<p>Each drum event is a Python frozenset of simultaneous (after quantization)
+drum "pitches", or an empty frozenset to indicate no drums are played.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A quantized NoteSequence instance.</dd>
+<dt><strong><code>search_start_step</code></strong></dt>
+<dd>Start searching for drums at this time step. Assumed to
+be the beginning of a bar.</dd>
+<dt><strong><code>gap_bars</code></strong></dt>
+<dd>If this many bars or more follow a non-empty drum event, the
+drum track is ended.</dd>
+<dt><strong><code>pad_end</code></strong></dt>
+<dd>If True, the end of the drums will be padded with empty events so
+that it will end at a bar boundary.</dd>
+<dt><strong><code>ignore_is_drum</code></strong></dt>
+<dd>Whether accept notes where <code>is_drum</code> is False.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NonIntegerStepsPerBarError</code></dt>
+<dd>If <code>quantized_sequence</code>'s bar length
+(derived from its time signature) is not an integer number of time
+steps.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def from_quantized_sequence(self,
+                            quantized_sequence,
+                            search_start_step=0,
+                            gap_bars=1,
+                            pad_end=False,
+                            ignore_is_drum=False):
+  &#34;&#34;&#34;Populate self with drums from the given quantized NoteSequence object.
+
+  A drum track is extracted from the given quantized sequence starting at time
+  step `start_step`. `start_step` can be used to drive extraction of multiple
+  drum tracks from the same quantized sequence. The end step of the extracted
+  drum track will be stored in `self._end_step`.
+
+  0 velocity notes are ignored. The drum extraction is ended when there are
+  no drums for a time stretch of `gap_bars` in bars (measures) of music. The
+  number of time steps per bar is computed from the time signature in
+  `quantized_sequence`.
+
+  Each drum event is a Python frozenset of simultaneous (after quantization)
+  drum &#34;pitches&#34;, or an empty frozenset to indicate no drums are played.
+
+  Args:
+    quantized_sequence: A quantized NoteSequence instance.
+    search_start_step: Start searching for drums at this time step. Assumed to
+        be the beginning of a bar.
+    gap_bars: If this many bars or more follow a non-empty drum event, the
+        drum track is ended.
+    pad_end: If True, the end of the drums will be padded with empty events so
+        that it will end at a bar boundary.
+    ignore_is_drum: Whether accept notes where `is_drum` is False.
+
+  Raises:
+    NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+        (derived from its time signature) is not an integer number of time
+        steps.
+  &#34;&#34;&#34;
+  sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+  self._reset()
+
+  steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+      quantized_sequence)
+  if steps_per_bar_float % 1 != 0:
+    raise events_lib.NonIntegerStepsPerBarError(
+        &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+        (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+         quantized_sequence.time_signatures[0].denominator))
+  self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+  self._steps_per_quarter = (
+      quantized_sequence.quantization_info.steps_per_quarter)
+
+  # Group all drum notes that start at the same step.
+  all_notes = [note for note in quantized_sequence.notes
+               if ((note.is_drum or ignore_is_drum)  # drums only
+                   and note.velocity  # no zero-velocity notes
+                   # after start_step only
+                   and note.quantized_start_step &gt;= search_start_step)]
+  grouped_notes = collections.defaultdict(list)
+  for note in all_notes:
+    grouped_notes[note.quantized_start_step].append(note)
+
+  # Sort by note start times.
+  notes = sorted(grouped_notes.items(), key=operator.itemgetter(0))
+
+  if not notes:
+    return
+
+  gap_start_index = 0
+
+  track_start_step = (
+      notes[0][0] - (notes[0][0] - search_start_step) % steps_per_bar)
+  for start, group in notes:
+
+    start_index = start - track_start_step
+    pitches = frozenset(note.pitch for note in group)
+
+    # If a gap of `gap` or more steps is found, end the drum track.
+    note_distance = start_index - gap_start_index
+    if len(self) and note_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+      break
+
+    # Add a drum event, a set of drum &#34;pitches&#34;.
+    self.set_length(start_index + 1)
+    self._events[start_index] = pitches
+
+    gap_start_index = start_index + 1
+
+  if not self._events:
+    # If no drum events were added, don&#39;t set `_start_step` and `_end_step`.
+    return
+
+  self._start_step = track_start_step
+
+  length = len(self)
+  # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+  if pad_end:
+    length += -len(self) % steps_per_bar
+  self.set_length(length)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib.DrumTrack.increase_resolution"><code class="name flex">
+<span>def <span class="ident">increase_resolution</span></span>(<span>self, k)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Increase the resolution of a DrumTrack.</p>
+<p>Increases the resolution of a DrumTrack object by a factor of <code>k</code>. This uses
+empty events to extend each event in the drum track to be <code>k</code> steps long.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>k</code></strong></dt>
+<dd>An integer, the factor by which to increase the resolution of the
+drum track.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def increase_resolution(self, k):
+  &#34;&#34;&#34;Increase the resolution of a DrumTrack.
+
+  Increases the resolution of a DrumTrack object by a factor of `k`. This uses
+  empty events to extend each event in the drum track to be `k` steps long.
+
+  Args:
+    k: An integer, the factor by which to increase the resolution of the
+        drum track.
+  &#34;&#34;&#34;
+  super(DrumTrack, self).increase_resolution(
+      k, fill_event=frozenset())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib.DrumTrack.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity=100, instrument=9, program=0, sequence_start_time=0.0, qpm=120.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the DrumTrack to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Midi velocity to give each note. Between 1 and 127 (inclusive).</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Midi instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>Midi program to give each note.</dd>
+<dt><strong><code>sequence_start_time</code></strong></dt>
+<dd>A time in seconds (float) that the first event in the
+sequence will land on.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Quarter notes per minute (float).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto encoding the given drum track.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                velocity=100,
+                instrument=9,
+                program=0,
+                sequence_start_time=0.0,
+                qpm=120.0):
+  &#34;&#34;&#34;Converts the DrumTrack to NoteSequence proto.
+
+  Args:
+    velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+    instrument: Midi instrument to give each note.
+    program: Midi program to give each note.
+    sequence_start_time: A time in seconds (float) that the first event in the
+        sequence will land on.
+    qpm: Quarter notes per minute (float).
+
+  Returns:
+    A NoteSequence proto encoding the given drum track.
+  &#34;&#34;&#34;
+  seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = STANDARD_PPQ
+
+  sequence_start_time += self.start_step * seconds_per_step
+  for step, event in enumerate(self):
+    for pitch in event:
+      # Add a note. All drum notes last a single step.
+      note = sequence.notes.add()
+      note.start_time = step * seconds_per_step + sequence_start_time
+      note.end_time = (step + 1) * seconds_per_step + sequence_start_time
+      note.pitch = pitch
+      note.velocity = velocity
+      note.instrument = instrument
+      note.program = program
+      note.is_drum = True
+
+  if sequence.notes:
+    sequence.total_time = sequence.notes[-1].end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.events_lib.SimpleEventSequence" href="events_lib.html#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.set_length" href="events_lib.html#note_seq.events_lib.SimpleEventSequence.set_length">set_length</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.drums_lib.midi_file_to_drum_track" href="#note_seq.drums_lib.midi_file_to_drum_track">midi_file_to_drum_track</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.drums_lib.DrumTrack" href="#note_seq.drums_lib.DrumTrack">DrumTrack</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.drums_lib.DrumTrack.append" href="#note_seq.drums_lib.DrumTrack.append">append</a></code></li>
+<li><code><a title="note_seq.drums_lib.DrumTrack.from_quantized_sequence" href="#note_seq.drums_lib.DrumTrack.from_quantized_sequence">from_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.drums_lib.DrumTrack.increase_resolution" href="#note_seq.drums_lib.DrumTrack.increase_resolution">increase_resolution</a></code></li>
+<li><code><a title="note_seq.drums_lib.DrumTrack.to_sequence" href="#note_seq.drums_lib.DrumTrack.to_sequence">to_sequence</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/drums_lib_test.html
+++ b/docs/drums_lib_test.html
@@ -1,0 +1,836 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.drums_lib_test API documentation</title>
+<meta name="description" content="Tests for drums_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.drums_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for drums_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for drums_lib.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import drums_lib
+from note_seq import sequences_lib
+from note_seq import testing_lib
+
+DRUMS = lambda *args: frozenset(args)
+NO_DRUMS = frozenset()
+
+
+class DrumsLibTest(testing_lib.ProtoTestCase):
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.25, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.25), (60, 100, 4.0, 5.5), (52, 99, 4.75, 5.0)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceMultipleTracks(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0, 10), (40, 45, 2.5, 3.5), (60, 100, 4, 5.5)],
+        is_drum=True)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1,
+        [(11, 55, .25, .5), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+        is_drum=True)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 2,
+        [(13, 100, 0, 10), (14, 45, 2.5, 3.5), (15, 100, 4, 5.5)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0, 10), (11, 55, .25, .5), (40, 45, 2.5, 3.5),
+         (30, 80, 2.5, 2.75), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(30, 40),
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(14, drums.steps_per_bar)
+
+  def testFromNotesTrimEmptyMeasures(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = [NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                DRUMS(12), NO_DRUMS, DRUMS(11)]
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromNotesStepsPerBar(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=12)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    self.assertEqual(42, drums.steps_per_bar)
+
+  def testFromNotesStartAndEndStep(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+         (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)],
+        is_drum=True)
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=18)
+    expected = [NO_DRUMS, DRUMS(14), NO_DRUMS, DRUMS(15)]
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(34, drums.start_step)
+    self.assertEqual(38, drums.end_step)
+
+  def testSetLength(self):
+    events = [DRUMS(60)]
+    drums = drums_lib.DrumTrack(events, start_step=9)
+    drums.set_length(5)
+    self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS],
+                         list(drums))
+    self.assertEqual(9, drums.start_step)
+    self.assertEqual(14, drums.end_step)
+
+    drums = drums_lib.DrumTrack(events, start_step=9)
+    drums.set_length(5, from_left=True)
+    self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(60)],
+                         list(drums))
+    self.assertEqual(5, drums.start_step)
+    self.assertEqual(10, drums.end_step)
+
+    events = [DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS]
+    drums = drums_lib.DrumTrack(events)
+    drums.set_length(3)
+    self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS], list(drums))
+    self.assertEqual(0, drums.start_step)
+    self.assertEqual(3, drums.end_step)
+
+    drums = drums_lib.DrumTrack(events)
+    drums.set_length(3, from_left=True)
+    self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS], list(drums))
+    self.assertEqual(1, drums.start_step)
+    self.assertEqual(4, drums.end_step)
+
+  def testToSequenceSimple(self):
+    drums = drums_lib.DrumTrack(
+        [NO_DRUMS, DRUMS(1, 2), NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(2),
+         DRUMS(3), NO_DRUMS, NO_DRUMS])
+    sequence = drums.to_sequence(
+        velocity=10,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 3.75 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 3.25 end_time: 3.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 3 velocity: 10 instrument: 9 start_time: 3.5 end_time: 3.75 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithNonzeroStart(self):
+    drums = drums_lib.DrumTrack([NO_DRUMS, DRUMS(1), NO_DRUMS], start_step=4)
+    sequence = drums.to_sequence(
+        velocity=100,
+        sequence_start_time=0.5,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.0 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 100 instrument: 9 start_time: 1.75 end_time: 2.0 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEmpty(self):
+    drums = drums_lib.DrumTrack()
+    sequence = drums.to_sequence(
+        velocity=10,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+        sequence)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.drums_lib_test.DRUMS"><code class="name flex">
+<span>def <span class="ident">DRUMS</span></span>(<span>*args)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">DRUMS = lambda *args: frozenset(args)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.drums_lib_test.DrumsLibTest"><code class="flex name class">
+<span>class <span class="ident">DrumsLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DrumsLibTest(testing_lib.ProtoTestCase):
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.25, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.25), (60, 100, 4.0, 5.5), (52, 99, 4.75, 5.0)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceMultipleTracks(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0, 10), (40, 45, 2.5, 3.5), (60, 100, 4, 5.5)],
+        is_drum=True)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1,
+        [(11, 55, .25, .5), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+        is_drum=True)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 2,
+        [(13, 100, 0, 10), (14, 45, 2.5, 3.5), (15, 100, 4, 5.5)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0, 10), (11, 55, .25, .5), (40, 45, 2.5, 3.5),
+         (30, 80, 2.5, 2.75), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(30, 40),
+                 NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55),
+                 NO_DRUMS, NO_DRUMS, DRUMS(52)])
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(14, drums.steps_per_bar)
+
+  def testFromNotesTrimEmptyMeasures(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    expected = [NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+                DRUMS(12), NO_DRUMS, DRUMS(11)]
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(16, drums.steps_per_bar)
+
+  def testFromNotesStepsPerBar(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=12)
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+    self.assertEqual(42, drums.steps_per_bar)
+
+  def testFromNotesStartAndEndStep(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+         (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)],
+        is_drum=True)
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    drums = drums_lib.DrumTrack()
+    drums.from_quantized_sequence(quantized_sequence, search_start_step=18)
+    expected = [NO_DRUMS, DRUMS(14), NO_DRUMS, DRUMS(15)]
+    self.assertEqual(expected, list(drums))
+    self.assertEqual(34, drums.start_step)
+    self.assertEqual(38, drums.end_step)
+
+  def testSetLength(self):
+    events = [DRUMS(60)]
+    drums = drums_lib.DrumTrack(events, start_step=9)
+    drums.set_length(5)
+    self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS],
+                         list(drums))
+    self.assertEqual(9, drums.start_step)
+    self.assertEqual(14, drums.end_step)
+
+    drums = drums_lib.DrumTrack(events, start_step=9)
+    drums.set_length(5, from_left=True)
+    self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(60)],
+                         list(drums))
+    self.assertEqual(5, drums.start_step)
+    self.assertEqual(10, drums.end_step)
+
+    events = [DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS]
+    drums = drums_lib.DrumTrack(events)
+    drums.set_length(3)
+    self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS], list(drums))
+    self.assertEqual(0, drums.start_step)
+    self.assertEqual(3, drums.end_step)
+
+    drums = drums_lib.DrumTrack(events)
+    drums.set_length(3, from_left=True)
+    self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS], list(drums))
+    self.assertEqual(1, drums.start_step)
+    self.assertEqual(4, drums.end_step)
+
+  def testToSequenceSimple(self):
+    drums = drums_lib.DrumTrack(
+        [NO_DRUMS, DRUMS(1, 2), NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(2),
+         DRUMS(3), NO_DRUMS, NO_DRUMS])
+    sequence = drums.to_sequence(
+        velocity=10,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 3.75 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 3.25 end_time: 3.5 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 3 velocity: 10 instrument: 9 start_time: 3.5 end_time: 3.75 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithNonzeroStart(self):
+    drums = drums_lib.DrumTrack([NO_DRUMS, DRUMS(1), NO_DRUMS], start_step=4)
+    sequence = drums.to_sequence(
+        velocity=100,
+        sequence_start_time=0.5,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.0 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 100 instrument: 9 start_time: 1.75 end_time: 2.0 &#39;
+        &#39;  is_drum: true &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEmpty(self):
+    drums = drums_lib.DrumTrack()
+    sequence = drums.to_sequence(
+        velocity=10,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+        sequence)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromNotesStartAndEndStep"><code class="name flex">
+<span>def <span class="ident">testFromNotesStartAndEndStep</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesStartAndEndStep(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+       (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)],
+      is_drum=True)
+
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=18)
+  expected = [NO_DRUMS, DRUMS(14), NO_DRUMS, DRUMS(15)]
+  self.assertEqual(expected, list(drums))
+  self.assertEqual(34, drums.start_step)
+  self.assertEqual(38, drums.end_step)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromNotesStepsPerBar"><code class="name flex">
+<span>def <span class="ident">testFromNotesStepsPerBar</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesStepsPerBar(self):
+  self.note_sequence.time_signatures[0].numerator = 7
+  self.note_sequence.time_signatures[0].denominator = 8
+
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=12)
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+  self.assertEqual(42, drums.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromNotesTrimEmptyMeasures"><code class="name flex">
+<span>def <span class="ident">testFromNotesTrimEmptyMeasures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesTrimEmptyMeasures(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)],
+      is_drum=True)
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+  expected = [NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+              DRUMS(12), NO_DRUMS, DRUMS(11)]
+  self.assertEqual(expected, list(drums))
+  self.assertEqual(16, drums.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.0, 10.0), (11, 55, 0.25, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.25), (60, 100, 4.0, 5.5), (52, 99, 4.75, 5.0)],
+      is_drum=True)
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+  expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+               NO_DRUMS, NO_DRUMS, DRUMS(52)])
+  self.assertEqual(expected, list(drums))
+  self.assertEqual(16, drums.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceMultipleTracks"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceMultipleTracks</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceMultipleTracks(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0, 10), (40, 45, 2.5, 3.5), (60, 100, 4, 5.5)],
+      is_drum=True)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 1,
+      [(11, 55, .25, .5), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+      is_drum=True)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 2,
+      [(13, 100, 0, 10), (14, 45, 2.5, 3.5), (15, 100, 4, 5.5)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+  expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(40), NO_DRUMS,
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55, 60),
+               NO_DRUMS, NO_DRUMS, DRUMS(52)])
+  self.assertEqual(expected, list(drums))
+  self.assertEqual(16, drums.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceNotCommonTimeSig</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+  self.note_sequence.time_signatures[0].numerator = 7
+  self.note_sequence.time_signatures[0].denominator = 8
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0, 10), (11, 55, .25, .5), (40, 45, 2.5, 3.5),
+       (30, 80, 2.5, 2.75), (55, 120, 4, 4.25), (52, 99, 4.75, 5)],
+      is_drum=True)
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  drums = drums_lib.DrumTrack()
+  drums.from_quantized_sequence(quantized_sequence, search_start_step=0)
+  expected = ([DRUMS(12), DRUMS(11), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS,
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(30, 40),
+               NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(55),
+               NO_DRUMS, NO_DRUMS, DRUMS(52)])
+  self.assertEqual(expected, list(drums))
+  self.assertEqual(14, drums.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testSetLength"><code class="name flex">
+<span>def <span class="ident">testSetLength</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLength(self):
+  events = [DRUMS(60)]
+  drums = drums_lib.DrumTrack(events, start_step=9)
+  drums.set_length(5)
+  self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS],
+                       list(drums))
+  self.assertEqual(9, drums.start_step)
+  self.assertEqual(14, drums.end_step)
+
+  drums = drums_lib.DrumTrack(events, start_step=9)
+  drums.set_length(5, from_left=True)
+  self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(60)],
+                       list(drums))
+  self.assertEqual(5, drums.start_step)
+  self.assertEqual(10, drums.end_step)
+
+  events = [DRUMS(60), NO_DRUMS, NO_DRUMS, NO_DRUMS]
+  drums = drums_lib.DrumTrack(events)
+  drums.set_length(3)
+  self.assertListEqual([DRUMS(60), NO_DRUMS, NO_DRUMS], list(drums))
+  self.assertEqual(0, drums.start_step)
+  self.assertEqual(3, drums.end_step)
+
+  drums = drums_lib.DrumTrack(events)
+  drums.set_length(3, from_left=True)
+  self.assertListEqual([NO_DRUMS, NO_DRUMS, NO_DRUMS], list(drums))
+  self.assertEqual(1, drums.start_step)
+  self.assertEqual(4, drums.end_step)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testToSequenceEmpty"><code class="name flex">
+<span>def <span class="ident">testToSequenceEmpty</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceEmpty(self):
+  drums = drums_lib.DrumTrack()
+  sequence = drums.to_sequence(
+      velocity=10,
+      sequence_start_time=2,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testToSequenceEndsWithNonzeroStart"><code class="name flex">
+<span>def <span class="ident">testToSequenceEndsWithNonzeroStart</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceEndsWithNonzeroStart(self):
+  drums = drums_lib.DrumTrack([NO_DRUMS, DRUMS(1), NO_DRUMS], start_step=4)
+  sequence = drums.to_sequence(
+      velocity=100,
+      sequence_start_time=0.5,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;total_time: 2.0 &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 1 velocity: 100 instrument: 9 start_time: 1.75 end_time: 2.0 &#39;
+      &#39;  is_drum: true &#39;
+      &#39;&gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.drums_lib_test.DrumsLibTest.testToSequenceSimple"><code class="name flex">
+<span>def <span class="ident">testToSequenceSimple</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceSimple(self):
+  drums = drums_lib.DrumTrack(
+      [NO_DRUMS, DRUMS(1, 2), NO_DRUMS, NO_DRUMS, NO_DRUMS, DRUMS(2),
+       DRUMS(3), NO_DRUMS, NO_DRUMS])
+  sequence = drums.to_sequence(
+      velocity=10,
+      sequence_start_time=2,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;total_time: 3.75 &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 1 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+      &#39;  is_drum: true &#39;
+      &#39;&gt; &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 2.25 end_time: 2.5 &#39;
+      &#39;  is_drum: true &#39;
+      &#39;&gt; &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 2 velocity: 10 instrument: 9 start_time: 3.25 end_time: 3.5 &#39;
+      &#39;  is_drum: true &#39;
+      &#39;&gt; &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 3 velocity: 10 instrument: 9 start_time: 3.5 end_time: 3.75 &#39;
+      &#39;  is_drum: true &#39;
+      &#39;&gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.drums_lib_test.DRUMS" href="#note_seq.drums_lib_test.DRUMS">DRUMS</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.drums_lib_test.DrumsLibTest" href="#note_seq.drums_lib_test.DrumsLibTest">DrumsLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromNotesStartAndEndStep" href="#note_seq.drums_lib_test.DrumsLibTest.testFromNotesStartAndEndStep">testFromNotesStartAndEndStep</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromNotesStepsPerBar" href="#note_seq.drums_lib_test.DrumsLibTest.testFromNotesStepsPerBar">testFromNotesStepsPerBar</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromNotesTrimEmptyMeasures" href="#note_seq.drums_lib_test.DrumsLibTest.testFromNotesTrimEmptyMeasures">testFromNotesTrimEmptyMeasures</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequence" href="#note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequence">testFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceMultipleTracks" href="#note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceMultipleTracks">testFromQuantizedNoteSequenceMultipleTracks</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig" href="#note_seq.drums_lib_test.DrumsLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig">testFromQuantizedNoteSequenceNotCommonTimeSig</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testSetLength" href="#note_seq.drums_lib_test.DrumsLibTest.testSetLength">testSetLength</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testToSequenceEmpty" href="#note_seq.drums_lib_test.DrumsLibTest.testToSequenceEmpty">testToSequenceEmpty</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testToSequenceEndsWithNonzeroStart" href="#note_seq.drums_lib_test.DrumsLibTest.testToSequenceEndsWithNonzeroStart">testToSequenceEndsWithNonzeroStart</a></code></li>
+<li><code><a title="note_seq.drums_lib_test.DrumsLibTest.testToSequenceSimple" href="#note_seq.drums_lib_test.DrumsLibTest.testToSequenceSimple">testToSequenceSimple</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/encoder_decoder.html
+++ b/docs/encoder_decoder.html
@@ -1,0 +1,3882 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between event sequences and models inputs/outputs …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between event sequences and models inputs/outputs.</p>
+<p>OneHotEncoding is an abstract class for specifying a one-hot encoding, i.e.
+how to convert back and forth between an arbitrary event space and integer
+indices between 0 and the number of classes.</p>
+<p>EventSequenceEncoderDecoder is an abstract class for translating event
+<em>sequences</em>, i.e. how to convert event sequences to input vectors and output
+labels to be fed into a model, and how to convert from output labels back to
+events.</p>
+<p>Use EventSequenceEncoderDecoder.encode to convert an event sequence to inputs
+and labels that can be fed into the model during training and evaluation.</p>
+<p>During generation, use EventSequenceEncoderDecoder.get_inputs_batch to convert a
+list of event sequences into an inputs batch which can be fed into the model to
+predict what the next event should be for each sequence. Then use
+EventSequenceEncoderDecoder.extend_event_sequences to extend each of those event
+sequences with an event sampled from the softmax output by the model.</p>
+<p>OneHotEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder that uses a
+OneHotEncoding of individual events. The input vectors are one-hot encodings of
+the most recent event. The output labels are one-hot encodings of the next
+event.</p>
+<p>LookbackEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder that also
+uses a OneHotEncoding of individual events. However, its input and output
+encodings also consider whether the event sequence is repeating, and the input
+encoding includes binary counters for timekeeping.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between event sequences and models inputs/outputs.
+
+OneHotEncoding is an abstract class for specifying a one-hot encoding, i.e.
+how to convert back and forth between an arbitrary event space and integer
+indices between 0 and the number of classes.
+
+EventSequenceEncoderDecoder is an abstract class for translating event
+_sequences_, i.e. how to convert event sequences to input vectors and output
+labels to be fed into a model, and how to convert from output labels back to
+events.
+
+Use EventSequenceEncoderDecoder.encode to convert an event sequence to inputs
+and labels that can be fed into the model during training and evaluation.
+
+During generation, use EventSequenceEncoderDecoder.get_inputs_batch to convert a
+list of event sequences into an inputs batch which can be fed into the model to
+predict what the next event should be for each sequence. Then use
+EventSequenceEncoderDecoder.extend_event_sequences to extend each of those event
+sequences with an event sampled from the softmax output by the model.
+
+OneHotEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder that uses a
+OneHotEncoding of individual events. The input vectors are one-hot encodings of
+the most recent event. The output labels are one-hot encodings of the next
+event.
+
+LookbackEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder that also
+uses a OneHotEncoding of individual events. However, its input and output
+encodings also consider whether the event sequence is repeating, and the input
+encoding includes binary counters for timekeeping.
+&#34;&#34;&#34;
+
+import abc
+import numbers
+
+from note_seq import constants
+import numpy as np
+
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_LOOKBACK_DISTANCES = [DEFAULT_STEPS_PER_BAR, DEFAULT_STEPS_PER_BAR * 2]
+
+
+class OneHotEncoding(object):
+  &#34;&#34;&#34;An interface for specifying a one-hot encoding of individual events.&#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def num_classes(self):
+    &#34;&#34;&#34;The number of distinct event encodings.
+
+    Returns:
+      An int, the range of ints that can be returned by self.encode_event.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_event(self):
+    &#34;&#34;&#34;An event value to use as a default.
+
+    Returns:
+      The default event value.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def encode_event(self, event):
+    &#34;&#34;&#34;Convert from an event value to an encoding integer.
+
+    Args:
+      event: An event value to encode.
+
+    Returns:
+      An integer representing the encoded event, in range [0, self.num_classes).
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def decode_event(self, index):
+    &#34;&#34;&#34;Convert from an encoding integer to an event value.
+
+    Args:
+      index: The encoding, an integer in the range [0, self.num_classes).
+
+    Returns:
+      The decoded event value.
+    &#34;&#34;&#34;
+    pass
+
+  def event_to_num_steps(self, unused_event):
+    &#34;&#34;&#34;Returns the number of time steps corresponding to an event value.
+
+    This is used for normalization when computing metrics. Subclasses with
+    variable step size should override this method.
+
+    Args:
+      unused_event: An event value for which to return the number of steps.
+
+    Returns:
+      The number of steps corresponding to the given event value, defaulting to
+      one.
+    &#34;&#34;&#34;
+    return 1
+
+
+class EventSequenceEncoderDecoder(object):
+  &#34;&#34;&#34;An abstract class for translating between events and model data.
+
+  When building your dataset, the `encode` method takes in an event sequence
+  and returns inputs and labels that can be fed into the model during training
+  and evaluation.
+
+  During generation, the `get_inputs_batch` method takes in a list of the
+  current event sequences and returns an inputs batch which is fed into the
+  model to predict what the next event should be for each sequence. The
+  `extend_event_sequences` method takes in the list of event sequences and the
+  softmax returned by the model and extends each sequence by one step by
+  sampling from the softmax probabilities. This loop (`get_inputs_batch` -&gt;
+  inputs batch is fed through the model to get a softmax -&gt;
+  `extend_event_sequences`) is repeated until the generated event sequences
+  have reached the desired length.
+
+  Properties:
+    input_size: The length of the list returned by self.events_to_input.
+    num_classes: The range of ints that can be returned by
+        self.events_to_label.
+
+  The `input_size`, `num_classes`, `events_to_input`, `events_to_label`, and
+  `class_index_to_event` method must be overwritten to be specific to your
+  model.
+  &#34;&#34;&#34;
+
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def input_size(self):
+    &#34;&#34;&#34;The size of the input vector used by this model.
+
+    Returns:
+        An integer, the length of the list returned by self.events_to_input.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def num_classes(self):
+    &#34;&#34;&#34;The range of labels used by this model.
+
+    Returns:
+        An integer, the range of integers that can be returned by
+            self.events_to_label.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_event_label(self):
+    &#34;&#34;&#34;The class label that represents a default event.
+
+    Returns:
+      An int, the class label that represents a default event.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the sequence.
+
+    Returns:
+      An input vector, a self.input_size length list of floats.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the sequence.
+
+    Returns:
+      A label, an integer in the range [0, self.num_classes).
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    pass
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    This is used for normalization when computing metrics. Subclasses with
+    variable step size should override this method.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, defaulting to one
+      per event.
+    &#34;&#34;&#34;
+    return len(labels)
+
+  def encode(self, events):
+    &#34;&#34;&#34;Returns inputs and labels for the given event sequence.
+
+    Args:
+      events: A list-like sequence of events.
+
+    Returns:
+      The inputs and labels.
+    &#34;&#34;&#34;
+    inputs = []
+    labels = []
+    for i in range(len(events) - 1):
+      inputs.append(self.events_to_input(events, i))
+      labels.append(self.events_to_label(events, i + 1))
+    return inputs, labels
+
+  def get_inputs_batch(self, event_sequences, full_length=False):
+    &#34;&#34;&#34;Returns an inputs batch for the given event sequences.
+
+    Args:
+      event_sequences: A list of list-like event sequences.
+      full_length: If True, the inputs batch will be for the full length of
+          each event sequence. If False, the inputs batch will only be for the
+          last event of each event sequence. A full-length inputs batch is used
+          for the first step of extending the event sequences, since the RNN
+          cell state needs to be initialized with the priming sequence. For
+          subsequent generation steps, only a last-event inputs batch is used.
+
+    Returns:
+      An inputs batch. If `full_length` is True, the shape will be
+      [len(event_sequences), len(event_sequences[0]), INPUT_SIZE]. If
+      `full_length` is False, the shape will be
+      [len(event_sequences), 1, INPUT_SIZE].
+    &#34;&#34;&#34;
+    inputs_batch = []
+    for events in event_sequences:
+      inputs = []
+      if full_length:
+        for i in range(len(events)):
+          inputs.append(self.events_to_input(events, i))
+      else:
+        inputs.append(self.events_to_input(events, len(events) - 1))
+      inputs_batch.append(inputs)
+    return inputs_batch
+
+  def extend_event_sequences(self, event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+    Args:
+      event_sequences: A list of EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list of chosen class indices, one for each event sequence.
+    &#34;&#34;&#34;
+    chosen_classes = []
+    for i in range(len(event_sequences)):
+      if not isinstance(softmax[0][0][0], numbers.Number):
+        # In this case, softmax is a list of several sub-softmaxes, each
+        # potentially with a different size.
+        # shape: [[beam_size, event_num, softmax_size]]
+        chosen_class = []
+        for sub_softmax in softmax:
+          num_classes = len(sub_softmax[0][0])
+          chosen_class.append(
+              np.random.choice(num_classes, p=sub_softmax[i][-1]))
+      else:
+        # In this case, softmax is just one softmax.
+        # shape: [beam_size, event_num, softmax_size]
+        num_classes = len(softmax[0][0])
+        chosen_class = np.random.choice(num_classes, p=softmax[i][-1])
+      event = self.class_index_to_event(chosen_class, event_sequences[i])
+      event_sequences[i].append(event)
+      chosen_classes.append(chosen_class)
+    return chosen_classes
+
+  def evaluate_log_likelihood(self, event_sequences, softmax):
+    &#34;&#34;&#34;Evaluate the log likelihood of multiple event sequences.
+
+    Each event sequence is evaluated from the end. If the size of the
+    corresponding softmax vector is 1 less than the number of events, the entire
+    event sequence will be evaluated (other than the first event, whose
+    distribution is not modeled). If the softmax vector is shorter than this,
+    only the events at the end of the sequence will be evaluated.
+
+    Args:
+      event_sequences: A list of EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list containing the log likelihood of each event sequence.
+
+    Raises:
+      ValueError: If one of the event sequences is too long with respect to the
+          corresponding softmax vectors.
+    &#34;&#34;&#34;
+    all_loglik = []
+    for i in range(len(event_sequences)):
+      if len(softmax[i]) &gt;= len(event_sequences[i]):
+        raise ValueError(
+            &#39;event sequence must be longer than softmax vector (%d events but &#39;
+            &#39;softmax vector has length %d)&#39; % (len(event_sequences[i]),
+                                               len(softmax[i])))
+      end_pos = len(event_sequences[i])
+      start_pos = end_pos - len(softmax[i])
+      loglik = 0.0
+      for softmax_pos, position in enumerate(range(start_pos, end_pos)):
+        index = self.events_to_label(event_sequences[i], position)
+        if isinstance(index, numbers.Number):
+          loglik += np.log(softmax[i][softmax_pos][index])
+        else:
+          for sub_softmax_i in range(len(index)):
+            loglik += np.log(
+                softmax[i][softmax_pos][sub_softmax_i][index[sub_softmax_i]])
+      all_loglik.append(loglik)
+    return all_loglik
+
+
+class OneHotEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces a one-hot encoding.&#34;&#34;&#34;
+
+  def __init__(self, one_hot_encoding):
+    &#34;&#34;&#34;Initialize a OneHotEventSequenceEncoderDecoder object.
+
+    Args:
+      one_hot_encoding: A OneHotEncoding object that transforms events to and
+          from integer indices.
+    &#34;&#34;&#34;
+    self._one_hot_encoding = one_hot_encoding
+
+  @property
+  def input_size(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a one-hot vector for the given position in the event sequence, as
+    determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    input_[self._one_hot_encoding.encode_event(events[position])] = 1.0
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns the zero-based index value for the given position in the event
+    sequence, as determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)
+
+
+class OneHotIndexEventSequenceEncoderDecoder(OneHotEventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces one-hot indices.&#34;&#34;&#34;
+
+  @property
+  def input_size(self):
+    return 1
+
+  @property
+  def input_depth(self):
+    return self._one_hot_encoding.num_classes
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the one-hot index for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An integer input event index.
+    &#34;&#34;&#34;
+    return [self._one_hot_encoding.encode_event(events[position])]
+
+
+class LookbackEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that encodes repeated events and meter.&#34;&#34;&#34;
+
+  def __init__(self, one_hot_encoding, lookback_distances=None,
+               binary_counter_bits=5):
+    &#34;&#34;&#34;Initializes the LookbackEventSequenceEncoderDecoder.
+
+    Args:
+      one_hot_encoding: A OneHotEncoding object that transforms events to and
+         from integer indices.
+      lookback_distances: A list of step intervals to look back in history to
+         encode both the following event and whether the current step is a
+         repeat. If None, use default lookback distances.
+      binary_counter_bits: The number of input bits to use as a counter for the
+         metric position of the next event.
+    &#34;&#34;&#34;
+    self._one_hot_encoding = one_hot_encoding
+    if lookback_distances is None:
+      self._lookback_distances = DEFAULT_LOOKBACK_DISTANCES
+    else:
+      self._lookback_distances = lookback_distances
+    self._binary_counter_bits = binary_counter_bits
+
+  @property
+  def input_size(self):
+    one_hot_size = self._one_hot_encoding.num_classes
+    num_lookbacks = len(self._lookback_distances)
+    return (one_hot_size +                  # current event
+            num_lookbacks * one_hot_size +  # next event for each lookback
+            self._binary_counter_bits +     # binary counters
+            num_lookbacks)                  # whether event matches lookbacks
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes + len(self._lookback_distances)
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a self.input_size length list of floats. Assuming a one-hot
+    encoding with 38 classes, two lookback distances, and five binary counters,
+    self.input_size will = 121. Each index represents a different input signal
+    to the model.
+
+    Indices [0, 120]:
+    [0, 37]: Event of current step.
+    [38, 75]: Event of next step for first lookback.
+    [76, 113]: Event of next step for second lookback.
+    114: 16th note binary counter.
+    115: 8th note binary counter.
+    116: 4th note binary counter.
+    117: Half note binary counter.
+    118: Whole note binary counter.
+    119: The current step is repeating (first lookback).
+    120: The current step is repeating (second lookback).
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer position in the event sequence.
+
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    offset = 0
+
+    # Last event.
+    index = self._one_hot_encoding.encode_event(events[position])
+    input_[index] = 1.0
+    offset += self._one_hot_encoding.num_classes
+
+    # Next event if repeating N positions ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance + 1
+      if lookback_position &lt; 0:
+        event = self._one_hot_encoding.default_event
+      else:
+        event = events[lookback_position]
+      index = self._one_hot_encoding.encode_event(event)
+      input_[offset + index] = 1.0
+      offset += self._one_hot_encoding.num_classes
+
+    # Binary time counter giving the metric location of the *next* event.
+    n = position + 1
+    for i in range(self._binary_counter_bits):
+      input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+      offset += 1
+
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        input_[offset] = 1.0
+      offset += 1
+
+    assert offset == self.input_size
+
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns an integer in the range [0, self.num_classes). Indices in the range
+    [0, self._one_hot_encoding.num_classes) map to standard events. Indices
+    self._one_hot_encoding.num_classes and self._one_hot_encoding.num_classes +
+    1 are signals to repeat events from earlier in the sequence. More distant
+    repeats are selected first and standard events are selected last.
+
+    Assuming a one-hot encoding with 38 classes and two lookback distances,
+    self.num_classes = 40 and the values will be as follows.
+
+    Values [0, 39]:
+      [0, 37]: Event of the last step in the event sequence, if not repeating
+               any of the lookbacks.
+      38: If the last event is repeating the first lookback, if not also
+          repeating the second lookback.
+      39: If the last event is repeating the second lookback.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    if (self._lookback_distances and
+        position &lt; self._lookback_distances[-1] and
+        events[position] == self._one_hot_encoding.default_event):
+      return (self._one_hot_encoding.num_classes +
+              len(self._lookback_distances) - 1)
+
+    # If last step repeated N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        return self._one_hot_encoding.num_classes + i
+
+    # If last step didn&#39;t repeat at one of the lookback positions, use the
+    # specific event.
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An int in the range [0, self.num_classes).
+      events: The current event sequence.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    # Repeat N bar ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      if class_index == self._one_hot_encoding.num_classes + i:
+        if len(events) &lt; lookback_distance:
+          return self._one_hot_encoding.default_event
+        return events[-lookback_distance]
+
+    # Return the event for that class index.
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    This method assumes the event sequence begins with the event corresponding
+    to the first label, which is inconsistent with the `encode` method in
+    EventSequenceEncoderDecoder that uses the second event as the first label.
+    Therefore, if the label sequence includes a lookback to the very first event
+    and that event is a different number of time steps than the default event,
+    this method will give an incorrect answer.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)
+
+
+class ConditionalEventSequenceEncoderDecoder(object):
+  &#34;&#34;&#34;An encoder/decoder for conditional event sequences.
+
+  This class is similar to an EventSequenceEncoderDecoder but operates on
+  *conditional* event sequences, where there is both a control event sequence
+  and a target event sequence. The target sequence consists of events that are
+  directly generated by the model, while the control sequence, known in advance,
+  affects the inputs provided to the model. The event types of the two sequences
+  can be different.
+
+  Model inputs are determined by both control and target sequences, and are
+  formed by concatenating the encoded control and target input vectors. Model
+  outputs are determined by the target sequence only.
+
+  This implementation assumes that the control event at position `i` is known
+  when the target event at position `i` is to be generated.
+
+  Properties:
+    input_size: The length of the list returned by self.events_to_input.
+    num_classes: The range of ints that can be returned by
+        self.events_to_label.
+  &#34;&#34;&#34;
+
+  def __init__(self, control_encoder_decoder, target_encoder_decoder):
+    &#34;&#34;&#34;Initialize a ConditionalEventSequenceEncoderDecoder object.
+
+    Args:
+      control_encoder_decoder: The EventSequenceEncoderDecoder to encode/decode
+          the control sequence.
+      target_encoder_decoder: The EventSequenceEncoderDecoder to encode/decode
+          the target sequence.
+    &#34;&#34;&#34;
+    self._control_encoder_decoder = control_encoder_decoder
+    self._target_encoder_decoder = target_encoder_decoder
+
+  @property
+  def input_size(self):
+    &#34;&#34;&#34;The size of the concatenated control and target input vectors.
+
+    Returns:
+        An integer, the size of an input vector.
+    &#34;&#34;&#34;
+    return (self._control_encoder_decoder.input_size +
+            self._target_encoder_decoder.input_size)
+
+  @property
+  def num_classes(self):
+    &#34;&#34;&#34;The range of target labels used by this model.
+
+    Returns:
+        An integer, the range of integers that can be returned by
+            self.events_to_label.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.num_classes
+
+  @property
+  def default_event_label(self):
+    &#34;&#34;&#34;The class label that represents a default target event.
+
+    Returns:
+      An integer, the class label that represents a default target event.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.default_event_label
+
+  def events_to_input(self, control_events, target_events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the sequence pair.
+
+    Returns the vector formed by concatenating the input vector for the control
+    sequence and the input vector for the target sequence.
+
+    Args:
+      control_events: A list-like sequence of control events.
+      target_events: A list-like sequence of target events.
+      position: An integer event position in the event sequences. When
+          predicting the target label at position `i + 1`, the input vector is
+          the concatenation of the control input vector at position `i + 1` and
+          the target input vector at position `i`.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    return (
+        self._control_encoder_decoder.events_to_input(
+            control_events, position + 1) +
+        self._target_encoder_decoder.events_to_input(target_events, position))
+
+  def events_to_label(self, target_events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the target event sequence.
+
+    Args:
+      target_events: A list-like sequence of target events.
+      position: An integer event position in the target event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.events_to_label(target_events, position)
+
+  def class_index_to_event(self, class_index, target_events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      target_events: A list-like sequence of target events.
+
+    Returns:
+      A target event value.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.class_index_to_event(
+        class_index, target_events)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the target encoder/decoder.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.labels_to_num_steps(labels)
+
+  def encode(self, control_events, target_events):
+    &#34;&#34;&#34;Returns inputs and labels for the given event sequence pair.
+
+    Args:
+      control_events: A list-like sequence of control events.
+      target_events: A list-like sequence of target events, the same length as
+          `control_events`.
+
+    Returns:
+      Inputs and labels.
+
+    Raises:
+      ValueError: If the control and target event sequences have different
+          length.
+    &#34;&#34;&#34;
+    if len(control_events) != len(target_events):
+      raise ValueError(&#39;must have the same number of control and target events &#39;
+                       &#39;(%d control events but %d target events)&#39; % (
+                           len(control_events), len(target_events)))
+
+    inputs = []
+    labels = []
+    for i in range(len(target_events) - 1):
+      inputs.append(self.events_to_input(control_events, target_events, i))
+      labels.append(self.events_to_label(target_events, i + 1))
+    return inputs, labels
+
+  def get_inputs_batch(self, control_event_sequences, target_event_sequences,
+                       full_length=False):
+    &#34;&#34;&#34;Returns an inputs batch for the given control and target event sequences.
+
+    Args:
+      control_event_sequences: A list of list-like control event sequences.
+      target_event_sequences: A list of list-like target event sequences, the
+          same length as `control_event_sequences`. Each target event sequence
+          must be shorter than the corresponding control event sequence.
+      full_length: If True, the inputs batch will be for the full length of
+          each control/target event sequence pair. If False, the inputs batch
+          will only be for the last event of each target event sequence. A full-
+          length inputs batch is used for the first step of extending the target
+          event sequences, since the RNN cell state needs to be initialized with
+          the priming target sequence. For subsequent generation steps, only a
+          last-event inputs batch is used.
+
+    Returns:
+      An inputs batch. If `full_length` is True, the shape will be
+      [len(target_event_sequences), len(target_event_sequences[0]), INPUT_SIZE].
+      If `full_length` is False, the shape will be
+      [len(target_event_sequences), 1, INPUT_SIZE].
+
+    Raises:
+      ValueError: If there are a different number of control and target event
+          sequences, or if one of the control event sequences is not shorter
+          than the corresponding control event sequence.
+    &#34;&#34;&#34;
+    if len(control_event_sequences) != len(target_event_sequences):
+      raise ValueError(
+          &#39;%d control event sequences but %d target event sequences&#39; %
+          (len(control_event_sequences, len(target_event_sequences))))
+
+    inputs_batch = []
+    for control_events, target_events in zip(
+        control_event_sequences, target_event_sequences):
+      if len(control_events) &lt;= len(target_events):
+        raise ValueError(&#39;control event sequence must be longer than target &#39;
+                         &#39;event sequence (%d control events but %d target &#39;
+                         &#39;events)&#39; % (len(control_events), len(target_events)))
+      inputs = []
+      if full_length:
+        for i in range(len(target_events)):
+          inputs.append(self.events_to_input(control_events, target_events, i))
+      else:
+        inputs.append(self.events_to_input(
+            control_events, target_events, len(target_events) - 1))
+      inputs_batch.append(inputs)
+    return inputs_batch
+
+  def extend_event_sequences(self, target_event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+    Args:
+      target_event_sequences: A list of target EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list of chosen class indices, one for each target event sequence.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.extend_event_sequences(
+        target_event_sequences, softmax)
+
+  def evaluate_log_likelihood(self, target_event_sequences, softmax):
+    &#34;&#34;&#34;Evaluate the log likelihood of multiple target event sequences.
+
+    Args:
+      target_event_sequences: A list of target EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of target event sequences. The
+          softmax vectors are assumed to have been generated by a full-length
+          inputs batch.
+
+    Returns:
+      A Python list containing the log likelihood of each target event sequence.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.evaluate_log_likelihood(
+        target_event_sequences, softmax)
+
+
+class OptionalEventSequenceEncoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder that augments a base encoder with a disable flag.
+
+  This encoder encodes event sequences consisting of tuples where the first
+  element is a disable flag. When set, the encoding consists of a 1 followed by
+  a zero-encoding the size of the base encoder&#39;s input. When unset, the encoding
+  consists of a 0 followed by the base encoder&#39;s encoding.
+  &#34;&#34;&#34;
+
+  def __init__(self, encoder):
+    &#34;&#34;&#34;Initialize an OptionalEventSequenceEncoder object.
+
+    Args:
+      encoder: The base EventSequenceEncoderDecoder to use.
+    &#34;&#34;&#34;
+    self._encoder = encoder
+
+  @property
+  def input_size(self):
+    return 1 + self._encoder.input_size
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    # The event sequence is a list of tuples where the first element is a
+    # disable flag.
+    disable, _ = events[position]
+    if disable:
+      return [1.0] + [0.0] * self._encoder.input_size
+    else:
+      return [0.0] + self._encoder.events_to_input(
+          [event for _, event in events], position)
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError
+
+
+class MultipleEventSequenceEncoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder that concatenates multiple component encoders.
+
+  This class, largely intended for use with control sequences for conditional
+  encoder/decoders, encodes event sequences with multiple encoders and
+  concatenates the encodings.
+
+  Despite being an EventSequenceEncoderDecoder this class does not decode.
+  &#34;&#34;&#34;
+
+  def __init__(self, encoders, encode_single_sequence=False):
+    &#34;&#34;&#34;Initialize a MultipleEventSequenceEncoder object.
+
+    Args:
+      encoders: A list of component EventSequenceEncoderDecoder objects whose
+          output will be concatenated.
+      encode_single_sequence: If True, at encoding time all of the encoders will
+          be applied to a single event sequence. If False, each event of the
+          event sequence should be a tuple with size the same as the number of
+          encoders, each of which will be applied to the events in the
+          corresponding position in the tuple, i.e. the first encoder will be
+          applied to the first element of each event tuple, the second encoder
+          will be applied to the second element, etc.
+    &#34;&#34;&#34;
+    self._encoders = encoders
+    self._encode_single_sequence = encode_single_sequence
+
+  @property
+  def input_size(self):
+    return sum(encoder.input_size for encoder in self._encoders)
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    input_ = []
+    if self._encode_single_sequence:
+      # Apply all encoders to the event sequence.
+      for encoder in self._encoders:
+        input_ += encoder.events_to_input(events, position)
+    else:
+      # The event sequence is a list of tuples. Apply each encoder to the
+      # elements in the corresponding tuple position.
+      event_sequences = list(zip(*events))
+      if len(event_sequences) != len(self._encoders):
+        raise ValueError(
+            &#39;Event tuple size must be the same as the number of encoders.&#39;)
+      for encoder, event_sequence in zip(self._encoders, event_sequences):
+        input_ += encoder.events_to_input(event_sequence, position)
+    return input_
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">ConditionalEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>control_encoder_decoder, target_encoder_decoder)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An encoder/decoder for conditional event sequences.</p>
+<p>This class is similar to an EventSequenceEncoderDecoder but operates on
+<em>conditional</em> event sequences, where there is both a control event sequence
+and a target event sequence. The target sequence consists of events that are
+directly generated by the model, while the control sequence, known in advance,
+affects the inputs provided to the model. The event types of the two sequences
+can be different.</p>
+<p>Model inputs are determined by both control and target sequences, and are
+formed by concatenating the encoded control and target input vectors. Model
+outputs are determined by the target sequence only.</p>
+<p>This implementation assumes that the control event at position <code>i</code> is known
+when the target event at position <code>i</code> is to be generated.</p>
+<h2 id="properties">Properties</h2>
+<p>input_size: The length of the list returned by self.events_to_input.
+num_classes: The range of ints that can be returned by
+self.events_to_label.</p>
+<p>Initialize a ConditionalEventSequenceEncoderDecoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>control_encoder_decoder</code></strong></dt>
+<dd>The EventSequenceEncoderDecoder to encode/decode
+the control sequence.</dd>
+<dt><strong><code>target_encoder_decoder</code></strong></dt>
+<dd>The EventSequenceEncoderDecoder to encode/decode
+the target sequence.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ConditionalEventSequenceEncoderDecoder(object):
+  &#34;&#34;&#34;An encoder/decoder for conditional event sequences.
+
+  This class is similar to an EventSequenceEncoderDecoder but operates on
+  *conditional* event sequences, where there is both a control event sequence
+  and a target event sequence. The target sequence consists of events that are
+  directly generated by the model, while the control sequence, known in advance,
+  affects the inputs provided to the model. The event types of the two sequences
+  can be different.
+
+  Model inputs are determined by both control and target sequences, and are
+  formed by concatenating the encoded control and target input vectors. Model
+  outputs are determined by the target sequence only.
+
+  This implementation assumes that the control event at position `i` is known
+  when the target event at position `i` is to be generated.
+
+  Properties:
+    input_size: The length of the list returned by self.events_to_input.
+    num_classes: The range of ints that can be returned by
+        self.events_to_label.
+  &#34;&#34;&#34;
+
+  def __init__(self, control_encoder_decoder, target_encoder_decoder):
+    &#34;&#34;&#34;Initialize a ConditionalEventSequenceEncoderDecoder object.
+
+    Args:
+      control_encoder_decoder: The EventSequenceEncoderDecoder to encode/decode
+          the control sequence.
+      target_encoder_decoder: The EventSequenceEncoderDecoder to encode/decode
+          the target sequence.
+    &#34;&#34;&#34;
+    self._control_encoder_decoder = control_encoder_decoder
+    self._target_encoder_decoder = target_encoder_decoder
+
+  @property
+  def input_size(self):
+    &#34;&#34;&#34;The size of the concatenated control and target input vectors.
+
+    Returns:
+        An integer, the size of an input vector.
+    &#34;&#34;&#34;
+    return (self._control_encoder_decoder.input_size +
+            self._target_encoder_decoder.input_size)
+
+  @property
+  def num_classes(self):
+    &#34;&#34;&#34;The range of target labels used by this model.
+
+    Returns:
+        An integer, the range of integers that can be returned by
+            self.events_to_label.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.num_classes
+
+  @property
+  def default_event_label(self):
+    &#34;&#34;&#34;The class label that represents a default target event.
+
+    Returns:
+      An integer, the class label that represents a default target event.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.default_event_label
+
+  def events_to_input(self, control_events, target_events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the sequence pair.
+
+    Returns the vector formed by concatenating the input vector for the control
+    sequence and the input vector for the target sequence.
+
+    Args:
+      control_events: A list-like sequence of control events.
+      target_events: A list-like sequence of target events.
+      position: An integer event position in the event sequences. When
+          predicting the target label at position `i + 1`, the input vector is
+          the concatenation of the control input vector at position `i + 1` and
+          the target input vector at position `i`.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    return (
+        self._control_encoder_decoder.events_to_input(
+            control_events, position + 1) +
+        self._target_encoder_decoder.events_to_input(target_events, position))
+
+  def events_to_label(self, target_events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the target event sequence.
+
+    Args:
+      target_events: A list-like sequence of target events.
+      position: An integer event position in the target event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.events_to_label(target_events, position)
+
+  def class_index_to_event(self, class_index, target_events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      target_events: A list-like sequence of target events.
+
+    Returns:
+      A target event value.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.class_index_to_event(
+        class_index, target_events)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the target encoder/decoder.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.labels_to_num_steps(labels)
+
+  def encode(self, control_events, target_events):
+    &#34;&#34;&#34;Returns inputs and labels for the given event sequence pair.
+
+    Args:
+      control_events: A list-like sequence of control events.
+      target_events: A list-like sequence of target events, the same length as
+          `control_events`.
+
+    Returns:
+      Inputs and labels.
+
+    Raises:
+      ValueError: If the control and target event sequences have different
+          length.
+    &#34;&#34;&#34;
+    if len(control_events) != len(target_events):
+      raise ValueError(&#39;must have the same number of control and target events &#39;
+                       &#39;(%d control events but %d target events)&#39; % (
+                           len(control_events), len(target_events)))
+
+    inputs = []
+    labels = []
+    for i in range(len(target_events) - 1):
+      inputs.append(self.events_to_input(control_events, target_events, i))
+      labels.append(self.events_to_label(target_events, i + 1))
+    return inputs, labels
+
+  def get_inputs_batch(self, control_event_sequences, target_event_sequences,
+                       full_length=False):
+    &#34;&#34;&#34;Returns an inputs batch for the given control and target event sequences.
+
+    Args:
+      control_event_sequences: A list of list-like control event sequences.
+      target_event_sequences: A list of list-like target event sequences, the
+          same length as `control_event_sequences`. Each target event sequence
+          must be shorter than the corresponding control event sequence.
+      full_length: If True, the inputs batch will be for the full length of
+          each control/target event sequence pair. If False, the inputs batch
+          will only be for the last event of each target event sequence. A full-
+          length inputs batch is used for the first step of extending the target
+          event sequences, since the RNN cell state needs to be initialized with
+          the priming target sequence. For subsequent generation steps, only a
+          last-event inputs batch is used.
+
+    Returns:
+      An inputs batch. If `full_length` is True, the shape will be
+      [len(target_event_sequences), len(target_event_sequences[0]), INPUT_SIZE].
+      If `full_length` is False, the shape will be
+      [len(target_event_sequences), 1, INPUT_SIZE].
+
+    Raises:
+      ValueError: If there are a different number of control and target event
+          sequences, or if one of the control event sequences is not shorter
+          than the corresponding control event sequence.
+    &#34;&#34;&#34;
+    if len(control_event_sequences) != len(target_event_sequences):
+      raise ValueError(
+          &#39;%d control event sequences but %d target event sequences&#39; %
+          (len(control_event_sequences, len(target_event_sequences))))
+
+    inputs_batch = []
+    for control_events, target_events in zip(
+        control_event_sequences, target_event_sequences):
+      if len(control_events) &lt;= len(target_events):
+        raise ValueError(&#39;control event sequence must be longer than target &#39;
+                         &#39;event sequence (%d control events but %d target &#39;
+                         &#39;events)&#39; % (len(control_events), len(target_events)))
+      inputs = []
+      if full_length:
+        for i in range(len(target_events)):
+          inputs.append(self.events_to_input(control_events, target_events, i))
+      else:
+        inputs.append(self.events_to_input(
+            control_events, target_events, len(target_events) - 1))
+      inputs_batch.append(inputs)
+    return inputs_batch
+
+  def extend_event_sequences(self, target_event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+    Args:
+      target_event_sequences: A list of target EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list of chosen class indices, one for each target event sequence.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.extend_event_sequences(
+        target_event_sequences, softmax)
+
+  def evaluate_log_likelihood(self, target_event_sequences, softmax):
+    &#34;&#34;&#34;Evaluate the log likelihood of multiple target event sequences.
+
+    Args:
+      target_event_sequences: A list of target EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of target event sequences. The
+          softmax vectors are assumed to have been generated by a full-length
+          inputs batch.
+
+    Returns:
+      A Python list containing the log likelihood of each target event sequence.
+    &#34;&#34;&#34;
+    return self._target_encoder_decoder.evaluate_log_likelihood(
+        target_event_sequences, softmax)</code></pre>
+</details>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.default_event_label"><code class="name">var <span class="ident">default_event_label</span></code></dt>
+<dd>
+<div class="desc"><p>The class label that represents a default target event.</p>
+<h2 id="returns">Returns</h2>
+<p>An integer, the class label that represents a default target event.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def default_event_label(self):
+  &#34;&#34;&#34;The class label that represents a default target event.
+
+  Returns:
+    An integer, the class label that represents a default target event.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.default_event_label</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.input_size"><code class="name">var <span class="ident">input_size</span></code></dt>
+<dd>
+<div class="desc"><p>The size of the concatenated control and target input vectors.</p>
+<h2 id="returns">Returns</h2>
+<p>An integer, the size of an input vector.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def input_size(self):
+  &#34;&#34;&#34;The size of the concatenated control and target input vectors.
+
+  Returns:
+      An integer, the size of an input vector.
+  &#34;&#34;&#34;
+  return (self._control_encoder_decoder.input_size +
+          self._target_encoder_decoder.input_size)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.num_classes"><code class="name">var <span class="ident">num_classes</span></code></dt>
+<dd>
+<div class="desc"><p>The range of target labels used by this model.</p>
+<h2 id="returns">Returns</h2>
+<p>An integer, the range of integers that can be returned by
+self.events_to_label.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def num_classes(self):
+  &#34;&#34;&#34;The range of target labels used by this model.
+
+  Returns:
+      An integer, the range of integers that can be returned by
+          self.events_to_label.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.num_classes</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, target_events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An integer in the range [0, self.num_classes).</dd>
+<dt><strong><code>target_events</code></strong></dt>
+<dd>A list-like sequence of target events.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A target event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, target_events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An integer in the range [0, self.num_classes).
+    target_events: A list-like sequence of target events.
+
+  Returns:
+    A target event value.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.class_index_to_event(
+      class_index, target_events)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.encode"><code class="name flex">
+<span>def <span class="ident">encode</span></span>(<span>self, control_events, target_events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns inputs and labels for the given event sequence pair.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>control_events</code></strong></dt>
+<dd>A list-like sequence of control events.</dd>
+<dt><strong><code>target_events</code></strong></dt>
+<dd>A list-like sequence of target events, the same length as
+<code>control_events</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Inputs and labels.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If the control and target event sequences have different
+length.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def encode(self, control_events, target_events):
+  &#34;&#34;&#34;Returns inputs and labels for the given event sequence pair.
+
+  Args:
+    control_events: A list-like sequence of control events.
+    target_events: A list-like sequence of target events, the same length as
+        `control_events`.
+
+  Returns:
+    Inputs and labels.
+
+  Raises:
+    ValueError: If the control and target event sequences have different
+        length.
+  &#34;&#34;&#34;
+  if len(control_events) != len(target_events):
+    raise ValueError(&#39;must have the same number of control and target events &#39;
+                     &#39;(%d control events but %d target events)&#39; % (
+                         len(control_events), len(target_events)))
+
+  inputs = []
+  labels = []
+  for i in range(len(target_events) - 1):
+    inputs.append(self.events_to_input(control_events, target_events, i))
+    labels.append(self.events_to_label(target_events, i + 1))
+  return inputs, labels</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.evaluate_log_likelihood"><code class="name flex">
+<span>def <span class="ident">evaluate_log_likelihood</span></span>(<span>self, target_event_sequences, softmax)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Evaluate the log likelihood of multiple target event sequences.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>target_event_sequences</code></strong></dt>
+<dd>A list of target EventSequence objects.</dd>
+<dt><strong><code>softmax</code></strong></dt>
+<dd>A list of softmax probability vectors. The list of softmaxes
+should be the same length as the list of target event sequences. The
+softmax vectors are assumed to have been generated by a full-length
+inputs batch.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list containing the log likelihood of each target event sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def evaluate_log_likelihood(self, target_event_sequences, softmax):
+  &#34;&#34;&#34;Evaluate the log likelihood of multiple target event sequences.
+
+  Args:
+    target_event_sequences: A list of target EventSequence objects.
+    softmax: A list of softmax probability vectors. The list of softmaxes
+        should be the same length as the list of target event sequences. The
+        softmax vectors are assumed to have been generated by a full-length
+        inputs batch.
+
+  Returns:
+    A Python list containing the log likelihood of each target event sequence.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.evaluate_log_likelihood(
+      target_event_sequences, softmax)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, control_events, target_events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the sequence pair.</p>
+<p>Returns the vector formed by concatenating the input vector for the control
+sequence and the input vector for the target sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>control_events</code></strong></dt>
+<dd>A list-like sequence of control events.</dd>
+<dt><strong><code>target_events</code></strong></dt>
+<dd>A list-like sequence of target events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequences. When
+predicting the target label at position <code>i + 1</code>, the input vector is
+the concatenation of the control input vector at position <code>i + 1</code> and
+the target input vector at position <code>i</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, a list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, control_events, target_events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the sequence pair.
+
+  Returns the vector formed by concatenating the input vector for the control
+  sequence and the input vector for the target sequence.
+
+  Args:
+    control_events: A list-like sequence of control events.
+    target_events: A list-like sequence of target events.
+    position: An integer event position in the event sequences. When
+        predicting the target label at position `i + 1`, the input vector is
+        the concatenation of the control input vector at position `i + 1` and
+        the target input vector at position `i`.
+
+  Returns:
+    An input vector, a list of floats.
+  &#34;&#34;&#34;
+  return (
+      self._control_encoder_decoder.events_to_input(
+          control_events, position + 1) +
+      self._target_encoder_decoder.events_to_input(target_events, position))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, target_events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the target event sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>target_events</code></strong></dt>
+<dd>A list-like sequence of target events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the target event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, target_events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the target event sequence.
+
+  Args:
+    target_events: A list-like sequence of target events.
+    position: An integer event position in the target event sequence.
+
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.events_to_label(target_events, position)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.extend_event_sequences"><code class="name flex">
+<span>def <span class="ident">extend_event_sequences</span></span>(<span>self, target_event_sequences, softmax)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extends the event sequences by sampling the softmax probabilities.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>target_event_sequences</code></strong></dt>
+<dd>A list of target EventSequence objects.</dd>
+<dt><strong><code>softmax</code></strong></dt>
+<dd>A list of softmax probability vectors. The list of softmaxes
+should be the same length as the list of event sequences.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list of chosen class indices, one for each target event sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extend_event_sequences(self, target_event_sequences, softmax):
+  &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+  Args:
+    target_event_sequences: A list of target EventSequence objects.
+    softmax: A list of softmax probability vectors. The list of softmaxes
+        should be the same length as the list of event sequences.
+
+  Returns:
+    A Python list of chosen class indices, one for each target event sequence.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.extend_event_sequences(
+      target_event_sequences, softmax)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.get_inputs_batch"><code class="name flex">
+<span>def <span class="ident">get_inputs_batch</span></span>(<span>self, control_event_sequences, target_event_sequences, full_length=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an inputs batch for the given control and target event sequences.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>control_event_sequences</code></strong></dt>
+<dd>A list of list-like control event sequences.</dd>
+<dt><strong><code>target_event_sequences</code></strong></dt>
+<dd>A list of list-like target event sequences, the
+same length as <code>control_event_sequences</code>. Each target event sequence
+must be shorter than the corresponding control event sequence.</dd>
+<dt><strong><code>full_length</code></strong></dt>
+<dd>If True, the inputs batch will be for the full length of
+each control/target event sequence pair. If False, the inputs batch
+will only be for the last event of each target event sequence. A full-
+length inputs batch is used for the first step of extending the target
+event sequences, since the RNN cell state needs to be initialized with
+the priming target sequence. For subsequent generation steps, only a
+last-event inputs batch is used.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An inputs batch. If <code>full_length</code> is True, the shape will be
+[len(target_event_sequences), len(target_event_sequences[0]), INPUT_SIZE].
+If <code>full_length</code> is False, the shape will be
+[len(target_event_sequences), 1, INPUT_SIZE].</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If there are a different number of control and target event
+sequences, or if one of the control event sequences is not shorter
+than the corresponding control event sequence.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_inputs_batch(self, control_event_sequences, target_event_sequences,
+                     full_length=False):
+  &#34;&#34;&#34;Returns an inputs batch for the given control and target event sequences.
+
+  Args:
+    control_event_sequences: A list of list-like control event sequences.
+    target_event_sequences: A list of list-like target event sequences, the
+        same length as `control_event_sequences`. Each target event sequence
+        must be shorter than the corresponding control event sequence.
+    full_length: If True, the inputs batch will be for the full length of
+        each control/target event sequence pair. If False, the inputs batch
+        will only be for the last event of each target event sequence. A full-
+        length inputs batch is used for the first step of extending the target
+        event sequences, since the RNN cell state needs to be initialized with
+        the priming target sequence. For subsequent generation steps, only a
+        last-event inputs batch is used.
+
+  Returns:
+    An inputs batch. If `full_length` is True, the shape will be
+    [len(target_event_sequences), len(target_event_sequences[0]), INPUT_SIZE].
+    If `full_length` is False, the shape will be
+    [len(target_event_sequences), 1, INPUT_SIZE].
+
+  Raises:
+    ValueError: If there are a different number of control and target event
+        sequences, or if one of the control event sequences is not shorter
+        than the corresponding control event sequence.
+  &#34;&#34;&#34;
+  if len(control_event_sequences) != len(target_event_sequences):
+    raise ValueError(
+        &#39;%d control event sequences but %d target event sequences&#39; %
+        (len(control_event_sequences, len(target_event_sequences))))
+
+  inputs_batch = []
+  for control_events, target_events in zip(
+      control_event_sequences, target_event_sequences):
+    if len(control_events) &lt;= len(target_events):
+      raise ValueError(&#39;control event sequence must be longer than target &#39;
+                       &#39;event sequence (%d control events but %d target &#39;
+                       &#39;events)&#39; % (len(control_events), len(target_events)))
+    inputs = []
+    if full_length:
+      for i in range(len(target_events)):
+        inputs.append(self.events_to_input(control_events, target_events, i))
+    else:
+      inputs.append(self.events_to_input(
+          control_events, target_events, len(target_events) - 1))
+    inputs_batch.append(inputs)
+  return inputs_batch</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.labels_to_num_steps"><code class="name flex">
+<span>def <span class="ident">labels_to_num_steps</span></span>(<span>self, labels)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the total number of time steps for a sequence of class labels.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>labels</code></strong></dt>
+<dd>A list-like sequence of integers in the range
+[0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The total number of time steps for the label sequence, as determined by
+the target encoder/decoder.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def labels_to_num_steps(self, labels):
+  &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+  Args:
+    labels: A list-like sequence of integers in the range
+        [0, self.num_classes).
+
+  Returns:
+    The total number of time steps for the label sequence, as determined by
+    the target encoder/decoder.
+  &#34;&#34;&#34;
+  return self._target_encoder_decoder.labels_to_num_steps(labels)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">EventSequenceEncoderDecoder</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>An abstract class for translating between events and model data.</p>
+<p>When building your dataset, the <code>encode</code> method takes in an event sequence
+and returns inputs and labels that can be fed into the model during training
+and evaluation.</p>
+<p>During generation, the <code>get_inputs_batch</code> method takes in a list of the
+current event sequences and returns an inputs batch which is fed into the
+model to predict what the next event should be for each sequence. The
+<code>extend_event_sequences</code> method takes in the list of event sequences and the
+softmax returned by the model and extends each sequence by one step by
+sampling from the softmax probabilities. This loop (<code>get_inputs_batch</code> -&gt;
+inputs batch is fed through the model to get a softmax -&gt;
+<code>extend_event_sequences</code>) is repeated until the generated event sequences
+have reached the desired length.</p>
+<h2 id="properties">Properties</h2>
+<p>input_size: The length of the list returned by self.events_to_input.
+num_classes: The range of ints that can be returned by
+self.events_to_label.</p>
+<p>The <code>input_size</code>, <code>num_classes</code>, <code>events_to_input</code>, <code>events_to_label</code>, and
+<code>class_index_to_event</code> method must be overwritten to be specific to your
+model.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EventSequenceEncoderDecoder(object):
+  &#34;&#34;&#34;An abstract class for translating between events and model data.
+
+  When building your dataset, the `encode` method takes in an event sequence
+  and returns inputs and labels that can be fed into the model during training
+  and evaluation.
+
+  During generation, the `get_inputs_batch` method takes in a list of the
+  current event sequences and returns an inputs batch which is fed into the
+  model to predict what the next event should be for each sequence. The
+  `extend_event_sequences` method takes in the list of event sequences and the
+  softmax returned by the model and extends each sequence by one step by
+  sampling from the softmax probabilities. This loop (`get_inputs_batch` -&gt;
+  inputs batch is fed through the model to get a softmax -&gt;
+  `extend_event_sequences`) is repeated until the generated event sequences
+  have reached the desired length.
+
+  Properties:
+    input_size: The length of the list returned by self.events_to_input.
+    num_classes: The range of ints that can be returned by
+        self.events_to_label.
+
+  The `input_size`, `num_classes`, `events_to_input`, `events_to_label`, and
+  `class_index_to_event` method must be overwritten to be specific to your
+  model.
+  &#34;&#34;&#34;
+
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def input_size(self):
+    &#34;&#34;&#34;The size of the input vector used by this model.
+
+    Returns:
+        An integer, the length of the list returned by self.events_to_input.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def num_classes(self):
+    &#34;&#34;&#34;The range of labels used by this model.
+
+    Returns:
+        An integer, the range of integers that can be returned by
+            self.events_to_label.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_event_label(self):
+    &#34;&#34;&#34;The class label that represents a default event.
+
+    Returns:
+      An int, the class label that represents a default event.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the sequence.
+
+    Returns:
+      An input vector, a self.input_size length list of floats.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the sequence.
+
+    Returns:
+      A label, an integer in the range [0, self.num_classes).
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    pass
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    This is used for normalization when computing metrics. Subclasses with
+    variable step size should override this method.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, defaulting to one
+      per event.
+    &#34;&#34;&#34;
+    return len(labels)
+
+  def encode(self, events):
+    &#34;&#34;&#34;Returns inputs and labels for the given event sequence.
+
+    Args:
+      events: A list-like sequence of events.
+
+    Returns:
+      The inputs and labels.
+    &#34;&#34;&#34;
+    inputs = []
+    labels = []
+    for i in range(len(events) - 1):
+      inputs.append(self.events_to_input(events, i))
+      labels.append(self.events_to_label(events, i + 1))
+    return inputs, labels
+
+  def get_inputs_batch(self, event_sequences, full_length=False):
+    &#34;&#34;&#34;Returns an inputs batch for the given event sequences.
+
+    Args:
+      event_sequences: A list of list-like event sequences.
+      full_length: If True, the inputs batch will be for the full length of
+          each event sequence. If False, the inputs batch will only be for the
+          last event of each event sequence. A full-length inputs batch is used
+          for the first step of extending the event sequences, since the RNN
+          cell state needs to be initialized with the priming sequence. For
+          subsequent generation steps, only a last-event inputs batch is used.
+
+    Returns:
+      An inputs batch. If `full_length` is True, the shape will be
+      [len(event_sequences), len(event_sequences[0]), INPUT_SIZE]. If
+      `full_length` is False, the shape will be
+      [len(event_sequences), 1, INPUT_SIZE].
+    &#34;&#34;&#34;
+    inputs_batch = []
+    for events in event_sequences:
+      inputs = []
+      if full_length:
+        for i in range(len(events)):
+          inputs.append(self.events_to_input(events, i))
+      else:
+        inputs.append(self.events_to_input(events, len(events) - 1))
+      inputs_batch.append(inputs)
+    return inputs_batch
+
+  def extend_event_sequences(self, event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+    Args:
+      event_sequences: A list of EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list of chosen class indices, one for each event sequence.
+    &#34;&#34;&#34;
+    chosen_classes = []
+    for i in range(len(event_sequences)):
+      if not isinstance(softmax[0][0][0], numbers.Number):
+        # In this case, softmax is a list of several sub-softmaxes, each
+        # potentially with a different size.
+        # shape: [[beam_size, event_num, softmax_size]]
+        chosen_class = []
+        for sub_softmax in softmax:
+          num_classes = len(sub_softmax[0][0])
+          chosen_class.append(
+              np.random.choice(num_classes, p=sub_softmax[i][-1]))
+      else:
+        # In this case, softmax is just one softmax.
+        # shape: [beam_size, event_num, softmax_size]
+        num_classes = len(softmax[0][0])
+        chosen_class = np.random.choice(num_classes, p=softmax[i][-1])
+      event = self.class_index_to_event(chosen_class, event_sequences[i])
+      event_sequences[i].append(event)
+      chosen_classes.append(chosen_class)
+    return chosen_classes
+
+  def evaluate_log_likelihood(self, event_sequences, softmax):
+    &#34;&#34;&#34;Evaluate the log likelihood of multiple event sequences.
+
+    Each event sequence is evaluated from the end. If the size of the
+    corresponding softmax vector is 1 less than the number of events, the entire
+    event sequence will be evaluated (other than the first event, whose
+    distribution is not modeled). If the softmax vector is shorter than this,
+    only the events at the end of the sequence will be evaluated.
+
+    Args:
+      event_sequences: A list of EventSequence objects.
+      softmax: A list of softmax probability vectors. The list of softmaxes
+          should be the same length as the list of event sequences.
+
+    Returns:
+      A Python list containing the log likelihood of each event sequence.
+
+    Raises:
+      ValueError: If one of the event sequences is too long with respect to the
+          corresponding softmax vectors.
+    &#34;&#34;&#34;
+    all_loglik = []
+    for i in range(len(event_sequences)):
+      if len(softmax[i]) &gt;= len(event_sequences[i]):
+        raise ValueError(
+            &#39;event sequence must be longer than softmax vector (%d events but &#39;
+            &#39;softmax vector has length %d)&#39; % (len(event_sequences[i]),
+                                               len(softmax[i])))
+      end_pos = len(event_sequences[i])
+      start_pos = end_pos - len(softmax[i])
+      loglik = 0.0
+      for softmax_pos, position in enumerate(range(start_pos, end_pos)):
+        index = self.events_to_label(event_sequences[i], position)
+        if isinstance(index, numbers.Number):
+          loglik += np.log(softmax[i][softmax_pos][index])
+        else:
+          for sub_softmax_i in range(len(index)):
+            loglik += np.log(
+                softmax[i][softmax_pos][sub_softmax_i][index[sub_softmax_i]])
+      all_loglik.append(loglik)
+    return all_loglik</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder" href="chords_encoder_decoder.html#note_seq.chords_encoder_decoder.PitchChordsEncoderDecoder">PitchChordsEncoderDecoder</a></li>
+<li><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder">LookbackEventSequenceEncoderDecoder</a></li>
+<li><a title="note_seq.encoder_decoder.MultipleEventSequenceEncoder" href="#note_seq.encoder_decoder.MultipleEventSequenceEncoder">MultipleEventSequenceEncoder</a></li>
+<li><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder">OneHotEventSequenceEncoderDecoder</a></li>
+<li><a title="note_seq.encoder_decoder.OptionalEventSequenceEncoder" href="#note_seq.encoder_decoder.OptionalEventSequenceEncoder">OptionalEventSequenceEncoder</a></li>
+<li><a title="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder" href="melody_encoder_decoder.html#note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder">KeyMelodyEncoderDecoder</a></li>
+<li><a title="note_seq.performance_controls.PitchHistogramPerformanceControlSignal.PitchHistogramEncoder" href="performance_controls.html#note_seq.performance_controls.PitchHistogramPerformanceControlSignal.PitchHistogramEncoder">PitchHistogramPerformanceControlSignal.PitchHistogramEncoder</a></li>
+<li><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder" href="performance_encoder_decoder.html#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder">ModuloPerformanceEventSequenceEncoderDecoder</a></li>
+<li><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder" href="performance_encoder_decoder.html#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder">NotePerformanceEventSequenceEncoderDecoder</a></li>
+<li><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder" href="pianoroll_encoder_decoder.html#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder">PianorollEncoderDecoder</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label"><code class="name">var <span class="ident">default_event_label</span></code></dt>
+<dd>
+<div class="desc"><p>The class label that represents a default event.</p>
+<h2 id="returns">Returns</h2>
+<p>An int, the class label that represents a default event.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def default_event_label(self):
+  &#34;&#34;&#34;The class label that represents a default event.
+
+  Returns:
+    An int, the class label that represents a default event.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size"><code class="name">var <span class="ident">input_size</span></code></dt>
+<dd>
+<div class="desc"><p>The size of the input vector used by this model.</p>
+<h2 id="returns">Returns</h2>
+<p>An integer, the length of the list returned by self.events_to_input.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def input_size(self):
+  &#34;&#34;&#34;The size of the input vector used by this model.
+
+  Returns:
+      An integer, the length of the list returned by self.events_to_input.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes"><code class="name">var <span class="ident">num_classes</span></code></dt>
+<dd>
+<div class="desc"><p>The range of labels used by this model.</p>
+<h2 id="returns">Returns</h2>
+<p>An integer, the range of integers that can be returned by
+self.events_to_label.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def num_classes(self):
+  &#34;&#34;&#34;The range of labels used by this model.
+
+  Returns:
+      An integer, the range of integers that can be returned by
+          self.events_to_label.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An integer in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An integer in the range [0, self.num_classes).
+    events: A list-like sequence of events.
+
+  Returns:
+    An event value.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode"><code class="name flex">
+<span>def <span class="ident">encode</span></span>(<span>self, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns inputs and labels for the given event sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The inputs and labels.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def encode(self, events):
+  &#34;&#34;&#34;Returns inputs and labels for the given event sequence.
+
+  Args:
+    events: A list-like sequence of events.
+
+  Returns:
+    The inputs and labels.
+  &#34;&#34;&#34;
+  inputs = []
+  labels = []
+  for i in range(len(events) - 1):
+    inputs.append(self.events_to_input(events, i))
+    labels.append(self.events_to_label(events, i + 1))
+  return inputs, labels</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood"><code class="name flex">
+<span>def <span class="ident">evaluate_log_likelihood</span></span>(<span>self, event_sequences, softmax)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Evaluate the log likelihood of multiple event sequences.</p>
+<p>Each event sequence is evaluated from the end. If the size of the
+corresponding softmax vector is 1 less than the number of events, the entire
+event sequence will be evaluated (other than the first event, whose
+distribution is not modeled). If the softmax vector is shorter than this,
+only the events at the end of the sequence will be evaluated.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event_sequences</code></strong></dt>
+<dd>A list of EventSequence objects.</dd>
+<dt><strong><code>softmax</code></strong></dt>
+<dd>A list of softmax probability vectors. The list of softmaxes
+should be the same length as the list of event sequences.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list containing the log likelihood of each event sequence.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If one of the event sequences is too long with respect to the
+corresponding softmax vectors.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def evaluate_log_likelihood(self, event_sequences, softmax):
+  &#34;&#34;&#34;Evaluate the log likelihood of multiple event sequences.
+
+  Each event sequence is evaluated from the end. If the size of the
+  corresponding softmax vector is 1 less than the number of events, the entire
+  event sequence will be evaluated (other than the first event, whose
+  distribution is not modeled). If the softmax vector is shorter than this,
+  only the events at the end of the sequence will be evaluated.
+
+  Args:
+    event_sequences: A list of EventSequence objects.
+    softmax: A list of softmax probability vectors. The list of softmaxes
+        should be the same length as the list of event sequences.
+
+  Returns:
+    A Python list containing the log likelihood of each event sequence.
+
+  Raises:
+    ValueError: If one of the event sequences is too long with respect to the
+        corresponding softmax vectors.
+  &#34;&#34;&#34;
+  all_loglik = []
+  for i in range(len(event_sequences)):
+    if len(softmax[i]) &gt;= len(event_sequences[i]):
+      raise ValueError(
+          &#39;event sequence must be longer than softmax vector (%d events but &#39;
+          &#39;softmax vector has length %d)&#39; % (len(event_sequences[i]),
+                                             len(softmax[i])))
+    end_pos = len(event_sequences[i])
+    start_pos = end_pos - len(softmax[i])
+    loglik = 0.0
+    for softmax_pos, position in enumerate(range(start_pos, end_pos)):
+      index = self.events_to_label(event_sequences[i], position)
+      if isinstance(index, numbers.Number):
+        loglik += np.log(softmax[i][softmax_pos][index])
+      else:
+        for sub_softmax_i in range(len(index)):
+          loglik += np.log(
+              softmax[i][softmax_pos][sub_softmax_i][index[sub_softmax_i]])
+    all_loglik.append(loglik)
+  return all_loglik</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the event at the given position.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, a self.input_size length list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the event at the given position.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the sequence.
+
+  Returns:
+    An input vector, a self.input_size length list of floats.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the event at the given position.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer in the range [0, self.num_classes).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the event at the given position.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the sequence.
+
+  Returns:
+    A label, an integer in the range [0, self.num_classes).
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences"><code class="name flex">
+<span>def <span class="ident">extend_event_sequences</span></span>(<span>self, event_sequences, softmax)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extends the event sequences by sampling the softmax probabilities.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event_sequences</code></strong></dt>
+<dd>A list of EventSequence objects.</dd>
+<dt><strong><code>softmax</code></strong></dt>
+<dd>A list of softmax probability vectors. The list of softmaxes
+should be the same length as the list of event sequences.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list of chosen class indices, one for each event sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extend_event_sequences(self, event_sequences, softmax):
+  &#34;&#34;&#34;Extends the event sequences by sampling the softmax probabilities.
+
+  Args:
+    event_sequences: A list of EventSequence objects.
+    softmax: A list of softmax probability vectors. The list of softmaxes
+        should be the same length as the list of event sequences.
+
+  Returns:
+    A Python list of chosen class indices, one for each event sequence.
+  &#34;&#34;&#34;
+  chosen_classes = []
+  for i in range(len(event_sequences)):
+    if not isinstance(softmax[0][0][0], numbers.Number):
+      # In this case, softmax is a list of several sub-softmaxes, each
+      # potentially with a different size.
+      # shape: [[beam_size, event_num, softmax_size]]
+      chosen_class = []
+      for sub_softmax in softmax:
+        num_classes = len(sub_softmax[0][0])
+        chosen_class.append(
+            np.random.choice(num_classes, p=sub_softmax[i][-1]))
+    else:
+      # In this case, softmax is just one softmax.
+      # shape: [beam_size, event_num, softmax_size]
+      num_classes = len(softmax[0][0])
+      chosen_class = np.random.choice(num_classes, p=softmax[i][-1])
+    event = self.class_index_to_event(chosen_class, event_sequences[i])
+    event_sequences[i].append(event)
+    chosen_classes.append(chosen_class)
+  return chosen_classes</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch"><code class="name flex">
+<span>def <span class="ident">get_inputs_batch</span></span>(<span>self, event_sequences, full_length=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an inputs batch for the given event sequences.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event_sequences</code></strong></dt>
+<dd>A list of list-like event sequences.</dd>
+<dt><strong><code>full_length</code></strong></dt>
+<dd>If True, the inputs batch will be for the full length of
+each event sequence. If False, the inputs batch will only be for the
+last event of each event sequence. A full-length inputs batch is used
+for the first step of extending the event sequences, since the RNN
+cell state needs to be initialized with the priming sequence. For
+subsequent generation steps, only a last-event inputs batch is used.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An inputs batch. If <code>full_length</code> is True, the shape will be
+[len(event_sequences), len(event_sequences[0]), INPUT_SIZE]. If
+<code>full_length</code> is False, the shape will be
+[len(event_sequences), 1, INPUT_SIZE].</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_inputs_batch(self, event_sequences, full_length=False):
+  &#34;&#34;&#34;Returns an inputs batch for the given event sequences.
+
+  Args:
+    event_sequences: A list of list-like event sequences.
+    full_length: If True, the inputs batch will be for the full length of
+        each event sequence. If False, the inputs batch will only be for the
+        last event of each event sequence. A full-length inputs batch is used
+        for the first step of extending the event sequences, since the RNN
+        cell state needs to be initialized with the priming sequence. For
+        subsequent generation steps, only a last-event inputs batch is used.
+
+  Returns:
+    An inputs batch. If `full_length` is True, the shape will be
+    [len(event_sequences), len(event_sequences[0]), INPUT_SIZE]. If
+    `full_length` is False, the shape will be
+    [len(event_sequences), 1, INPUT_SIZE].
+  &#34;&#34;&#34;
+  inputs_batch = []
+  for events in event_sequences:
+    inputs = []
+    if full_length:
+      for i in range(len(events)):
+        inputs.append(self.events_to_input(events, i))
+    else:
+      inputs.append(self.events_to_input(events, len(events) - 1))
+    inputs_batch.append(inputs)
+  return inputs_batch</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps"><code class="name flex">
+<span>def <span class="ident">labels_to_num_steps</span></span>(<span>self, labels)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the total number of time steps for a sequence of class labels.</p>
+<p>This is used for normalization when computing metrics. Subclasses with
+variable step size should override this method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>labels</code></strong></dt>
+<dd>A list-like sequence of integers in the range
+[0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The total number of time steps for the label sequence, defaulting to one
+per event.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def labels_to_num_steps(self, labels):
+  &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+  This is used for normalization when computing metrics. Subclasses with
+  variable step size should override this method.
+
+  Args:
+    labels: A list-like sequence of integers in the range
+        [0, self.num_classes).
+
+  Returns:
+    The total number of time steps for the label sequence, defaulting to one
+    per event.
+  &#34;&#34;&#34;
+  return len(labels)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">LookbackEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>one_hot_encoding, lookback_distances=None, binary_counter_bits=5)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An EventSequenceEncoderDecoder that encodes repeated events and meter.</p>
+<p>Initializes the LookbackEventSequenceEncoderDecoder.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>one_hot_encoding</code></strong></dt>
+<dd>A OneHotEncoding object that transforms events to and
+from integer indices.</dd>
+<dt><strong><code>lookback_distances</code></strong></dt>
+<dd>A list of step intervals to look back in history to
+encode both the following event and whether the current step is a
+repeat. If None, use default lookback distances.</dd>
+<dt><strong><code>binary_counter_bits</code></strong></dt>
+<dd>The number of input bits to use as a counter for the
+metric position of the next event.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class LookbackEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that encodes repeated events and meter.&#34;&#34;&#34;
+
+  def __init__(self, one_hot_encoding, lookback_distances=None,
+               binary_counter_bits=5):
+    &#34;&#34;&#34;Initializes the LookbackEventSequenceEncoderDecoder.
+
+    Args:
+      one_hot_encoding: A OneHotEncoding object that transforms events to and
+         from integer indices.
+      lookback_distances: A list of step intervals to look back in history to
+         encode both the following event and whether the current step is a
+         repeat. If None, use default lookback distances.
+      binary_counter_bits: The number of input bits to use as a counter for the
+         metric position of the next event.
+    &#34;&#34;&#34;
+    self._one_hot_encoding = one_hot_encoding
+    if lookback_distances is None:
+      self._lookback_distances = DEFAULT_LOOKBACK_DISTANCES
+    else:
+      self._lookback_distances = lookback_distances
+    self._binary_counter_bits = binary_counter_bits
+
+  @property
+  def input_size(self):
+    one_hot_size = self._one_hot_encoding.num_classes
+    num_lookbacks = len(self._lookback_distances)
+    return (one_hot_size +                  # current event
+            num_lookbacks * one_hot_size +  # next event for each lookback
+            self._binary_counter_bits +     # binary counters
+            num_lookbacks)                  # whether event matches lookbacks
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes + len(self._lookback_distances)
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a self.input_size length list of floats. Assuming a one-hot
+    encoding with 38 classes, two lookback distances, and five binary counters,
+    self.input_size will = 121. Each index represents a different input signal
+    to the model.
+
+    Indices [0, 120]:
+    [0, 37]: Event of current step.
+    [38, 75]: Event of next step for first lookback.
+    [76, 113]: Event of next step for second lookback.
+    114: 16th note binary counter.
+    115: 8th note binary counter.
+    116: 4th note binary counter.
+    117: Half note binary counter.
+    118: Whole note binary counter.
+    119: The current step is repeating (first lookback).
+    120: The current step is repeating (second lookback).
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer position in the event sequence.
+
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    offset = 0
+
+    # Last event.
+    index = self._one_hot_encoding.encode_event(events[position])
+    input_[index] = 1.0
+    offset += self._one_hot_encoding.num_classes
+
+    # Next event if repeating N positions ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance + 1
+      if lookback_position &lt; 0:
+        event = self._one_hot_encoding.default_event
+      else:
+        event = events[lookback_position]
+      index = self._one_hot_encoding.encode_event(event)
+      input_[offset + index] = 1.0
+      offset += self._one_hot_encoding.num_classes
+
+    # Binary time counter giving the metric location of the *next* event.
+    n = position + 1
+    for i in range(self._binary_counter_bits):
+      input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+      offset += 1
+
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        input_[offset] = 1.0
+      offset += 1
+
+    assert offset == self.input_size
+
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns an integer in the range [0, self.num_classes). Indices in the range
+    [0, self._one_hot_encoding.num_classes) map to standard events. Indices
+    self._one_hot_encoding.num_classes and self._one_hot_encoding.num_classes +
+    1 are signals to repeat events from earlier in the sequence. More distant
+    repeats are selected first and standard events are selected last.
+
+    Assuming a one-hot encoding with 38 classes and two lookback distances,
+    self.num_classes = 40 and the values will be as follows.
+
+    Values [0, 39]:
+      [0, 37]: Event of the last step in the event sequence, if not repeating
+               any of the lookbacks.
+      38: If the last event is repeating the first lookback, if not also
+          repeating the second lookback.
+      39: If the last event is repeating the second lookback.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    if (self._lookback_distances and
+        position &lt; self._lookback_distances[-1] and
+        events[position] == self._one_hot_encoding.default_event):
+      return (self._one_hot_encoding.num_classes +
+              len(self._lookback_distances) - 1)
+
+    # If last step repeated N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        return self._one_hot_encoding.num_classes + i
+
+    # If last step didn&#39;t repeat at one of the lookback positions, use the
+    # specific event.
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An int in the range [0, self.num_classes).
+      events: The current event sequence.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    # Repeat N bar ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      if class_index == self._one_hot_encoding.num_classes + i:
+        if len(events) &lt; lookback_distance:
+          return self._one_hot_encoding.default_event
+        return events[-lookback_distance]
+
+    # Return the event for that class index.
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    This method assumes the event sequence begins with the event corresponding
+    to the first label, which is inconsistent with the `encode` method in
+    EventSequenceEncoderDecoder that uses the second event as the first label.
+    Therefore, if the label sequence includes a lookback to the very first event
+    and that event is a different number of time steps than the default event,
+    this method will give an incorrect answer.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An int in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>The current event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An int in the range [0, self.num_classes).
+    events: The current event sequence.
+
+  Returns:
+    An event value.
+  &#34;&#34;&#34;
+  # Repeat N bar ago.
+  for i, lookback_distance in reversed(
+      list(enumerate(self._lookback_distances))):
+    if class_index == self._one_hot_encoding.num_classes + i:
+      if len(events) &lt; lookback_distance:
+        return self._one_hot_encoding.default_event
+      return events[-lookback_distance]
+
+  # Return the event for that class index.
+  return self._one_hot_encoding.decode_event(class_index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the event sequence.</p>
+<p>Returns a self.input_size length list of floats. Assuming a one-hot
+encoding with 38 classes, two lookback distances, and five binary counters,
+self.input_size will = 121. Each index represents a different input signal
+to the model.</p>
+<p>Indices [0, 120]:
+[0, 37]: Event of current step.
+[38, 75]: Event of next step for first lookback.
+[76, 113]: Event of next step for second lookback.
+114: 16th note binary counter.
+115: 8th note binary counter.
+116: 4th note binary counter.
+117: Half note binary counter.
+118: Whole note binary counter.
+119: The current step is repeating (first lookback).
+120: The current step is repeating (second lookback).</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, an self.input_size length list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+  Returns a self.input_size length list of floats. Assuming a one-hot
+  encoding with 38 classes, two lookback distances, and five binary counters,
+  self.input_size will = 121. Each index represents a different input signal
+  to the model.
+
+  Indices [0, 120]:
+  [0, 37]: Event of current step.
+  [38, 75]: Event of next step for first lookback.
+  [76, 113]: Event of next step for second lookback.
+  114: 16th note binary counter.
+  115: 8th note binary counter.
+  116: 4th note binary counter.
+  117: Half note binary counter.
+  118: Whole note binary counter.
+  119: The current step is repeating (first lookback).
+  120: The current step is repeating (second lookback).
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer position in the event sequence.
+
+  Returns:
+    An input vector, an self.input_size length list of floats.
+  &#34;&#34;&#34;
+  input_ = [0.0] * self.input_size
+  offset = 0
+
+  # Last event.
+  index = self._one_hot_encoding.encode_event(events[position])
+  input_[index] = 1.0
+  offset += self._one_hot_encoding.num_classes
+
+  # Next event if repeating N positions ago.
+  for i, lookback_distance in enumerate(self._lookback_distances):
+    lookback_position = position - lookback_distance + 1
+    if lookback_position &lt; 0:
+      event = self._one_hot_encoding.default_event
+    else:
+      event = events[lookback_position]
+    index = self._one_hot_encoding.encode_event(event)
+    input_[offset + index] = 1.0
+    offset += self._one_hot_encoding.num_classes
+
+  # Binary time counter giving the metric location of the *next* event.
+  n = position + 1
+  for i in range(self._binary_counter_bits):
+    input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+    offset += 1
+
+  # Last event is repeating N bars ago.
+  for i, lookback_distance in enumerate(self._lookback_distances):
+    lookback_position = position - lookback_distance
+    if (lookback_position &gt;= 0 and
+        events[position] == events[lookback_position]):
+      input_[offset] = 1.0
+    offset += 1
+
+  assert offset == self.input_size
+
+  return input_</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the event sequence.</p>
+<p>Returns an integer in the range [0, self.num_classes). Indices in the range
+[0, self._one_hot_encoding.num_classes) map to standard events. Indices
+self._one_hot_encoding.num_classes and self._one_hot_encoding.num_classes +
+1 are signals to repeat events from earlier in the sequence. More distant
+repeats are selected first and standard events are selected last.</p>
+<p>Assuming a one-hot encoding with 38 classes and two lookback distances,
+self.num_classes = 40 and the values will be as follows.</p>
+<p>Values [0, 39]:
+[0, 37]: Event of the last step in the event sequence, if not repeating
+any of the lookbacks.
+38: If the last event is repeating the first lookback, if not also
+repeating the second lookback.
+39: If the last event is repeating the second lookback.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+  Returns an integer in the range [0, self.num_classes). Indices in the range
+  [0, self._one_hot_encoding.num_classes) map to standard events. Indices
+  self._one_hot_encoding.num_classes and self._one_hot_encoding.num_classes +
+  1 are signals to repeat events from earlier in the sequence. More distant
+  repeats are selected first and standard events are selected last.
+
+  Assuming a one-hot encoding with 38 classes and two lookback distances,
+  self.num_classes = 40 and the values will be as follows.
+
+  Values [0, 39]:
+    [0, 37]: Event of the last step in the event sequence, if not repeating
+             any of the lookbacks.
+    38: If the last event is repeating the first lookback, if not also
+        repeating the second lookback.
+    39: If the last event is repeating the second lookback.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer position in the event sequence.
+
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  if (self._lookback_distances and
+      position &lt; self._lookback_distances[-1] and
+      events[position] == self._one_hot_encoding.default_event):
+    return (self._one_hot_encoding.num_classes +
+            len(self._lookback_distances) - 1)
+
+  # If last step repeated N bars ago.
+  for i, lookback_distance in reversed(
+      list(enumerate(self._lookback_distances))):
+    lookback_position = position - lookback_distance
+    if (lookback_position &gt;= 0 and
+        events[position] == events[lookback_position]):
+      return self._one_hot_encoding.num_classes + i
+
+  # If last step didn&#39;t repeat at one of the lookback positions, use the
+  # specific event.
+  return self._one_hot_encoding.encode_event(events[position])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.labels_to_num_steps"><code class="name flex">
+<span>def <span class="ident">labels_to_num_steps</span></span>(<span>self, labels)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the total number of time steps for a sequence of class labels.</p>
+<p>This method assumes the event sequence begins with the event corresponding
+to the first label, which is inconsistent with the <code>encode</code> method in
+EventSequenceEncoderDecoder that uses the second event as the first label.
+Therefore, if the label sequence includes a lookback to the very first event
+and that event is a different number of time steps than the default event,
+this method will give an incorrect answer.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>labels</code></strong></dt>
+<dd>A list-like sequence of integers in the range
+[0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The total number of time steps for the label sequence, as determined by
+the one-hot encoding.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def labels_to_num_steps(self, labels):
+  &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+  This method assumes the event sequence begins with the event corresponding
+  to the first label, which is inconsistent with the `encode` method in
+  EventSequenceEncoderDecoder that uses the second event as the first label.
+  Therefore, if the label sequence includes a lookback to the very first event
+  and that event is a different number of time steps than the default event,
+  this method will give an incorrect answer.
+
+  Args:
+    labels: A list-like sequence of integers in the range
+        [0, self.num_classes).
+
+  Returns:
+    The total number of time steps for the label sequence, as determined by
+    the one-hot encoding.
+  &#34;&#34;&#34;
+  events = []
+  for label in labels:
+    events.append(self.class_index_to_event(label, events))
+  return sum(self._one_hot_encoding.event_to_num_steps(event)
+             for event in events)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.encoder_decoder.MultipleEventSequenceEncoder"><code class="flex name class">
+<span>class <span class="ident">MultipleEventSequenceEncoder</span></span>
+<span>(</span><span>encoders, encode_single_sequence=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An encoder that concatenates multiple component encoders.</p>
+<p>This class, largely intended for use with control sequences for conditional
+encoder/decoders, encodes event sequences with multiple encoders and
+concatenates the encodings.</p>
+<p>Despite being an EventSequenceEncoderDecoder this class does not decode.</p>
+<p>Initialize a MultipleEventSequenceEncoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>encoders</code></strong></dt>
+<dd>A list of component EventSequenceEncoderDecoder objects whose
+output will be concatenated.</dd>
+<dt><strong><code>encode_single_sequence</code></strong></dt>
+<dd>If True, at encoding time all of the encoders will
+be applied to a single event sequence. If False, each event of the
+event sequence should be a tuple with size the same as the number of
+encoders, each of which will be applied to the events in the
+corresponding position in the tuple, i.e. the first encoder will be
+applied to the first element of each event tuple, the second encoder
+will be applied to the second element, etc.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultipleEventSequenceEncoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder that concatenates multiple component encoders.
+
+  This class, largely intended for use with control sequences for conditional
+  encoder/decoders, encodes event sequences with multiple encoders and
+  concatenates the encodings.
+
+  Despite being an EventSequenceEncoderDecoder this class does not decode.
+  &#34;&#34;&#34;
+
+  def __init__(self, encoders, encode_single_sequence=False):
+    &#34;&#34;&#34;Initialize a MultipleEventSequenceEncoder object.
+
+    Args:
+      encoders: A list of component EventSequenceEncoderDecoder objects whose
+          output will be concatenated.
+      encode_single_sequence: If True, at encoding time all of the encoders will
+          be applied to a single event sequence. If False, each event of the
+          event sequence should be a tuple with size the same as the number of
+          encoders, each of which will be applied to the events in the
+          corresponding position in the tuple, i.e. the first encoder will be
+          applied to the first element of each event tuple, the second encoder
+          will be applied to the second element, etc.
+    &#34;&#34;&#34;
+    self._encoders = encoders
+    self._encode_single_sequence = encode_single_sequence
+
+  @property
+  def input_size(self):
+    return sum(encoder.input_size for encoder in self._encoders)
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    input_ = []
+    if self._encode_single_sequence:
+      # Apply all encoders to the event sequence.
+      for encoder in self._encoders:
+        input_ += encoder.events_to_input(events, position)
+    else:
+      # The event sequence is a list of tuples. Apply each encoder to the
+      # elements in the corresponding tuple position.
+      event_sequences = list(zip(*events))
+      if len(event_sequences) != len(self._encoders):
+        raise ValueError(
+            &#39;Event tuple size must be the same as the number of encoders.&#39;)
+      for encoder, event_sequence in zip(self._encoders, event_sequences):
+        input_ += encoder.events_to_input(event_sequence, position)
+    return input_
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">OneHotEncoding</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>An interface for specifying a one-hot encoding of individual events.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OneHotEncoding(object):
+  &#34;&#34;&#34;An interface for specifying a one-hot encoding of individual events.&#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def num_classes(self):
+    &#34;&#34;&#34;The number of distinct event encodings.
+
+    Returns:
+      An int, the range of ints that can be returned by self.encode_event.
+    &#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_event(self):
+    &#34;&#34;&#34;An event value to use as a default.
+
+    Returns:
+      The default event value.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def encode_event(self, event):
+    &#34;&#34;&#34;Convert from an event value to an encoding integer.
+
+    Args:
+      event: An event value to encode.
+
+    Returns:
+      An integer representing the encoded event, in range [0, self.num_classes).
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def decode_event(self, index):
+    &#34;&#34;&#34;Convert from an encoding integer to an event value.
+
+    Args:
+      index: The encoding, an integer in the range [0, self.num_classes).
+
+    Returns:
+      The decoded event value.
+    &#34;&#34;&#34;
+    pass
+
+  def event_to_num_steps(self, unused_event):
+    &#34;&#34;&#34;Returns the number of time steps corresponding to an event value.
+
+    This is used for normalization when computing metrics. Subclasses with
+    variable step size should override this method.
+
+    Args:
+      unused_event: An event value for which to return the number of steps.
+
+    Returns:
+      The number of steps corresponding to the given event value, defaulting to
+      one.
+    &#34;&#34;&#34;
+    return 1</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.chords_encoder_decoder.MajorMinorChordOneHotEncoding" href="chords_encoder_decoder.html#note_seq.chords_encoder_decoder.MajorMinorChordOneHotEncoding">MajorMinorChordOneHotEncoding</a></li>
+<li><a title="note_seq.chords_encoder_decoder.TriadChordOneHotEncoding" href="chords_encoder_decoder.html#note_seq.chords_encoder_decoder.TriadChordOneHotEncoding">TriadChordOneHotEncoding</a></li>
+<li><a title="note_seq.drums_encoder_decoder.MultiDrumOneHotEncoding" href="drums_encoder_decoder.html#note_seq.drums_encoder_decoder.MultiDrumOneHotEncoding">MultiDrumOneHotEncoding</a></li>
+<li><a title="note_seq.melody_encoder_decoder.MelodyOneHotEncoding" href="melody_encoder_decoder.html#note_seq.melody_encoder_decoder.MelodyOneHotEncoding">MelodyOneHotEncoding</a></li>
+<li><a title="note_seq.performance_controls.NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding" href="performance_controls.html#note_seq.performance_controls.NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding">NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding</a></li>
+<li><a title="note_seq.performance_encoder_decoder.PerformanceOneHotEncoding" href="performance_encoder_decoder.html#note_seq.performance_encoder_decoder.PerformanceOneHotEncoding">PerformanceOneHotEncoding</a></li>
+<li><a title="note_seq.testing_lib.TrivialOneHotEncoding" href="testing_lib.html#note_seq.testing_lib.TrivialOneHotEncoding">TrivialOneHotEncoding</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.OneHotEncoding.default_event"><code class="name">var <span class="ident">default_event</span></code></dt>
+<dd>
+<div class="desc"><p>An event value to use as a default.</p>
+<h2 id="returns">Returns</h2>
+<p>The default event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def default_event(self):
+  &#34;&#34;&#34;An event value to use as a default.
+
+  Returns:
+    The default event value.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEncoding.num_classes"><code class="name">var <span class="ident">num_classes</span></code></dt>
+<dd>
+<div class="desc"><p>The number of distinct event encodings.</p>
+<h2 id="returns">Returns</h2>
+<p>An int, the range of ints that can be returned by self.encode_event.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def num_classes(self):
+  &#34;&#34;&#34;The number of distinct event encodings.
+
+  Returns:
+    An int, the range of ints that can be returned by self.encode_event.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.OneHotEncoding.decode_event"><code class="name flex">
+<span>def <span class="ident">decode_event</span></span>(<span>self, index)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert from an encoding integer to an event value.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>index</code></strong></dt>
+<dd>The encoding, an integer in the range [0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The decoded event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def decode_event(self, index):
+  &#34;&#34;&#34;Convert from an encoding integer to an event value.
+
+  Args:
+    index: The encoding, an integer in the range [0, self.num_classes).
+
+  Returns:
+    The decoded event value.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEncoding.encode_event"><code class="name flex">
+<span>def <span class="ident">encode_event</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert from an event value to an encoding integer.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>An event value to encode.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An integer representing the encoded event, in range [0, self.num_classes).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def encode_event(self, event):
+  &#34;&#34;&#34;Convert from an event value to an encoding integer.
+
+  Args:
+    event: An event value to encode.
+
+  Returns:
+    An integer representing the encoded event, in range [0, self.num_classes).
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps"><code class="name flex">
+<span>def <span class="ident">event_to_num_steps</span></span>(<span>self, unused_event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the number of time steps corresponding to an event value.</p>
+<p>This is used for normalization when computing metrics. Subclasses with
+variable step size should override this method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>unused_event</code></strong></dt>
+<dd>An event value for which to return the number of steps.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The number of steps corresponding to the given event value, defaulting to
+one.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def event_to_num_steps(self, unused_event):
+  &#34;&#34;&#34;Returns the number of time steps corresponding to an event value.
+
+  This is used for normalization when computing metrics. Subclasses with
+  variable step size should override this method.
+
+  Args:
+    unused_event: An event value for which to return the number of steps.
+
+  Returns:
+    The number of steps corresponding to the given event value, defaulting to
+    one.
+  &#34;&#34;&#34;
+  return 1</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">OneHotEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>one_hot_encoding)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An EventSequenceEncoderDecoder that produces a one-hot encoding.</p>
+<p>Initialize a OneHotEventSequenceEncoderDecoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>one_hot_encoding</code></strong></dt>
+<dd>A OneHotEncoding object that transforms events to and
+from integer indices.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OneHotEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces a one-hot encoding.&#34;&#34;&#34;
+
+  def __init__(self, one_hot_encoding):
+    &#34;&#34;&#34;Initialize a OneHotEventSequenceEncoderDecoder object.
+
+    Args:
+      one_hot_encoding: A OneHotEncoding object that transforms events to and
+          from integer indices.
+    &#34;&#34;&#34;
+    self._one_hot_encoding = one_hot_encoding
+
+  @property
+  def input_size(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a one-hot vector for the given position in the event sequence, as
+    determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    input_[self._one_hot_encoding.encode_event(events[position])] = 1.0
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns the zero-based index value for the given position in the event
+    sequence, as determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder">OneHotIndexEventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An integer in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events. This object is not used in this
+implementation.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An integer in the range [0, self.num_classes).
+    events: A list-like sequence of events. This object is not used in this
+        implementation.
+
+  Returns:
+    An event value.
+  &#34;&#34;&#34;
+  return self._one_hot_encoding.decode_event(class_index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the event sequence.</p>
+<p>Returns a one-hot vector for the given position in the event sequence, as
+determined by the one hot encoding.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, a list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+  Returns a one-hot vector for the given position in the event sequence, as
+  determined by the one hot encoding.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    An input vector, a list of floats.
+  &#34;&#34;&#34;
+  input_ = [0.0] * self.input_size
+  input_[self._one_hot_encoding.encode_event(events[position])] = 1.0
+  return input_</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the event sequence.</p>
+<p>Returns the zero-based index value for the given position in the event
+sequence, as determined by the one hot encoding.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+  Returns the zero-based index value for the given position in the event
+  sequence, as determined by the one hot encoding.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  return self._one_hot_encoding.encode_event(events[position])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.labels_to_num_steps"><code class="name flex">
+<span>def <span class="ident">labels_to_num_steps</span></span>(<span>self, labels)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the total number of time steps for a sequence of class labels.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>labels</code></strong></dt>
+<dd>A list-like sequence of integers in the range
+[0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The total number of time steps for the label sequence, as determined by
+the one-hot encoding.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def labels_to_num_steps(self, labels):
+  &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+  Args:
+    labels: A list-like sequence of integers in the range
+        [0, self.num_classes).
+
+  Returns:
+    The total number of time steps for the label sequence, as determined by
+    the one-hot encoding.
+  &#34;&#34;&#34;
+  events = []
+  for label in labels:
+    events.append(self.class_index_to_event(label, events))
+  return sum(self._one_hot_encoding.event_to_num_steps(event)
+             for event in events)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">OneHotIndexEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>one_hot_encoding)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An EventSequenceEncoderDecoder that produces one-hot indices.</p>
+<p>Initialize a OneHotEventSequenceEncoderDecoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>one_hot_encoding</code></strong></dt>
+<dd>A OneHotEncoding object that transforms events to and
+from integer indices.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OneHotIndexEventSequenceEncoderDecoder(OneHotEventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces one-hot indices.&#34;&#34;&#34;
+
+  @property
+  def input_size(self):
+    return 1
+
+  @property
+  def input_depth(self):
+    return self._one_hot_encoding.num_classes
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the one-hot index for the event at the given position.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An integer input event index.
+    &#34;&#34;&#34;
+    return [self._one_hot_encoding.encode_event(events[position])]</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder">OneHotEventSequenceEncoderDecoder</a></li>
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.input_depth"><code class="name">var <span class="ident">input_depth</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def input_depth(self):
+  return self._one_hot_encoding.num_classes</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the one-hot index for the event at the given position.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An integer input event index.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the one-hot index for the event at the given position.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    An integer input event index.
+  &#34;&#34;&#34;
+  return [self._one_hot_encoding.encode_event(events[position])]</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder">OneHotEventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.encoder_decoder.OptionalEventSequenceEncoder"><code class="flex name class">
+<span>class <span class="ident">OptionalEventSequenceEncoder</span></span>
+<span>(</span><span>encoder)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An encoder that augments a base encoder with a disable flag.</p>
+<p>This encoder encodes event sequences consisting of tuples where the first
+element is a disable flag. When set, the encoding consists of a 1 followed by
+a zero-encoding the size of the base encoder's input. When unset, the encoding
+consists of a 0 followed by the base encoder's encoding.</p>
+<p>Initialize an OptionalEventSequenceEncoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>encoder</code></strong></dt>
+<dd>The base EventSequenceEncoderDecoder to use.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OptionalEventSequenceEncoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An encoder that augments a base encoder with a disable flag.
+
+  This encoder encodes event sequences consisting of tuples where the first
+  element is a disable flag. When set, the encoding consists of a 1 followed by
+  a zero-encoding the size of the base encoder&#39;s input. When unset, the encoding
+  consists of a 0 followed by the base encoder&#39;s encoding.
+  &#34;&#34;&#34;
+
+  def __init__(self, encoder):
+    &#34;&#34;&#34;Initialize an OptionalEventSequenceEncoder object.
+
+    Args:
+      encoder: The base EventSequenceEncoderDecoder to use.
+    &#34;&#34;&#34;
+    self._encoder = encoder
+
+  @property
+  def input_size(self):
+    return 1 + self._encoder.input_size
+
+  @property
+  def num_classes(self):
+    raise NotImplementedError
+
+  @property
+  def default_event_label(self):
+    raise NotImplementedError
+
+  def events_to_input(self, events, position):
+    # The event sequence is a list of tuples where the first element is a
+    # disable flag.
+    disable, _ = events[position]
+    if disable:
+      return [1.0] + [0.0] * self._encoder.input_size
+    else:
+      return [0.0] + self._encoder.events_to_input(
+          [event for _, event in events], position)
+
+  def events_to_label(self, events, position):
+    raise NotImplementedError
+
+  def class_index_to_event(self, class_index, events):
+    raise NotImplementedError</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder">ConditionalEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.ConditionalEventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder">LookbackEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.LookbackEventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.MultipleEventSequenceEncoder" href="#note_seq.encoder_decoder.MultipleEventSequenceEncoder">MultipleEventSequenceEncoder</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.OneHotEncoding" href="#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder">OneHotEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_label" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.encoder_decoder.OneHotEventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder" href="#note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder">OneHotIndexEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.events_to_input" href="#note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.input_depth" href="#note_seq.encoder_decoder.OneHotIndexEventSequenceEncoderDecoder.input_depth">input_depth</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder.OptionalEventSequenceEncoder" href="#note_seq.encoder_decoder.OptionalEventSequenceEncoder">OptionalEventSequenceEncoder</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/encoder_decoder_test.html
+++ b/docs/encoder_decoder_test.html
@@ -1,0 +1,1933 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for encoder_decoder.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import encoder_decoder
+from note_seq import testing_lib
+import numpy as np
+
+
+class OneHotEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))
+
+  def testInputSize(self):
+    self.assertEqual(3, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(3, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0], self.enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0], self.enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 4))
+
+  def testEventsToLabel(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.events_to_label(events, 0))
+    self.assertEqual(1, self.enc.events_to_label(events, 1))
+    self.assertEqual(0, self.enc.events_to_label(events, 2))
+    self.assertEqual(2, self.enc.events_to_label(events, 3))
+    self.assertEqual(0, self.enc.events_to_label(events, 4))
+
+  def testClassIndexToEvent(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, events))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events))
+
+  def testLabelsToNumSteps(self):
+    labels = [0, 1, 0, 2, 0]
+    self.assertEqual(3, self.enc.labels_to_num_steps(labels))
+
+  def testEncode(self):
+    events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(events)
+    expected_inputs = [[1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0],
+                       [1.0, 0.0, 0.0],
+                       [0.0, 0.0, 1.0]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+    expected_inputs_1 = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [1.0, 0.0, 0.0],
+                         [0.0, 0.0, 1.0],
+                         [1.0, 0.0, 0.0]]
+    expected_inputs_2 = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [0.0, 0.0, 1.0]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences))
+
+  def testExtendEventSequences(self):
+    events1 = [0]
+    events2 = [0]
+    events3 = [0]
+    event_sequences = [events1, events2, events3]
+    softmax = [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]]
+    self.enc.extend_event_sequences(event_sequences, softmax)
+    self.assertListEqual(list(events1), [0, 2])
+    self.assertListEqual(list(events2), [0, 0])
+    self.assertListEqual(list(events3), [0, 1])
+
+  def testEvaluateLogLikelihood(self):
+    events1 = [0, 1, 0]
+    events2 = [1, 2, 2]
+    event_sequences = [events1, events2]
+    softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+               [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+    p = self.enc.evaluate_log_likelihood(event_sequences, softmax)
+    self.assertListEqual([np.log(0.5) + np.log(0.3),
+                          np.log(0.4) + np.log(0.6)], p)
+
+
+class OneHotIndexEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OneHotIndexEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))
+
+  def testInputSize(self):
+    self.assertEqual(1, self.enc.input_size)
+
+  def testInputDepth(self):
+    self.assertEqual(3, self.enc.input_depth)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([0], self.enc.events_to_input(events, 0))
+    self.assertEqual([1], self.enc.events_to_input(events, 1))
+    self.assertEqual([0], self.enc.events_to_input(events, 2))
+    self.assertEqual([2], self.enc.events_to_input(events, 3))
+    self.assertEqual([0], self.enc.events_to_input(events, 4))
+
+  def testEncode(self):
+    events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(events)
+    expected_inputs = [[0], [1], [0], [2]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+    expected_inputs_1 = [[0], [1], [0], [2], [0]]
+    expected_inputs_2 = [[0], [1], [2]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences))
+
+
+class LookbackEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)), [1, 2], 2)
+
+  def testInputSize(self):
+    self.assertEqual(13, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(5, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                      1.0, -1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+                      -1.0, 1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                      1.0, 1.0, 0.0, 1.0],
+                     self.enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+                      -1.0, -1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                      1.0, -1.0, 0.0, 1.0],
+                     self.enc.events_to_input(events, 4))
+
+  def testEventsToLabel(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(4, self.enc.events_to_label(events, 0))
+    self.assertEqual(1, self.enc.events_to_label(events, 1))
+    self.assertEqual(4, self.enc.events_to_label(events, 2))
+    self.assertEqual(2, self.enc.events_to_label(events, 3))
+    self.assertEqual(4, self.enc.events_to_label(events, 4))
+
+  def testClassIndexToEvent(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(3, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(4, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(3, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(4, events[:5]))
+
+  def testLabelsToNumSteps(self):
+    labels = [0, 1, 0, 2, 0]
+    self.assertEqual(3, self.enc.labels_to_num_steps(labels))
+
+    labels = [0, 1, 3, 2, 4]
+    self.assertEqual(5, self.enc.labels_to_num_steps(labels))
+
+  def testEmptyLookback(self):
+    enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3), [], 2)
+    self.assertEqual(5, enc.input_size)
+    self.assertEqual(3, enc.num_classes)
+
+    events = [0, 1, 0, 2, 0]
+
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                     enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0, -1.0, 1.0],
+                     enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 1.0],
+                     enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0, -1.0, -1.0],
+                     enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                     enc.events_to_input(events, 4))
+
+    self.assertEqual(0, enc.events_to_label(events, 0))
+    self.assertEqual(1, enc.events_to_label(events, 1))
+    self.assertEqual(0, enc.events_to_label(events, 2))
+    self.assertEqual(2, enc.events_to_label(events, 3))
+    self.assertEqual(0, enc.events_to_label(events, 4))
+
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))
+
+
+class ConditionalEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.ConditionalEventSequenceEncoderDecoder(
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(2)),
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3)))
+
+  def testInputSize(self):
+    self.assertEqual(5, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(3, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    control_events = [1, 1, 1, 0, 0]
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 0))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 1))
+    self.assertEqual(
+        [1.0, 0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0, 1.0],
+        self.enc.events_to_input(control_events, target_events, 3))
+
+  def testEventsToLabel(self):
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.events_to_label(target_events, 0))
+    self.assertEqual(1, self.enc.events_to_label(target_events, 1))
+    self.assertEqual(0, self.enc.events_to_label(target_events, 2))
+    self.assertEqual(2, self.enc.events_to_label(target_events, 3))
+    self.assertEqual(0, self.enc.events_to_label(target_events, 4))
+
+  def testClassIndexToEvent(self):
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, target_events))
+    self.assertEqual(1, self.enc.class_index_to_event(1, target_events))
+    self.assertEqual(2, self.enc.class_index_to_event(2, target_events))
+
+  def testEncode(self):
+    control_events = [1, 1, 1, 0, 0]
+    target_events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(control_events, target_events)
+    expected_inputs = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0, 1.0, 0.0],
+                       [1.0, 0.0, 1.0, 0.0, 0.0],
+                       [1.0, 0.0, 0.0, 0.0, 1.0]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    control_event_sequences = [[1, 1, 1, 0, 0], [1, 1, 1, 0, 0]]
+    target_event_sequences = [[0, 1, 0, 2], [0, 1]]
+    expected_inputs_1 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 1.0, 0.0],
+                         [1.0, 0.0, 1.0, 0.0, 0.0],
+                         [1.0, 0.0, 0.0, 0.0, 1.0]]
+    expected_inputs_2 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 1.0, 0.0]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(
+            control_event_sequences, target_event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(
+            control_event_sequences, target_event_sequences))
+
+  def testExtendEventSequences(self):
+    target_events_1 = [0]
+    target_events_2 = [0]
+    target_events_3 = [0]
+    target_event_sequences = [target_events_1, target_events_2, target_events_3]
+    softmax = np.array(
+        [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]])
+    self.enc.extend_event_sequences(target_event_sequences, softmax)
+    self.assertListEqual(list(target_events_1), [0, 2])
+    self.assertListEqual(list(target_events_2), [0, 0])
+    self.assertListEqual(list(target_events_3), [0, 1])
+
+  def testEvaluateLogLikelihood(self):
+    target_events_1 = [0, 1, 0]
+    target_events_2 = [1, 2, 2]
+    target_event_sequences = [target_events_1, target_events_2]
+    softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+               [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+    p = self.enc.evaluate_log_likelihood(target_event_sequences, softmax)
+    self.assertListEqual([np.log(0.5) + np.log(0.3),
+                          np.log(0.4) + np.log(0.6)], p)
+
+
+class OptionalEventSequenceEncoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OptionalEventSequenceEncoder(
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3)))
+
+  def testInputSize(self):
+    self.assertEqual(4, self.enc.input_size)
+
+  def testEventsToInput(self):
+    events = [(False, 0), (False, 1), (False, 0), (True, 2), (True, 0)]
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 0))
+    self.assertEqual(
+        [0.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(events, 1))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 3))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 4))
+
+
+class MultipleEventSequenceEncoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.MultipleEventSequenceEncoder([
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(2)),
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3))])
+
+  def testInputSize(self):
+    self.assertEqual(5, self.enc.input_size)
+
+  def testEventsToInput(self):
+    events = [(1, 0), (1, 1), (1, 0), (0, 2), (0, 0)]
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 0))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(events, 1))
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0, 1.0],
+        self.enc.events_to_input(events, 3))
+    self.assertEqual(
+        [1.0, 0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 4))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">ConditionalEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ConditionalEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.ConditionalEventSequenceEncoderDecoder(
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(2)),
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3)))
+
+  def testInputSize(self):
+    self.assertEqual(5, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(3, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    control_events = [1, 1, 1, 0, 0]
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 0))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 1))
+    self.assertEqual(
+        [1.0, 0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(control_events, target_events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0, 1.0],
+        self.enc.events_to_input(control_events, target_events, 3))
+
+  def testEventsToLabel(self):
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.events_to_label(target_events, 0))
+    self.assertEqual(1, self.enc.events_to_label(target_events, 1))
+    self.assertEqual(0, self.enc.events_to_label(target_events, 2))
+    self.assertEqual(2, self.enc.events_to_label(target_events, 3))
+    self.assertEqual(0, self.enc.events_to_label(target_events, 4))
+
+  def testClassIndexToEvent(self):
+    target_events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, target_events))
+    self.assertEqual(1, self.enc.class_index_to_event(1, target_events))
+    self.assertEqual(2, self.enc.class_index_to_event(2, target_events))
+
+  def testEncode(self):
+    control_events = [1, 1, 1, 0, 0]
+    target_events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(control_events, target_events)
+    expected_inputs = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0, 1.0, 0.0],
+                       [1.0, 0.0, 1.0, 0.0, 0.0],
+                       [1.0, 0.0, 0.0, 0.0, 1.0]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    control_event_sequences = [[1, 1, 1, 0, 0], [1, 1, 1, 0, 0]]
+    target_event_sequences = [[0, 1, 0, 2], [0, 1]]
+    expected_inputs_1 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 1.0, 0.0],
+                         [1.0, 0.0, 1.0, 0.0, 0.0],
+                         [1.0, 0.0, 0.0, 0.0, 1.0]]
+    expected_inputs_2 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 1.0, 0.0]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(
+            control_event_sequences, target_event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(
+            control_event_sequences, target_event_sequences))
+
+  def testExtendEventSequences(self):
+    target_events_1 = [0]
+    target_events_2 = [0]
+    target_events_3 = [0]
+    target_event_sequences = [target_events_1, target_events_2, target_events_3]
+    softmax = np.array(
+        [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]])
+    self.enc.extend_event_sequences(target_event_sequences, softmax)
+    self.assertListEqual(list(target_events_1), [0, 2])
+    self.assertListEqual(list(target_events_2), [0, 0])
+    self.assertListEqual(list(target_events_3), [0, 1])
+
+  def testEvaluateLogLikelihood(self):
+    target_events_1 = [0, 1, 0]
+    target_events_2 = [1, 2, 2]
+    target_event_sequences = [target_events_1, target_events_2]
+    softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+               [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+    p = self.enc.evaluate_log_likelihood(target_event_sequences, softmax)
+    self.assertListEqual([np.log(0.5) + np.log(0.3),
+                          np.log(0.4) + np.log(0.6)], p)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.ConditionalEventSequenceEncoderDecoder(
+      encoder_decoder.OneHotEventSequenceEncoderDecoder(
+          testing_lib.TrivialOneHotEncoding(2)),
+      encoder_decoder.OneHotEventSequenceEncoderDecoder(
+          testing_lib.TrivialOneHotEncoding(3)))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testClassIndexToEvent"><code class="name flex">
+<span>def <span class="ident">testClassIndexToEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testClassIndexToEvent(self):
+  target_events = [0, 1, 0, 2, 0]
+  self.assertEqual(0, self.enc.class_index_to_event(0, target_events))
+  self.assertEqual(1, self.enc.class_index_to_event(1, target_events))
+  self.assertEqual(2, self.enc.class_index_to_event(2, target_events))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEncode"><code class="name flex">
+<span>def <span class="ident">testEncode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncode(self):
+  control_events = [1, 1, 1, 0, 0]
+  target_events = [0, 1, 0, 2, 0]
+  inputs, labels = self.enc.encode(control_events, target_events)
+  expected_inputs = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                     [0.0, 1.0, 0.0, 1.0, 0.0],
+                     [1.0, 0.0, 1.0, 0.0, 0.0],
+                     [1.0, 0.0, 0.0, 0.0, 1.0]]
+  expected_labels = [1, 0, 2, 0]
+  self.assertEqual(inputs, expected_inputs)
+  self.assertEqual(labels, expected_labels)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood"><code class="name flex">
+<span>def <span class="ident">testEvaluateLogLikelihood</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEvaluateLogLikelihood(self):
+  target_events_1 = [0, 1, 0]
+  target_events_2 = [1, 2, 2]
+  target_event_sequences = [target_events_1, target_events_2]
+  softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+             [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+  p = self.enc.evaluate_log_likelihood(target_event_sequences, softmax)
+  self.assertListEqual([np.log(0.5) + np.log(0.3),
+                        np.log(0.4) + np.log(0.6)], p)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  control_events = [1, 1, 1, 0, 0]
+  target_events = [0, 1, 0, 2, 0]
+  self.assertEqual(
+      [0.0, 1.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(control_events, target_events, 0))
+  self.assertEqual(
+      [0.0, 1.0, 0.0, 1.0, 0.0],
+      self.enc.events_to_input(control_events, target_events, 1))
+  self.assertEqual(
+      [1.0, 0.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(control_events, target_events, 2))
+  self.assertEqual(
+      [1.0, 0.0, 0.0, 0.0, 1.0],
+      self.enc.events_to_input(control_events, target_events, 3))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToLabel"><code class="name flex">
+<span>def <span class="ident">testEventsToLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToLabel(self):
+  target_events = [0, 1, 0, 2, 0]
+  self.assertEqual(0, self.enc.events_to_label(target_events, 0))
+  self.assertEqual(1, self.enc.events_to_label(target_events, 1))
+  self.assertEqual(0, self.enc.events_to_label(target_events, 2))
+  self.assertEqual(2, self.enc.events_to_label(target_events, 3))
+  self.assertEqual(0, self.enc.events_to_label(target_events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testExtendEventSequences"><code class="name flex">
+<span>def <span class="ident">testExtendEventSequences</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtendEventSequences(self):
+  target_events_1 = [0]
+  target_events_2 = [0]
+  target_events_3 = [0]
+  target_event_sequences = [target_events_1, target_events_2, target_events_3]
+  softmax = np.array(
+      [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]])
+  self.enc.extend_event_sequences(target_event_sequences, softmax)
+  self.assertListEqual(list(target_events_1), [0, 2])
+  self.assertListEqual(list(target_events_2), [0, 0])
+  self.assertListEqual(list(target_events_3), [0, 1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testGetInputsBatch"><code class="name flex">
+<span>def <span class="ident">testGetInputsBatch</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetInputsBatch(self):
+  control_event_sequences = [[1, 1, 1, 0, 0], [1, 1, 1, 0, 0]]
+  target_event_sequences = [[0, 1, 0, 2], [0, 1]]
+  expected_inputs_1 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0, 1.0, 0.0],
+                       [1.0, 0.0, 1.0, 0.0, 0.0],
+                       [1.0, 0.0, 0.0, 0.0, 1.0]]
+  expected_inputs_2 = [[0.0, 1.0, 1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0, 1.0, 0.0]]
+  expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+  expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                      expected_inputs_2[-1:]]
+  self.assertListEqual(
+      expected_full_length_inputs_batch,
+      self.enc.get_inputs_batch(
+          control_event_sequences, target_event_sequences, True))
+  self.assertListEqual(
+      expected_last_event_inputs_batch,
+      self.enc.get_inputs_batch(
+          control_event_sequences, target_event_sequences))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(5, self.enc.input_size)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testNumClasses"><code class="name flex">
+<span>def <span class="ident">testNumClasses</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumClasses(self):
+  self.assertEqual(3, self.enc.num_classes)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">LookbackEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class LookbackEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)), [1, 2], 2)
+
+  def testInputSize(self):
+    self.assertEqual(13, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(5, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                      1.0, -1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+                      -1.0, 1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                      1.0, 1.0, 0.0, 1.0],
+                     self.enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+                      -1.0, -1.0, 0.0, 0.0],
+                     self.enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                      1.0, -1.0, 0.0, 1.0],
+                     self.enc.events_to_input(events, 4))
+
+  def testEventsToLabel(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(4, self.enc.events_to_label(events, 0))
+    self.assertEqual(1, self.enc.events_to_label(events, 1))
+    self.assertEqual(4, self.enc.events_to_label(events, 2))
+    self.assertEqual(2, self.enc.events_to_label(events, 3))
+    self.assertEqual(4, self.enc.events_to_label(events, 4))
+
+  def testClassIndexToEvent(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(3, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(4, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(3, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(4, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))
+    self.assertEqual(0, self.enc.class_index_to_event(3, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(4, events[:5]))
+
+  def testLabelsToNumSteps(self):
+    labels = [0, 1, 0, 2, 0]
+    self.assertEqual(3, self.enc.labels_to_num_steps(labels))
+
+    labels = [0, 1, 3, 2, 4]
+    self.assertEqual(5, self.enc.labels_to_num_steps(labels))
+
+  def testEmptyLookback(self):
+    enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3), [], 2)
+    self.assertEqual(5, enc.input_size)
+    self.assertEqual(3, enc.num_classes)
+
+    events = [0, 1, 0, 2, 0]
+
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                     enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0, -1.0, 1.0],
+                     enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, 1.0],
+                     enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0, -1.0, -1.0],
+                     enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                     enc.events_to_input(events, 4))
+
+    self.assertEqual(0, enc.events_to_label(events, 0))
+    self.assertEqual(1, enc.events_to_label(events, 1))
+    self.assertEqual(0, enc.events_to_label(events, 2))
+    self.assertEqual(2, enc.events_to_label(events, 3))
+    self.assertEqual(0, enc.events_to_label(events, 4))
+
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+    self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+      testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)), [1, 2], 2)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testClassIndexToEvent"><code class="name flex">
+<span>def <span class="ident">testClassIndexToEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testClassIndexToEvent(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+  self.assertEqual(0, self.enc.class_index_to_event(3, events[:1]))
+  self.assertEqual(0, self.enc.class_index_to_event(4, events[:1]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+  self.assertEqual(1, self.enc.class_index_to_event(3, events[:2]))
+  self.assertEqual(0, self.enc.class_index_to_event(4, events[:2]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+  self.assertEqual(0, self.enc.class_index_to_event(3, events[:3]))
+  self.assertEqual(1, self.enc.class_index_to_event(4, events[:3]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+  self.assertEqual(2, self.enc.class_index_to_event(3, events[:4]))
+  self.assertEqual(0, self.enc.class_index_to_event(4, events[:4]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))
+  self.assertEqual(0, self.enc.class_index_to_event(3, events[:5]))
+  self.assertEqual(2, self.enc.class_index_to_event(4, events[:5]))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEmptyLookback"><code class="name flex">
+<span>def <span class="ident">testEmptyLookback</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmptyLookback(self):
+  enc = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+      testing_lib.TrivialOneHotEncoding(3), [], 2)
+  self.assertEqual(5, enc.input_size)
+  self.assertEqual(3, enc.num_classes)
+
+  events = [0, 1, 0, 2, 0]
+
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                   enc.events_to_input(events, 0))
+  self.assertEqual([0.0, 1.0, 0.0, -1.0, 1.0],
+                   enc.events_to_input(events, 1))
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, 1.0],
+                   enc.events_to_input(events, 2))
+  self.assertEqual([0.0, 0.0, 1.0, -1.0, -1.0],
+                   enc.events_to_input(events, 3))
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, -1.0],
+                   enc.events_to_input(events, 4))
+
+  self.assertEqual(0, enc.events_to_label(events, 0))
+  self.assertEqual(1, enc.events_to_label(events, 1))
+  self.assertEqual(0, enc.events_to_label(events, 2))
+  self.assertEqual(2, enc.events_to_label(events, 3))
+  self.assertEqual(0, enc.events_to_label(events, 4))
+
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:1]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:1]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:1]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:2]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:2]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:2]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:3]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:3]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:3]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:4]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:4]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:4]))
+  self.assertEqual(0, self.enc.class_index_to_event(0, events[:5]))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events[:5]))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events[:5]))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                    1.0, -1.0, 0.0, 0.0],
+                   self.enc.events_to_input(events, 0))
+  self.assertEqual([0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+                    -1.0, 1.0, 0.0, 0.0],
+                   self.enc.events_to_input(events, 1))
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                    1.0, 1.0, 0.0, 1.0],
+                   self.enc.events_to_input(events, 2))
+  self.assertEqual([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+                    -1.0, -1.0, 0.0, 0.0],
+                   self.enc.events_to_input(events, 3))
+  self.assertEqual([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                    1.0, -1.0, 0.0, 1.0],
+                   self.enc.events_to_input(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToLabel"><code class="name flex">
+<span>def <span class="ident">testEventsToLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToLabel(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual(4, self.enc.events_to_label(events, 0))
+  self.assertEqual(1, self.enc.events_to_label(events, 1))
+  self.assertEqual(4, self.enc.events_to_label(events, 2))
+  self.assertEqual(2, self.enc.events_to_label(events, 3))
+  self.assertEqual(4, self.enc.events_to_label(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(13, self.enc.input_size)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testLabelsToNumSteps"><code class="name flex">
+<span>def <span class="ident">testLabelsToNumSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testLabelsToNumSteps(self):
+  labels = [0, 1, 0, 2, 0]
+  self.assertEqual(3, self.enc.labels_to_num_steps(labels))
+
+  labels = [0, 1, 3, 2, 4]
+  self.assertEqual(5, self.enc.labels_to_num_steps(labels))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testNumClasses"><code class="name flex">
+<span>def <span class="ident">testNumClasses</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumClasses(self):
+  self.assertEqual(5, self.enc.num_classes)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest"><code class="flex name class">
+<span>class <span class="ident">MultipleEventSequenceEncoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultipleEventSequenceEncoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.MultipleEventSequenceEncoder([
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(2)),
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3))])
+
+  def testInputSize(self):
+    self.assertEqual(5, self.enc.input_size)
+
+  def testEventsToInput(self):
+    events = [(1, 0), (1, 1), (1, 0), (0, 2), (0, 0)]
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 0))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(events, 1))
+    self.assertEqual(
+        [0.0, 1.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0, 1.0],
+        self.enc.events_to_input(events, 3))
+    self.assertEqual(
+        [1.0, 0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 4))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.MultipleEventSequenceEncoder([
+      encoder_decoder.OneHotEventSequenceEncoderDecoder(
+          testing_lib.TrivialOneHotEncoding(2)),
+      encoder_decoder.OneHotEventSequenceEncoderDecoder(
+          testing_lib.TrivialOneHotEncoding(3))])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  events = [(1, 0), (1, 1), (1, 0), (0, 2), (0, 0)]
+  self.assertEqual(
+      [0.0, 1.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 0))
+  self.assertEqual(
+      [0.0, 1.0, 0.0, 1.0, 0.0],
+      self.enc.events_to_input(events, 1))
+  self.assertEqual(
+      [0.0, 1.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 2))
+  self.assertEqual(
+      [1.0, 0.0, 0.0, 0.0, 1.0],
+      self.enc.events_to_input(events, 3))
+  self.assertEqual(
+      [1.0, 0.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(5, self.enc.input_size)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">OneHotEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OneHotEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))
+
+  def testInputSize(self):
+    self.assertEqual(3, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(3, self.enc.num_classes)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 0))
+    self.assertEqual([0.0, 1.0, 0.0], self.enc.events_to_input(events, 1))
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 2))
+    self.assertEqual([0.0, 0.0, 1.0], self.enc.events_to_input(events, 3))
+    self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 4))
+
+  def testEventsToLabel(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.events_to_label(events, 0))
+    self.assertEqual(1, self.enc.events_to_label(events, 1))
+    self.assertEqual(0, self.enc.events_to_label(events, 2))
+    self.assertEqual(2, self.enc.events_to_label(events, 3))
+    self.assertEqual(0, self.enc.events_to_label(events, 4))
+
+  def testClassIndexToEvent(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual(0, self.enc.class_index_to_event(0, events))
+    self.assertEqual(1, self.enc.class_index_to_event(1, events))
+    self.assertEqual(2, self.enc.class_index_to_event(2, events))
+
+  def testLabelsToNumSteps(self):
+    labels = [0, 1, 0, 2, 0]
+    self.assertEqual(3, self.enc.labels_to_num_steps(labels))
+
+  def testEncode(self):
+    events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(events)
+    expected_inputs = [[1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0],
+                       [1.0, 0.0, 0.0],
+                       [0.0, 0.0, 1.0]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+    expected_inputs_1 = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [1.0, 0.0, 0.0],
+                         [0.0, 0.0, 1.0],
+                         [1.0, 0.0, 0.0]]
+    expected_inputs_2 = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [0.0, 0.0, 1.0]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences))
+
+  def testExtendEventSequences(self):
+    events1 = [0]
+    events2 = [0]
+    events3 = [0]
+    event_sequences = [events1, events2, events3]
+    softmax = [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]]
+    self.enc.extend_event_sequences(event_sequences, softmax)
+    self.assertListEqual(list(events1), [0, 2])
+    self.assertListEqual(list(events2), [0, 0])
+    self.assertListEqual(list(events3), [0, 1])
+
+  def testEvaluateLogLikelihood(self):
+    events1 = [0, 1, 0]
+    events2 = [1, 2, 2]
+    event_sequences = [events1, events2]
+    softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+               [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+    p = self.enc.evaluate_log_likelihood(event_sequences, softmax)
+    self.assertListEqual([np.log(0.5) + np.log(0.3),
+                          np.log(0.4) + np.log(0.6)], p)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+      testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testClassIndexToEvent"><code class="name flex">
+<span>def <span class="ident">testClassIndexToEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testClassIndexToEvent(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual(0, self.enc.class_index_to_event(0, events))
+  self.assertEqual(1, self.enc.class_index_to_event(1, events))
+  self.assertEqual(2, self.enc.class_index_to_event(2, events))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEncode"><code class="name flex">
+<span>def <span class="ident">testEncode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncode(self):
+  events = [0, 1, 0, 2, 0]
+  inputs, labels = self.enc.encode(events)
+  expected_inputs = [[1.0, 0.0, 0.0],
+                     [0.0, 1.0, 0.0],
+                     [1.0, 0.0, 0.0],
+                     [0.0, 0.0, 1.0]]
+  expected_labels = [1, 0, 2, 0]
+  self.assertEqual(inputs, expected_inputs)
+  self.assertEqual(labels, expected_labels)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood"><code class="name flex">
+<span>def <span class="ident">testEvaluateLogLikelihood</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEvaluateLogLikelihood(self):
+  events1 = [0, 1, 0]
+  events2 = [1, 2, 2]
+  event_sequences = [events1, events2]
+  softmax = [[[0.0, 0.5, 0.5], [0.3, 0.4, 0.3]],
+             [[0.0, 0.6, 0.4], [0.0, 0.4, 0.6]]]
+  p = self.enc.evaluate_log_likelihood(event_sequences, softmax)
+  self.assertListEqual([np.log(0.5) + np.log(0.3),
+                        np.log(0.4) + np.log(0.6)], p)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 0))
+  self.assertEqual([0.0, 1.0, 0.0], self.enc.events_to_input(events, 1))
+  self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 2))
+  self.assertEqual([0.0, 0.0, 1.0], self.enc.events_to_input(events, 3))
+  self.assertEqual([1.0, 0.0, 0.0], self.enc.events_to_input(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToLabel"><code class="name flex">
+<span>def <span class="ident">testEventsToLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToLabel(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual(0, self.enc.events_to_label(events, 0))
+  self.assertEqual(1, self.enc.events_to_label(events, 1))
+  self.assertEqual(0, self.enc.events_to_label(events, 2))
+  self.assertEqual(2, self.enc.events_to_label(events, 3))
+  self.assertEqual(0, self.enc.events_to_label(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testExtendEventSequences"><code class="name flex">
+<span>def <span class="ident">testExtendEventSequences</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtendEventSequences(self):
+  events1 = [0]
+  events2 = [0]
+  events3 = [0]
+  event_sequences = [events1, events2, events3]
+  softmax = [[[0.0, 0.0, 1.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]]
+  self.enc.extend_event_sequences(event_sequences, softmax)
+  self.assertListEqual(list(events1), [0, 2])
+  self.assertListEqual(list(events2), [0, 0])
+  self.assertListEqual(list(events3), [0, 1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testGetInputsBatch"><code class="name flex">
+<span>def <span class="ident">testGetInputsBatch</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetInputsBatch(self):
+  event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+  expected_inputs_1 = [[1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0],
+                       [1.0, 0.0, 0.0],
+                       [0.0, 0.0, 1.0],
+                       [1.0, 0.0, 0.0]]
+  expected_inputs_2 = [[1.0, 0.0, 0.0],
+                       [0.0, 1.0, 0.0],
+                       [0.0, 0.0, 1.0]]
+  expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+  expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                      expected_inputs_2[-1:]]
+  self.assertListEqual(
+      expected_full_length_inputs_batch,
+      self.enc.get_inputs_batch(event_sequences, True))
+  self.assertListEqual(
+      expected_last_event_inputs_batch,
+      self.enc.get_inputs_batch(event_sequences))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(3, self.enc.input_size)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testLabelsToNumSteps"><code class="name flex">
+<span>def <span class="ident">testLabelsToNumSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testLabelsToNumSteps(self):
+  labels = [0, 1, 0, 2, 0]
+  self.assertEqual(3, self.enc.labels_to_num_steps(labels))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testNumClasses"><code class="name flex">
+<span>def <span class="ident">testNumClasses</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumClasses(self):
+  self.assertEqual(3, self.enc.num_classes)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">OneHotIndexEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OneHotIndexEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OneHotIndexEventSequenceEncoderDecoder(
+        testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))
+
+  def testInputSize(self):
+    self.assertEqual(1, self.enc.input_size)
+
+  def testInputDepth(self):
+    self.assertEqual(3, self.enc.input_depth)
+
+  def testEventsToInput(self):
+    events = [0, 1, 0, 2, 0]
+    self.assertEqual([0], self.enc.events_to_input(events, 0))
+    self.assertEqual([1], self.enc.events_to_input(events, 1))
+    self.assertEqual([0], self.enc.events_to_input(events, 2))
+    self.assertEqual([2], self.enc.events_to_input(events, 3))
+    self.assertEqual([0], self.enc.events_to_input(events, 4))
+
+  def testEncode(self):
+    events = [0, 1, 0, 2, 0]
+    inputs, labels = self.enc.encode(events)
+    expected_inputs = [[0], [1], [0], [2]]
+    expected_labels = [1, 0, 2, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+    expected_inputs_1 = [[0], [1], [0], [2], [0]]
+    expected_inputs_2 = [[0], [1], [2]]
+    expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+    expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                        expected_inputs_2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.enc.get_inputs_batch(event_sequences))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.OneHotIndexEventSequenceEncoderDecoder(
+      testing_lib.TrivialOneHotEncoding(3, num_steps=range(3)))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEncode"><code class="name flex">
+<span>def <span class="ident">testEncode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncode(self):
+  events = [0, 1, 0, 2, 0]
+  inputs, labels = self.enc.encode(events)
+  expected_inputs = [[0], [1], [0], [2]]
+  expected_labels = [1, 0, 2, 0]
+  self.assertEqual(inputs, expected_inputs)
+  self.assertEqual(labels, expected_labels)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  events = [0, 1, 0, 2, 0]
+  self.assertEqual([0], self.enc.events_to_input(events, 0))
+  self.assertEqual([1], self.enc.events_to_input(events, 1))
+  self.assertEqual([0], self.enc.events_to_input(events, 2))
+  self.assertEqual([2], self.enc.events_to_input(events, 3))
+  self.assertEqual([0], self.enc.events_to_input(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testGetInputsBatch"><code class="name flex">
+<span>def <span class="ident">testGetInputsBatch</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetInputsBatch(self):
+  event_sequences = [[0, 1, 0, 2, 0], [0, 1, 2]]
+  expected_inputs_1 = [[0], [1], [0], [2], [0]]
+  expected_inputs_2 = [[0], [1], [2]]
+  expected_full_length_inputs_batch = [expected_inputs_1, expected_inputs_2]
+  expected_last_event_inputs_batch = [expected_inputs_1[-1:],
+                                      expected_inputs_2[-1:]]
+  self.assertListEqual(
+      expected_full_length_inputs_batch,
+      self.enc.get_inputs_batch(event_sequences, True))
+  self.assertListEqual(
+      expected_last_event_inputs_batch,
+      self.enc.get_inputs_batch(event_sequences))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputDepth"><code class="name flex">
+<span>def <span class="ident">testInputDepth</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputDepth(self):
+  self.assertEqual(3, self.enc.input_depth)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(1, self.enc.input_size)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest"><code class="flex name class">
+<span>class <span class="ident">OptionalEventSequenceEncoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class OptionalEventSequenceEncoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.enc = encoder_decoder.OptionalEventSequenceEncoder(
+        encoder_decoder.OneHotEventSequenceEncoderDecoder(
+            testing_lib.TrivialOneHotEncoding(3)))
+
+  def testInputSize(self):
+    self.assertEqual(4, self.enc.input_size)
+
+  def testEventsToInput(self):
+    events = [(False, 0), (False, 1), (False, 0), (True, 2), (True, 0)]
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 0))
+    self.assertEqual(
+        [0.0, 0.0, 1.0, 0.0],
+        self.enc.events_to_input(events, 1))
+    self.assertEqual(
+        [0.0, 1.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 2))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 3))
+    self.assertEqual(
+        [1.0, 0.0, 0.0, 0.0],
+        self.enc.events_to_input(events, 4))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.enc = encoder_decoder.OptionalEventSequenceEncoder(
+      encoder_decoder.OneHotEventSequenceEncoderDecoder(
+          testing_lib.TrivialOneHotEncoding(3)))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  events = [(False, 0), (False, 1), (False, 0), (True, 2), (True, 0)]
+  self.assertEqual(
+      [0.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 0))
+  self.assertEqual(
+      [0.0, 0.0, 1.0, 0.0],
+      self.enc.events_to_input(events, 1))
+  self.assertEqual(
+      [0.0, 1.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 2))
+  self.assertEqual(
+      [1.0, 0.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 3))
+  self.assertEqual(
+      [1.0, 0.0, 0.0, 0.0],
+      self.enc.events_to_input(events, 4))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(4, self.enc.input_size)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest">ConditionalEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.setUp" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testClassIndexToEvent" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testClassIndexToEvent">testClassIndexToEvent</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEncode" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEncode">testEncode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood">testEvaluateLogLikelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToLabel" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testEventsToLabel">testEventsToLabel</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testExtendEventSequences" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testExtendEventSequences">testExtendEventSequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testGetInputsBatch" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testGetInputsBatch">testGetInputsBatch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testInputSize" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testInputSize">testInputSize</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testNumClasses" href="#note_seq.encoder_decoder_test.ConditionalEventSequenceEncoderDecoderTest.testNumClasses">testNumClasses</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest">LookbackEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.setUp" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testClassIndexToEvent" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testClassIndexToEvent">testClassIndexToEvent</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEmptyLookback" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEmptyLookback">testEmptyLookback</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToLabel" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testEventsToLabel">testEventsToLabel</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testInputSize" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testInputSize">testInputSize</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testLabelsToNumSteps" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testLabelsToNumSteps">testLabelsToNumSteps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testNumClasses" href="#note_seq.encoder_decoder_test.LookbackEventSequenceEncoderDecoderTest.testNumClasses">testNumClasses</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest" href="#note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest">MultipleEventSequenceEncoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.setUp" href="#note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testInputSize" href="#note_seq.encoder_decoder_test.MultipleEventSequenceEncoderTest.testInputSize">testInputSize</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest">OneHotEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.setUp" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testClassIndexToEvent" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testClassIndexToEvent">testClassIndexToEvent</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEncode" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEncode">testEncode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEvaluateLogLikelihood">testEvaluateLogLikelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToLabel" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testEventsToLabel">testEventsToLabel</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testExtendEventSequences" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testExtendEventSequences">testExtendEventSequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testGetInputsBatch" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testGetInputsBatch">testGetInputsBatch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testInputSize" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testInputSize">testInputSize</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testLabelsToNumSteps" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testLabelsToNumSteps">testLabelsToNumSteps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testNumClasses" href="#note_seq.encoder_decoder_test.OneHotEventSequenceEncoderDecoderTest.testNumClasses">testNumClasses</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest">OneHotIndexEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.setUp" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEncode" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEncode">testEncode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testGetInputsBatch" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testGetInputsBatch">testGetInputsBatch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputDepth" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputDepth">testInputDepth</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputSize" href="#note_seq.encoder_decoder_test.OneHotIndexEventSequenceEncoderDecoderTest.testInputSize">testInputSize</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest" href="#note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest">OptionalEventSequenceEncoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.setUp" href="#note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testEventsToInput" href="#note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testInputSize" href="#note_seq.encoder_decoder_test.OptionalEventSequenceEncoderTest.testInputSize">testInputSize</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/events_lib.html
+++ b/docs/events_lib.html
@@ -1,0 +1,1075 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.events_lib API documentation</title>
+<meta name="description" content="Abstract base classes for working with musical event sequences …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.events_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Abstract base classes for working with musical event sequences.</p>
+<p>The abstract <code><a title="note_seq.events_lib.EventSequence" href="#note_seq.events_lib.EventSequence">EventSequence</a></code> class is an interface for a sequence of musical
+events. The <code><a title="note_seq.events_lib.SimpleEventSequence" href="#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></code> class is a basic implementation of this
+interface.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Abstract base classes for working with musical event sequences.
+
+The abstract `EventSequence` class is an interface for a sequence of musical
+events. The `SimpleEventSequence` class is a basic implementation of this
+interface.
+&#34;&#34;&#34;
+
+import abc
+import copy
+
+from note_seq import constants
+
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+STANDARD_PPQ = constants.STANDARD_PPQ
+
+
+class NonIntegerStepsPerBarError(Exception):
+  pass
+
+
+class EventSequence(object):
+  &#34;&#34;&#34;Stores a quantized stream of events.
+
+  EventSequence is an abstract class to use as an interface for interacting
+  with musical event sequences. Concrete implementations SimpleEventSequence
+  (and its descendants Melody and ChordProgression) and LeadSheet represent
+  sequences of musical events of particular types. In all cases, model-specific
+  code is responsible for converting this representation to SequenceExample
+  protos for TensorFlow.
+
+  EventSequence represents an iterable object. Simply iterate to retrieve the
+  events.
+
+  Attributes:
+    start_step: The offset of the first step of the sequence relative to the
+        beginning of the source sequence.
+    end_step: The offset to the beginning of the bar following the last step
+        of the sequence relative to the beginning of the source sequence.
+    steps: A Python list containing the time step at each event of the sequence.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def start_step(self):
+    pass
+
+  @property
+  @abc.abstractmethod
+  def end_step(self):
+    pass
+
+  @property
+  @abc.abstractmethod
+  def steps(self):
+    pass
+
+  @abc.abstractmethod
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence.
+
+    Args:
+      event: The event to append to the end.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, will pad  to make the sequence
+    the specified length. If it is too long, it will be truncated to the
+    requested length.
+
+    Args:
+      steps: How many steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __iter__(self):
+    &#34;&#34;&#34;Returns an iterator over the events.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this EventSequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    pass
+
+
+class SimpleEventSequence(EventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of events.
+
+  This class can be instantiated, but its main purpose is to serve as a base
+  class for Melody, ChordProgression, and any other simple stream of musical
+  events.
+
+  SimpleEventSequence represents an iterable object. Simply iterate to retrieve
+  the events.
+
+  Attributes:
+    start_step: The offset of the first step of the sequence relative to the
+        beginning of the source sequence. Should always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the sequence relative to the beginning of the source sequence. Will
+       always be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, pad_event, events=None, start_step=0,
+               steps_per_bar=DEFAULT_STEPS_PER_BAR,
+               steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Construct a SimpleEventSequence.
+
+    If `events` is specified, instantiate with the provided event list.
+    Otherwise, create an empty SimpleEventSequence.
+
+    Args:
+      pad_event: Event value to use when padding sequences.
+      events: List of events to instantiate with.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+    &#34;&#34;&#34;
+    self._pad_event = pad_event
+    if events is not None:
+      self._from_event_list(events, start_step=start_step,
+                            steps_per_bar=steps_per_bar,
+                            steps_per_quarter=steps_per_quarter)
+    else:
+      self._events = []
+      self._steps_per_bar = steps_per_bar
+      self._steps_per_quarter = steps_per_quarter
+      self._start_step = start_step
+      self._end_step = start_step
+
+  def _reset(self):
+    &#34;&#34;&#34;Clear events and reset object state.&#34;&#34;&#34;
+    self._events = []
+    self._steps_per_bar = DEFAULT_STEPS_PER_BAR
+    self._steps_per_quarter = DEFAULT_STEPS_PER_QUARTER
+    self._start_step = 0
+    self._end_step = 0
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.&#34;&#34;&#34;
+    self._events = list(events)
+    self._start_step = start_step
+    self._end_step = start_step + len(self)
+    self._steps_per_bar = steps_per_bar
+    self._steps_per_quarter = steps_per_quarter
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this SimpleEventSequence.
+
+    Returns:
+      Python iterator over events.
+    &#34;&#34;&#34;
+    return iter(self._events)
+
+  def __getitem__(self, key):
+    &#34;&#34;&#34;Returns the slice or individual item.&#34;&#34;&#34;
+    if isinstance(key, int):
+      return self._events[key]
+    elif isinstance(key, slice):
+      events = self._events.__getitem__(key)
+      return type(self)(pad_event=self._pad_event,
+                        events=events,
+                        start_step=self.start_step + (key.start or 0),
+                        steps_per_bar=self.steps_per_bar,
+                        steps_per_quarter=self.steps_per_quarter)
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this SimpleEventSequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __deepcopy__(self, memo=None):
+    return type(self)(pad_event=self._pad_event,
+                      events=copy.deepcopy(self._events, memo),
+                      start_step=self.start_step,
+                      steps_per_bar=self.steps_per_bar,
+                      steps_per_quarter=self.steps_per_quarter)
+
+  def __eq__(self, other):
+    if type(self) is not type(other):
+      return False
+    return (list(self) == list(other) and
+            self.steps_per_bar == other.steps_per_bar and
+            self.steps_per_quarter == other.steps_per_quarter and
+            self.start_step == other.start_step and
+            self.end_step == other.end_step)
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def end_step(self):
+    return self._end_step
+
+  @property
+  def steps(self):
+    return list(range(self._start_step, self._end_step))
+
+  @property
+  def steps_per_bar(self):
+    return self._steps_per_bar
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+    Args:
+      event: The event to append to the end.
+    &#34;&#34;&#34;
+    self._events.append(event)
+    self._end_step += 1
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads to make the sequence the
+    specified length. If it is too long, it will be truncated to the requested
+    length.
+
+    Args:
+      steps: How many steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if steps &gt; len(self):
+      if from_left:
+        self._events[:0] = [self._pad_event] * (steps - len(self))
+      else:
+        self._events.extend([self._pad_event] * (steps - len(self)))
+    else:
+      if from_left:
+        del self._events[0:-steps]
+      else:
+        del self._events[steps:]
+
+    if from_left:
+      self._start_step = self._end_step - steps
+    else:
+      self._end_step = self._start_step + steps
+
+  def increase_resolution(self, k, fill_event=None):
+    &#34;&#34;&#34;Increase the resolution of an event sequence.
+
+    Increases the resolution of a SimpleEventSequence object by a factor of
+    `k`.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          event sequence.
+      fill_event: Event value to use to extend each low-resolution event. If
+          None, each low-resolution event value will be repeated `k` times.
+    &#34;&#34;&#34;
+    if fill_event is None:
+      fill = lambda event: [event] * k
+    else:
+      fill = lambda event: [event] + [fill_event] * (k - 1)
+
+    new_events = []
+    for event in self._events:
+      new_events += fill(event)
+
+    self._events = new_events
+    self._start_step *= k
+    self._end_step *= k
+    self._steps_per_bar *= k
+    self._steps_per_quarter *= k</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.events_lib.EventSequence"><code class="flex name class">
+<span>class <span class="ident">EventSequence</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a quantized stream of events.</p>
+<p>EventSequence is an abstract class to use as an interface for interacting
+with musical event sequences. Concrete implementations SimpleEventSequence
+(and its descendants Melody and ChordProgression) and LeadSheet represent
+sequences of musical events of particular types. In all cases, model-specific
+code is responsible for converting this representation to SequenceExample
+protos for TensorFlow.</p>
+<p>EventSequence represents an iterable object. Simply iterate to retrieve the
+events.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of the first step of the sequence relative to the
+beginning of the source sequence.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>The offset to the beginning of the bar following the last step
+of the sequence relative to the beginning of the source sequence.</dd>
+<dt><strong><code>steps</code></strong></dt>
+<dd>A Python list containing the time step at each event of the sequence.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EventSequence(object):
+  &#34;&#34;&#34;Stores a quantized stream of events.
+
+  EventSequence is an abstract class to use as an interface for interacting
+  with musical event sequences. Concrete implementations SimpleEventSequence
+  (and its descendants Melody and ChordProgression) and LeadSheet represent
+  sequences of musical events of particular types. In all cases, model-specific
+  code is responsible for converting this representation to SequenceExample
+  protos for TensorFlow.
+
+  EventSequence represents an iterable object. Simply iterate to retrieve the
+  events.
+
+  Attributes:
+    start_step: The offset of the first step of the sequence relative to the
+        beginning of the source sequence.
+    end_step: The offset to the beginning of the bar following the last step
+        of the sequence relative to the beginning of the source sequence.
+    steps: A Python list containing the time step at each event of the sequence.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def start_step(self):
+    pass
+
+  @property
+  @abc.abstractmethod
+  def end_step(self):
+    pass
+
+  @property
+  @abc.abstractmethod
+  def steps(self):
+    pass
+
+  @abc.abstractmethod
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence.
+
+    Args:
+      event: The event to append to the end.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, will pad  to make the sequence
+    the specified length. If it is too long, it will be truncated to the
+    requested length.
+
+    Args:
+      steps: How many steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __iter__(self):
+    &#34;&#34;&#34;Returns an iterator over the events.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this EventSequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    pass</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.SimpleEventSequence" href="#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></li>
+<li><a title="note_seq.lead_sheets_lib.LeadSheet" href="lead_sheets_lib.html#note_seq.lead_sheets_lib.LeadSheet">LeadSheet</a></li>
+<li><a title="note_seq.performance_lib.BasePerformance" href="performance_lib.html#note_seq.performance_lib.BasePerformance">BasePerformance</a></li>
+<li><a title="note_seq.pianoroll_lib.PianorollSequence" href="pianoroll_lib.html#note_seq.pianoroll_lib.PianorollSequence">PianorollSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.events_lib.EventSequence.end_step"><code class="name">var <span class="ident">end_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def end_step(self):
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.EventSequence.start_step"><code class="name">var <span class="ident">start_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def start_step(self):
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.EventSequence.steps"><code class="name">var <span class="ident">steps</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def steps(self):
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.events_lib.EventSequence.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends event to the end of the sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The event to append to the end.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def append(self, event):
+  &#34;&#34;&#34;Appends event to the end of the sequence.
+
+  Args:
+    event: The event to append to the end.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.EventSequence.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps, from_left=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the sequence to the specified number of steps.</p>
+<p>If the event sequence is not long enough, will pad
+to make the sequence
+the specified length. If it is too long, it will be truncated to the
+requested length.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many steps long the event sequence should be.</dd>
+<dt><strong><code>from_left</code></strong></dt>
+<dd>Whether to add/remove from the left instead of right.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def set_length(self, steps, from_left=False):
+  &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+  If the event sequence is not long enough, will pad  to make the sequence
+  the specified length. If it is too long, it will be truncated to the
+  requested length.
+
+  Args:
+    steps: How many steps long the event sequence should be.
+    from_left: Whether to add/remove from the left instead of right.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.events_lib.NonIntegerStepsPerBarError"><code class="flex name class">
+<span>class <span class="ident">NonIntegerStepsPerBarError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NonIntegerStepsPerBarError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence"><code class="flex name class">
+<span>class <span class="ident">SimpleEventSequence</span></span>
+<span>(</span><span>pad_event, events=None, start_step=0, steps_per_bar=16, steps_per_quarter=4)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a quantized stream of events.</p>
+<p>This class can be instantiated, but its main purpose is to serve as a base
+class for Melody, ChordProgression, and any other simple stream of musical
+events.</p>
+<p>SimpleEventSequence represents an iterable object. Simply iterate to retrieve
+the events.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of the first step of the sequence relative to the
+beginning of the source sequence. Should always be the first step of a
+bar.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>The offset to the beginning of the bar following the last step
+of the sequence relative to the beginning of the source sequence. Will
+always be the first step of a bar.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Number of steps in in a quarter note.</dd>
+<dt><strong><code>steps_per_bar</code></strong></dt>
+<dd>Number of steps in a bar (measure) of music.</dd>
+</dl>
+<p>Construct a SimpleEventSequence.</p>
+<p>If <code>events</code> is specified, instantiate with the provided event list.
+Otherwise, create an empty SimpleEventSequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pad_event</code></strong></dt>
+<dd>Event value to use when padding sequences.</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>List of events to instantiate with.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The integer starting step offset.</dd>
+<dt><strong><code>steps_per_bar</code></strong></dt>
+<dd>The number of steps in a bar.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>The number of steps in a quarter note.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SimpleEventSequence(EventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of events.
+
+  This class can be instantiated, but its main purpose is to serve as a base
+  class for Melody, ChordProgression, and any other simple stream of musical
+  events.
+
+  SimpleEventSequence represents an iterable object. Simply iterate to retrieve
+  the events.
+
+  Attributes:
+    start_step: The offset of the first step of the sequence relative to the
+        beginning of the source sequence. Should always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the sequence relative to the beginning of the source sequence. Will
+       always be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, pad_event, events=None, start_step=0,
+               steps_per_bar=DEFAULT_STEPS_PER_BAR,
+               steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Construct a SimpleEventSequence.
+
+    If `events` is specified, instantiate with the provided event list.
+    Otherwise, create an empty SimpleEventSequence.
+
+    Args:
+      pad_event: Event value to use when padding sequences.
+      events: List of events to instantiate with.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+    &#34;&#34;&#34;
+    self._pad_event = pad_event
+    if events is not None:
+      self._from_event_list(events, start_step=start_step,
+                            steps_per_bar=steps_per_bar,
+                            steps_per_quarter=steps_per_quarter)
+    else:
+      self._events = []
+      self._steps_per_bar = steps_per_bar
+      self._steps_per_quarter = steps_per_quarter
+      self._start_step = start_step
+      self._end_step = start_step
+
+  def _reset(self):
+    &#34;&#34;&#34;Clear events and reset object state.&#34;&#34;&#34;
+    self._events = []
+    self._steps_per_bar = DEFAULT_STEPS_PER_BAR
+    self._steps_per_quarter = DEFAULT_STEPS_PER_QUARTER
+    self._start_step = 0
+    self._end_step = 0
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.&#34;&#34;&#34;
+    self._events = list(events)
+    self._start_step = start_step
+    self._end_step = start_step + len(self)
+    self._steps_per_bar = steps_per_bar
+    self._steps_per_quarter = steps_per_quarter
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this SimpleEventSequence.
+
+    Returns:
+      Python iterator over events.
+    &#34;&#34;&#34;
+    return iter(self._events)
+
+  def __getitem__(self, key):
+    &#34;&#34;&#34;Returns the slice or individual item.&#34;&#34;&#34;
+    if isinstance(key, int):
+      return self._events[key]
+    elif isinstance(key, slice):
+      events = self._events.__getitem__(key)
+      return type(self)(pad_event=self._pad_event,
+                        events=events,
+                        start_step=self.start_step + (key.start or 0),
+                        steps_per_bar=self.steps_per_bar,
+                        steps_per_quarter=self.steps_per_quarter)
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this SimpleEventSequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __deepcopy__(self, memo=None):
+    return type(self)(pad_event=self._pad_event,
+                      events=copy.deepcopy(self._events, memo),
+                      start_step=self.start_step,
+                      steps_per_bar=self.steps_per_bar,
+                      steps_per_quarter=self.steps_per_quarter)
+
+  def __eq__(self, other):
+    if type(self) is not type(other):
+      return False
+    return (list(self) == list(other) and
+            self.steps_per_bar == other.steps_per_bar and
+            self.steps_per_quarter == other.steps_per_quarter and
+            self.start_step == other.start_step and
+            self.end_step == other.end_step)
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def end_step(self):
+    return self._end_step
+
+  @property
+  def steps(self):
+    return list(range(self._start_step, self._end_step))
+
+  @property
+  def steps_per_bar(self):
+    return self._steps_per_bar
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+    Args:
+      event: The event to append to the end.
+    &#34;&#34;&#34;
+    self._events.append(event)
+    self._end_step += 1
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads to make the sequence the
+    specified length. If it is too long, it will be truncated to the requested
+    length.
+
+    Args:
+      steps: How many steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if steps &gt; len(self):
+      if from_left:
+        self._events[:0] = [self._pad_event] * (steps - len(self))
+      else:
+        self._events.extend([self._pad_event] * (steps - len(self)))
+    else:
+      if from_left:
+        del self._events[0:-steps]
+      else:
+        del self._events[steps:]
+
+    if from_left:
+      self._start_step = self._end_step - steps
+    else:
+      self._end_step = self._start_step + steps
+
+  def increase_resolution(self, k, fill_event=None):
+    &#34;&#34;&#34;Increase the resolution of an event sequence.
+
+    Increases the resolution of a SimpleEventSequence object by a factor of
+    `k`.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          event sequence.
+      fill_event: Event value to use to extend each low-resolution event. If
+          None, each low-resolution event value will be repeated `k` times.
+    &#34;&#34;&#34;
+    if fill_event is None:
+      fill = lambda event: [event] * k
+    else:
+      fill = lambda event: [event] + [fill_event] * (k - 1)
+
+    new_events = []
+    for event in self._events:
+      new_events += fill(event)
+
+    self._events = new_events
+    self._start_step *= k
+    self._end_step *= k
+    self._steps_per_bar *= k
+    self._steps_per_quarter *= k</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.EventSequence" href="#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.chords_lib.ChordProgression" href="chords_lib.html#note_seq.chords_lib.ChordProgression">ChordProgression</a></li>
+<li><a title="note_seq.drums_lib.DrumTrack" href="drums_lib.html#note_seq.drums_lib.DrumTrack">DrumTrack</a></li>
+<li><a title="note_seq.melodies_lib.Melody" href="melodies_lib.html#note_seq.melodies_lib.Melody">Melody</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.events_lib.SimpleEventSequence.end_step"><code class="name">var <span class="ident">end_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def end_step(self):
+  return self._end_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.start_step"><code class="name">var <span class="ident">start_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def start_step(self):
+  return self._start_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.steps"><code class="name">var <span class="ident">steps</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps(self):
+  return list(range(self._start_step, self._end_step))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.steps_per_bar"><code class="name">var <span class="ident">steps_per_bar</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_bar(self):
+  return self._steps_per_bar</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.steps_per_quarter"><code class="name">var <span class="ident">steps_per_quarter</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_quarter(self):
+  return self._steps_per_quarter</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.events_lib.SimpleEventSequence.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends event to the end of the sequence and increments the end step.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The event to append to the end.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+  Args:
+    event: The event to append to the end.
+  &#34;&#34;&#34;
+  self._events.append(event)
+  self._end_step += 1</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.increase_resolution"><code class="name flex">
+<span>def <span class="ident">increase_resolution</span></span>(<span>self, k, fill_event=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Increase the resolution of an event sequence.</p>
+<p>Increases the resolution of a SimpleEventSequence object by a factor of
+<code>k</code>.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>k</code></strong></dt>
+<dd>An integer, the factor by which to increase the resolution of the
+event sequence.</dd>
+<dt><strong><code>fill_event</code></strong></dt>
+<dd>Event value to use to extend each low-resolution event. If
+None, each low-resolution event value will be repeated <code>k</code> times.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def increase_resolution(self, k, fill_event=None):
+  &#34;&#34;&#34;Increase the resolution of an event sequence.
+
+  Increases the resolution of a SimpleEventSequence object by a factor of
+  `k`.
+
+  Args:
+    k: An integer, the factor by which to increase the resolution of the
+        event sequence.
+    fill_event: Event value to use to extend each low-resolution event. If
+        None, each low-resolution event value will be repeated `k` times.
+  &#34;&#34;&#34;
+  if fill_event is None:
+    fill = lambda event: [event] * k
+  else:
+    fill = lambda event: [event] + [fill_event] * (k - 1)
+
+  new_events = []
+  for event in self._events:
+    new_events += fill(event)
+
+  self._events = new_events
+  self._start_step *= k
+  self._end_step *= k
+  self._steps_per_bar *= k
+  self._steps_per_quarter *= k</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib.SimpleEventSequence.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps, from_left=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the sequence to the specified number of steps.</p>
+<p>If the event sequence is not long enough, pads to make the sequence the
+specified length. If it is too long, it will be truncated to the requested
+length.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many steps long the event sequence should be.</dd>
+<dt><strong><code>from_left</code></strong></dt>
+<dd>Whether to add/remove from the left instead of right.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_length(self, steps, from_left=False):
+  &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+  If the event sequence is not long enough, pads to make the sequence the
+  specified length. If it is too long, it will be truncated to the requested
+  length.
+
+  Args:
+    steps: How many steps long the event sequence should be.
+    from_left: Whether to add/remove from the left instead of right.
+  &#34;&#34;&#34;
+  if steps &gt; len(self):
+    if from_left:
+      self._events[:0] = [self._pad_event] * (steps - len(self))
+    else:
+      self._events.extend([self._pad_event] * (steps - len(self)))
+  else:
+    if from_left:
+      del self._events[0:-steps]
+    else:
+      del self._events[steps:]
+
+  if from_left:
+    self._start_step = self._end_step - steps
+  else:
+    self._end_step = self._start_step + steps</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.events_lib.EventSequence" href="#note_seq.events_lib.EventSequence">EventSequence</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.events_lib.EventSequence.append" href="#note_seq.events_lib.EventSequence.append">append</a></code></li>
+<li><code><a title="note_seq.events_lib.EventSequence.end_step" href="#note_seq.events_lib.EventSequence.end_step">end_step</a></code></li>
+<li><code><a title="note_seq.events_lib.EventSequence.set_length" href="#note_seq.events_lib.EventSequence.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.events_lib.EventSequence.start_step" href="#note_seq.events_lib.EventSequence.start_step">start_step</a></code></li>
+<li><code><a title="note_seq.events_lib.EventSequence.steps" href="#note_seq.events_lib.EventSequence.steps">steps</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.events_lib.NonIntegerStepsPerBarError" href="#note_seq.events_lib.NonIntegerStepsPerBarError">NonIntegerStepsPerBarError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.events_lib.SimpleEventSequence" href="#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.append" href="#note_seq.events_lib.SimpleEventSequence.append">append</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.end_step" href="#note_seq.events_lib.SimpleEventSequence.end_step">end_step</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.increase_resolution" href="#note_seq.events_lib.SimpleEventSequence.increase_resolution">increase_resolution</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.set_length" href="#note_seq.events_lib.SimpleEventSequence.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.start_step" href="#note_seq.events_lib.SimpleEventSequence.start_step">start_step</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.steps" href="#note_seq.events_lib.SimpleEventSequence.steps">steps</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.steps_per_bar" href="#note_seq.events_lib.SimpleEventSequence.steps_per_bar">steps_per_bar</a></code></li>
+<li><code><a title="note_seq.events_lib.SimpleEventSequence.steps_per_quarter" href="#note_seq.events_lib.SimpleEventSequence.steps_per_quarter">steps_per_quarter</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/events_lib_test.html
+++ b/docs/events_lib_test.html
@@ -1,0 +1,377 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.events_lib_test API documentation</title>
+<meta name="description" content="Tests for events_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.events_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for events_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for events_lib.&#34;&#34;&#34;
+
+import copy
+
+from absl.testing import absltest
+from note_seq import events_lib
+
+
+class EventsLibTest(absltest.TestCase):
+
+  def testDeepcopy(self):
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[0, 1, 2], start_step=0, steps_per_quarter=4,
+        steps_per_bar=8)
+    events_copy = copy.deepcopy(events)
+    self.assertEqual(events, events_copy)
+
+    events.set_length(2)
+    self.assertNotEqual(events, events_copy)
+
+  def testAppendEvent(self):
+    events = events_lib.SimpleEventSequence(pad_event=0)
+
+    events.append(7)
+    self.assertListEqual([7], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(1, events.end_step)
+
+    events.append(&#39;cheese&#39;)
+    self.assertListEqual([7, &#39;cheese&#39;], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(2, events.end_step)
+
+  def testSetLength(self):
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[60], start_step=9)
+    events.set_length(5)
+    self.assertListEqual([60, 0, 0, 0, 0],
+                         list(events))
+    self.assertEqual(9, events.start_step)
+    self.assertEqual(14, events.end_step)
+    self.assertListEqual([9, 10, 11, 12, 13], events.steps)
+
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[60], start_step=9)
+    events.set_length(5, from_left=True)
+    self.assertListEqual([0, 0, 0, 0, 60],
+                         list(events))
+    self.assertEqual(5, events.start_step)
+    self.assertEqual(10, events.end_step)
+    self.assertListEqual([5, 6, 7, 8, 9], events.steps)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+    events.set_length(3)
+    self.assertListEqual([60, 0, 0], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(3, events.end_step)
+    self.assertListEqual([0, 1, 2], events.steps)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+    events.set_length(3, from_left=True)
+    self.assertListEqual([0, 0, 0], list(events))
+    self.assertEqual(1, events.start_step)
+    self.assertEqual(4, events.end_step)
+    self.assertListEqual([1, 2, 3], events.steps)
+
+  def testIncreaseResolution(self):
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0],
+                                            start_step=5, steps_per_bar=4,
+                                            steps_per_quarter=1)
+    events.increase_resolution(3, fill_event=None)
+    self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0], list(events))
+    self.assertEqual(events.start_step, 15)
+    self.assertEqual(events.steps_per_bar, 12)
+    self.assertEqual(events.steps_per_quarter, 3)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0])
+    events.increase_resolution(2, fill_event=0)
+    self.assertListEqual([1, 0, 0, 0, 1, 0, 0, 0], list(events))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.events_lib_test.EventsLibTest"><code class="flex name class">
+<span>class <span class="ident">EventsLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EventsLibTest(absltest.TestCase):
+
+  def testDeepcopy(self):
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[0, 1, 2], start_step=0, steps_per_quarter=4,
+        steps_per_bar=8)
+    events_copy = copy.deepcopy(events)
+    self.assertEqual(events, events_copy)
+
+    events.set_length(2)
+    self.assertNotEqual(events, events_copy)
+
+  def testAppendEvent(self):
+    events = events_lib.SimpleEventSequence(pad_event=0)
+
+    events.append(7)
+    self.assertListEqual([7], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(1, events.end_step)
+
+    events.append(&#39;cheese&#39;)
+    self.assertListEqual([7, &#39;cheese&#39;], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(2, events.end_step)
+
+  def testSetLength(self):
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[60], start_step=9)
+    events.set_length(5)
+    self.assertListEqual([60, 0, 0, 0, 0],
+                         list(events))
+    self.assertEqual(9, events.start_step)
+    self.assertEqual(14, events.end_step)
+    self.assertListEqual([9, 10, 11, 12, 13], events.steps)
+
+    events = events_lib.SimpleEventSequence(
+        pad_event=0, events=[60], start_step=9)
+    events.set_length(5, from_left=True)
+    self.assertListEqual([0, 0, 0, 0, 60],
+                         list(events))
+    self.assertEqual(5, events.start_step)
+    self.assertEqual(10, events.end_step)
+    self.assertListEqual([5, 6, 7, 8, 9], events.steps)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+    events.set_length(3)
+    self.assertListEqual([60, 0, 0], list(events))
+    self.assertEqual(0, events.start_step)
+    self.assertEqual(3, events.end_step)
+    self.assertListEqual([0, 1, 2], events.steps)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+    events.set_length(3, from_left=True)
+    self.assertListEqual([0, 0, 0], list(events))
+    self.assertEqual(1, events.start_step)
+    self.assertEqual(4, events.end_step)
+    self.assertListEqual([1, 2, 3], events.steps)
+
+  def testIncreaseResolution(self):
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0],
+                                            start_step=5, steps_per_bar=4,
+                                            steps_per_quarter=1)
+    events.increase_resolution(3, fill_event=None)
+    self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0], list(events))
+    self.assertEqual(events.start_step, 15)
+    self.assertEqual(events.steps_per_bar, 12)
+    self.assertEqual(events.steps_per_quarter, 3)
+
+    events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0])
+    events.increase_resolution(2, fill_event=0)
+    self.assertListEqual([1, 0, 0, 0, 1, 0, 0, 0], list(events))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.events_lib_test.EventsLibTest.testAppendEvent"><code class="name flex">
+<span>def <span class="ident">testAppendEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAppendEvent(self):
+  events = events_lib.SimpleEventSequence(pad_event=0)
+
+  events.append(7)
+  self.assertListEqual([7], list(events))
+  self.assertEqual(0, events.start_step)
+  self.assertEqual(1, events.end_step)
+
+  events.append(&#39;cheese&#39;)
+  self.assertListEqual([7, &#39;cheese&#39;], list(events))
+  self.assertEqual(0, events.start_step)
+  self.assertEqual(2, events.end_step)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib_test.EventsLibTest.testDeepcopy"><code class="name flex">
+<span>def <span class="ident">testDeepcopy</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDeepcopy(self):
+  events = events_lib.SimpleEventSequence(
+      pad_event=0, events=[0, 1, 2], start_step=0, steps_per_quarter=4,
+      steps_per_bar=8)
+  events_copy = copy.deepcopy(events)
+  self.assertEqual(events, events_copy)
+
+  events.set_length(2)
+  self.assertNotEqual(events, events_copy)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib_test.EventsLibTest.testIncreaseResolution"><code class="name flex">
+<span>def <span class="ident">testIncreaseResolution</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testIncreaseResolution(self):
+  events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0],
+                                          start_step=5, steps_per_bar=4,
+                                          steps_per_quarter=1)
+  events.increase_resolution(3, fill_event=None)
+  self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0], list(events))
+  self.assertEqual(events.start_step, 15)
+  self.assertEqual(events.steps_per_bar, 12)
+  self.assertEqual(events.steps_per_quarter, 3)
+
+  events = events_lib.SimpleEventSequence(pad_event=0, events=[1, 0, 1, 0])
+  events.increase_resolution(2, fill_event=0)
+  self.assertListEqual([1, 0, 0, 0, 1, 0, 0, 0], list(events))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.events_lib_test.EventsLibTest.testSetLength"><code class="name flex">
+<span>def <span class="ident">testSetLength</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLength(self):
+  events = events_lib.SimpleEventSequence(
+      pad_event=0, events=[60], start_step=9)
+  events.set_length(5)
+  self.assertListEqual([60, 0, 0, 0, 0],
+                       list(events))
+  self.assertEqual(9, events.start_step)
+  self.assertEqual(14, events.end_step)
+  self.assertListEqual([9, 10, 11, 12, 13], events.steps)
+
+  events = events_lib.SimpleEventSequence(
+      pad_event=0, events=[60], start_step=9)
+  events.set_length(5, from_left=True)
+  self.assertListEqual([0, 0, 0, 0, 60],
+                       list(events))
+  self.assertEqual(5, events.start_step)
+  self.assertEqual(10, events.end_step)
+  self.assertListEqual([5, 6, 7, 8, 9], events.steps)
+
+  events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+  events.set_length(3)
+  self.assertListEqual([60, 0, 0], list(events))
+  self.assertEqual(0, events.start_step)
+  self.assertEqual(3, events.end_step)
+  self.assertListEqual([0, 1, 2], events.steps)
+
+  events = events_lib.SimpleEventSequence(pad_event=0, events=[60, 0, 0, 0])
+  events.set_length(3, from_left=True)
+  self.assertListEqual([0, 0, 0], list(events))
+  self.assertEqual(1, events.start_step)
+  self.assertEqual(4, events.end_step)
+  self.assertListEqual([1, 2, 3], events.steps)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.events_lib_test.EventsLibTest" href="#note_seq.events_lib_test.EventsLibTest">EventsLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.events_lib_test.EventsLibTest.testAppendEvent" href="#note_seq.events_lib_test.EventsLibTest.testAppendEvent">testAppendEvent</a></code></li>
+<li><code><a title="note_seq.events_lib_test.EventsLibTest.testDeepcopy" href="#note_seq.events_lib_test.EventsLibTest.testDeepcopy">testDeepcopy</a></code></li>
+<li><code><a title="note_seq.events_lib_test.EventsLibTest.testIncreaseResolution" href="#note_seq.events_lib_test.EventsLibTest.testIncreaseResolution">testIncreaseResolution</a></code></li>
+<li><code><a title="note_seq.events_lib_test.EventsLibTest.testSetLength" href="#note_seq.events_lib_test.EventsLibTest.testSetLength">testSetLength</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,461 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq API documentation</title>
+<meta name="description" content="Imports classes and utils into the top-level namespace." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Package <code>note_seq</code></h1>
+</header>
+<section id="section-intro">
+<p>Imports classes and utils into the top-level namespace.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Imports classes and utils into the top-level namespace.&#34;&#34;&#34;
+
+from note_seq.abc_parser import parse_abc_tunebook
+from note_seq.abc_parser import parse_abc_tunebook_file
+
+import note_seq.audio_io
+
+from note_seq.chord_inference import ChordInferenceError
+from note_seq.chord_inference import infer_chords_for_sequence
+
+from note_seq.chord_symbols_lib import chord_symbol_bass
+from note_seq.chord_symbols_lib import chord_symbol_pitches
+from note_seq.chord_symbols_lib import chord_symbol_quality
+from note_seq.chord_symbols_lib import chord_symbol_root
+from note_seq.chord_symbols_lib import ChordSymbolError
+from note_seq.chord_symbols_lib import pitches_to_chord_symbol
+from note_seq.chord_symbols_lib import transpose_chord_symbol
+
+from note_seq.chords_encoder_decoder import ChordEncodingError
+from note_seq.chords_encoder_decoder import MajorMinorChordOneHotEncoding
+from note_seq.chords_encoder_decoder import PitchChordsEncoderDecoder
+from note_seq.chords_encoder_decoder import TriadChordOneHotEncoding
+
+from note_seq.chords_lib import BasicChordRenderer
+from note_seq.chords_lib import ChordProgression
+
+from note_seq.constants import *  # pylint: disable=wildcard-import
+
+from note_seq.drums_encoder_decoder import MultiDrumOneHotEncoding
+
+from note_seq.drums_lib import DrumTrack
+from note_seq.drums_lib import midi_file_to_drum_track
+
+from note_seq.encoder_decoder import ConditionalEventSequenceEncoderDecoder
+from note_seq.encoder_decoder import EventSequenceEncoderDecoder
+from note_seq.encoder_decoder import LookbackEventSequenceEncoderDecoder
+from note_seq.encoder_decoder import MultipleEventSequenceEncoder
+from note_seq.encoder_decoder import OneHotEncoding
+from note_seq.encoder_decoder import OneHotEventSequenceEncoderDecoder
+from note_seq.encoder_decoder import OneHotIndexEventSequenceEncoderDecoder
+from note_seq.encoder_decoder import OptionalEventSequenceEncoder
+
+from note_seq.events_lib import NonIntegerStepsPerBarError
+
+from note_seq.lead_sheets_lib import LeadSheet
+
+from note_seq.melodies_lib import BadNoteError
+from note_seq.melodies_lib import Melody
+from note_seq.melodies_lib import midi_file_to_melody
+from note_seq.melodies_lib import PolyphonicMelodyError
+
+from note_seq.melody_encoder_decoder import KeyMelodyEncoderDecoder
+from note_seq.melody_encoder_decoder import MelodyOneHotEncoding
+
+from note_seq.melody_inference import infer_melody_for_sequence
+from note_seq.melody_inference import MelodyInferenceError
+
+from note_seq.midi_io import midi_file_to_note_sequence
+from note_seq.midi_io import midi_file_to_sequence_proto
+from note_seq.midi_io import midi_to_note_sequence
+from note_seq.midi_io import midi_to_sequence_proto
+from note_seq.midi_io import MIDIConversionError
+from note_seq.midi_io import note_sequence_to_midi_file
+from note_seq.midi_io import note_sequence_to_pretty_midi
+from note_seq.midi_io import sequence_proto_to_midi_file
+from note_seq.midi_io import sequence_proto_to_pretty_midi
+
+from note_seq.midi_synth import fluidsynth
+from note_seq.midi_synth import synthesize
+
+import note_seq.musicnet_io
+
+from note_seq.musicxml_parser import MusicXMLDocument
+from note_seq.musicxml_parser import MusicXMLParseError
+
+from note_seq.musicxml_reader import musicxml_file_to_sequence_proto
+from note_seq.musicxml_reader import musicxml_to_sequence_proto
+from note_seq.musicxml_reader import MusicXMLConversionError
+
+from note_seq.notebook_utils import play_sequence
+from note_seq.notebook_utils import plot_sequence
+
+from note_seq.performance_controls import all_performance_control_signals
+from note_seq.performance_controls import NoteDensityPerformanceControlSignal
+from note_seq.performance_controls import PitchHistogramPerformanceControlSignal
+
+from note_seq.performance_encoder_decoder import ModuloPerformanceEventSequenceEncoderDecoder
+from note_seq.performance_encoder_decoder import NotePerformanceEventSequenceEncoderDecoder
+from note_seq.performance_encoder_decoder import PerformanceModuloEncoding
+from note_seq.performance_encoder_decoder import PerformanceOneHotEncoding
+
+from note_seq.performance_lib import MetricPerformance
+from note_seq.performance_lib import Performance
+from note_seq.performance_lib import PerformanceEvent
+
+from note_seq.pianoroll_encoder_decoder import PianorollEncoderDecoder
+
+from note_seq.pianoroll_lib import PianorollSequence
+
+from note_seq.protobuf import music_pb2
+from note_seq.protobuf.music_pb2 import NoteSequence  # pylint:disable=g-importing-member
+
+from note_seq.sequences_lib import apply_sustain_control_changes
+from note_seq.sequences_lib import BadTimeSignatureError
+from note_seq.sequences_lib import concatenate_sequences
+from note_seq.sequences_lib import extract_subsequence
+from note_seq.sequences_lib import infer_dense_chords_for_sequence
+from note_seq.sequences_lib import MultipleTempoError
+from note_seq.sequences_lib import MultipleTimeSignatureError
+from note_seq.sequences_lib import NegativeTimeError
+from note_seq.sequences_lib import quantize_note_sequence
+from note_seq.sequences_lib import quantize_note_sequence_absolute
+from note_seq.sequences_lib import quantize_to_step
+from note_seq.sequences_lib import sequence_to_pianoroll
+from note_seq.sequences_lib import split_note_sequence
+from note_seq.sequences_lib import steps_per_bar_in_quantized_sequence
+from note_seq.sequences_lib import steps_per_quarter_to_steps_per_second
+from note_seq.sequences_lib import trim_note_sequence
+
+import note_seq.version
+from note_seq.version import __version__</code></pre>
+</details>
+</section>
+<section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="note_seq.abc_parser" href="abc_parser.html">note_seq.abc_parser</a></code></dt>
+<dd>
+<div class="desc"><p>Parser for ABC files …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.abc_parser_test" href="abc_parser_test.html">note_seq.abc_parser_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for abc_parser.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.audio_io" href="audio_io.html">note_seq.audio_io</a></code></dt>
+<dd>
+<div class="desc"><p>Audio file helper functions.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.audio_io_test" href="audio_io_test.html">note_seq.audio_io_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for audio_io.py.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chord_inference" href="chord_inference.html">note_seq.chord_inference</a></code></dt>
+<dd>
+<div class="desc"><p>Chord inference for NoteSequences.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chord_inference_test" href="chord_inference_test.html">note_seq.chord_inference_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for chord_inference.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chord_symbols_lib" href="chord_symbols_lib.html">note_seq.chord_symbols_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with chord symbols …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chord_symbols_lib_test" href="chord_symbols_lib_test.html">note_seq.chord_symbols_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for chord_symbols_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chords_encoder_decoder" href="chords_encoder_decoder.html">note_seq.chords_encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between chord progressions and models inputs/outputs …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chords_encoder_decoder_test" href="chords_encoder_decoder_test.html">note_seq.chords_encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for chords_encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chords_lib" href="chords_lib.html">note_seq.chords_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with chord progressions …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.chords_lib_test" href="chords_lib_test.html">note_seq.chords_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for chords_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.constants" href="constants.html">note_seq.constants</a></code></dt>
+<dd>
+<div class="desc"><p>Constants for music processing in Magenta.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.drums_encoder_decoder" href="drums_encoder_decoder.html">note_seq.drums_encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between drum tracks and models inputs/outputs.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.drums_encoder_decoder_test" href="drums_encoder_decoder_test.html">note_seq.drums_encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for drums_encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.drums_lib" href="drums_lib.html">note_seq.drums_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with drums …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.drums_lib_test" href="drums_lib_test.html">note_seq.drums_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for drums_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.encoder_decoder" href="encoder_decoder.html">note_seq.encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between event sequences and models inputs/outputs …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.encoder_decoder_test" href="encoder_decoder_test.html">note_seq.encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.events_lib" href="events_lib.html">note_seq.events_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Abstract base classes for working with musical event sequences …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.events_lib_test" href="events_lib_test.html">note_seq.events_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for events_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.lead_sheets_lib" href="lead_sheets_lib.html">note_seq.lead_sheets_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with lead sheets.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.lead_sheets_lib_test" href="lead_sheets_lib_test.html">note_seq.lead_sheets_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for lead_sheets.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melodies_lib" href="melodies_lib.html">note_seq.melodies_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with melodies …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melodies_lib_test" href="melodies_lib_test.html">note_seq.melodies_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for melodies_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melody_encoder_decoder" href="melody_encoder_decoder.html">note_seq.melody_encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between Melody objects and models inputs/outputs …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melody_encoder_decoder_test" href="melody_encoder_decoder_test.html">note_seq.melody_encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for melody_encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melody_inference" href="melody_inference.html">note_seq.melody_inference</a></code></dt>
+<dd>
+<div class="desc"><p>Infer melody from polyphonic NoteSequence.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.melody_inference_test" href="melody_inference_test.html">note_seq.melody_inference_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for melody inference.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.midi_io" href="midi_io.html">note_seq.midi_io</a></code></dt>
+<dd>
+<div class="desc"><p>MIDI ops …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.midi_io_test" href="midi_io_test.html">note_seq.midi_io_test</a></code></dt>
+<dd>
+<div class="desc"><p>Test to ensure correct midi input and output.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.midi_synth" href="midi_synth.html">note_seq.midi_synth</a></code></dt>
+<dd>
+<div class="desc"><p>MIDI audio synthesis.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.musicnet_io" href="musicnet_io.html">note_seq.musicnet_io</a></code></dt>
+<dd>
+<div class="desc"><p>Import NoteSequences from MusicNet.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.musicnet_io_test" href="musicnet_io_test.html">note_seq.musicnet_io_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for MusicNet data parsing.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.musicxml_parser" href="musicxml_parser.html">note_seq.musicxml_parser</a></code></dt>
+<dd>
+<div class="desc"><p>MusicXML parser …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.musicxml_parser_test" href="musicxml_parser_test.html">note_seq.musicxml_parser_test</a></code></dt>
+<dd>
+<div class="desc"><p>Test to ensure correct import of MusicXML.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.musicxml_reader" href="musicxml_reader.html">note_seq.musicxml_reader</a></code></dt>
+<dd>
+<div class="desc"><p>MusicXML import …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.notebook_utils" href="notebook_utils.html">note_seq.notebook_utils</a></code></dt>
+<dd>
+<div class="desc"><p>Python functions which run only within a Jupyter or Colab notebook.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_controls" href="performance_controls.html">note_seq.performance_controls</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for computing performance control signals.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_controls_test" href="performance_controls_test.html">note_seq.performance_controls_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for performance controls.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_encoder_decoder" href="performance_encoder_decoder.html">note_seq.performance_encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between performance input and model input/output.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_encoder_decoder_test" href="performance_encoder_decoder_test.html">note_seq.performance_encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for performance_encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_lib" href="performance_lib.html">note_seq.performance_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with polyphonic performances.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.performance_lib_test" href="performance_lib_test.html">note_seq.performance_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for performance_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.pianoroll_encoder_decoder" href="pianoroll_encoder_decoder.html">note_seq.pianoroll_encoder_decoder</a></code></dt>
+<dd>
+<div class="desc"><p>Classes for converting between pianoroll input and model input/output.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.pianoroll_encoder_decoder_test" href="pianoroll_encoder_decoder_test.html">note_seq.pianoroll_encoder_decoder_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for pianoroll_encoder_decoder.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.pianoroll_lib" href="pianoroll_lib.html">note_seq.pianoroll_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for working with pianoroll sequences.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.pianoroll_lib_test" href="pianoroll_lib_test.html">note_seq.pianoroll_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for pianoroll_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.protobuf" href="protobuf/index.html">note_seq.protobuf</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="note_seq.sequences_lib" href="sequences_lib.html">note_seq.sequences_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Defines sequence of notes objects for creating datasets.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.sequences_lib_test" href="sequences_lib_test.html">note_seq.sequences_lib_test</a></code></dt>
+<dd>
+<div class="desc"><p>Tests for sequences_lib.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.testing_lib" href="testing_lib.html">note_seq.testing_lib</a></code></dt>
+<dd>
+<div class="desc"><p>Testing support code.</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.version" href="version.html">note_seq.version</a></code></dt>
+<dd>
+<div class="desc"><p>Separate file for storing the current version of note-seq …</p></div>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="note_seq.abc_parser" href="abc_parser.html">note_seq.abc_parser</a></code></li>
+<li><code><a title="note_seq.abc_parser_test" href="abc_parser_test.html">note_seq.abc_parser_test</a></code></li>
+<li><code><a title="note_seq.audio_io" href="audio_io.html">note_seq.audio_io</a></code></li>
+<li><code><a title="note_seq.audio_io_test" href="audio_io_test.html">note_seq.audio_io_test</a></code></li>
+<li><code><a title="note_seq.chord_inference" href="chord_inference.html">note_seq.chord_inference</a></code></li>
+<li><code><a title="note_seq.chord_inference_test" href="chord_inference_test.html">note_seq.chord_inference_test</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib" href="chord_symbols_lib.html">note_seq.chord_symbols_lib</a></code></li>
+<li><code><a title="note_seq.chord_symbols_lib_test" href="chord_symbols_lib_test.html">note_seq.chord_symbols_lib_test</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder" href="chords_encoder_decoder.html">note_seq.chords_encoder_decoder</a></code></li>
+<li><code><a title="note_seq.chords_encoder_decoder_test" href="chords_encoder_decoder_test.html">note_seq.chords_encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.chords_lib" href="chords_lib.html">note_seq.chords_lib</a></code></li>
+<li><code><a title="note_seq.chords_lib_test" href="chords_lib_test.html">note_seq.chords_lib_test</a></code></li>
+<li><code><a title="note_seq.constants" href="constants.html">note_seq.constants</a></code></li>
+<li><code><a title="note_seq.drums_encoder_decoder" href="drums_encoder_decoder.html">note_seq.drums_encoder_decoder</a></code></li>
+<li><code><a title="note_seq.drums_encoder_decoder_test" href="drums_encoder_decoder_test.html">note_seq.drums_encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.drums_lib" href="drums_lib.html">note_seq.drums_lib</a></code></li>
+<li><code><a title="note_seq.drums_lib_test" href="drums_lib_test.html">note_seq.drums_lib_test</a></code></li>
+<li><code><a title="note_seq.encoder_decoder" href="encoder_decoder.html">note_seq.encoder_decoder</a></code></li>
+<li><code><a title="note_seq.encoder_decoder_test" href="encoder_decoder_test.html">note_seq.encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.events_lib" href="events_lib.html">note_seq.events_lib</a></code></li>
+<li><code><a title="note_seq.events_lib_test" href="events_lib_test.html">note_seq.events_lib_test</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib" href="lead_sheets_lib.html">note_seq.lead_sheets_lib</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib_test" href="lead_sheets_lib_test.html">note_seq.lead_sheets_lib_test</a></code></li>
+<li><code><a title="note_seq.melodies_lib" href="melodies_lib.html">note_seq.melodies_lib</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test" href="melodies_lib_test.html">note_seq.melodies_lib_test</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder" href="melody_encoder_decoder.html">note_seq.melody_encoder_decoder</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test" href="melody_encoder_decoder_test.html">note_seq.melody_encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.melody_inference" href="melody_inference.html">note_seq.melody_inference</a></code></li>
+<li><code><a title="note_seq.melody_inference_test" href="melody_inference_test.html">note_seq.melody_inference_test</a></code></li>
+<li><code><a title="note_seq.midi_io" href="midi_io.html">note_seq.midi_io</a></code></li>
+<li><code><a title="note_seq.midi_io_test" href="midi_io_test.html">note_seq.midi_io_test</a></code></li>
+<li><code><a title="note_seq.midi_synth" href="midi_synth.html">note_seq.midi_synth</a></code></li>
+<li><code><a title="note_seq.musicnet_io" href="musicnet_io.html">note_seq.musicnet_io</a></code></li>
+<li><code><a title="note_seq.musicnet_io_test" href="musicnet_io_test.html">note_seq.musicnet_io_test</a></code></li>
+<li><code><a title="note_seq.musicxml_parser" href="musicxml_parser.html">note_seq.musicxml_parser</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test" href="musicxml_parser_test.html">note_seq.musicxml_parser_test</a></code></li>
+<li><code><a title="note_seq.musicxml_reader" href="musicxml_reader.html">note_seq.musicxml_reader</a></code></li>
+<li><code><a title="note_seq.notebook_utils" href="notebook_utils.html">note_seq.notebook_utils</a></code></li>
+<li><code><a title="note_seq.performance_controls" href="performance_controls.html">note_seq.performance_controls</a></code></li>
+<li><code><a title="note_seq.performance_controls_test" href="performance_controls_test.html">note_seq.performance_controls_test</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder" href="performance_encoder_decoder.html">note_seq.performance_encoder_decoder</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test" href="performance_encoder_decoder_test.html">note_seq.performance_encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.performance_lib" href="performance_lib.html">note_seq.performance_lib</a></code></li>
+<li><code><a title="note_seq.performance_lib_test" href="performance_lib_test.html">note_seq.performance_lib_test</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder" href="pianoroll_encoder_decoder.html">note_seq.pianoroll_encoder_decoder</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test" href="pianoroll_encoder_decoder_test.html">note_seq.pianoroll_encoder_decoder_test</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib" href="pianoroll_lib.html">note_seq.pianoroll_lib</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test" href="pianoroll_lib_test.html">note_seq.pianoroll_lib_test</a></code></li>
+<li><code><a title="note_seq.protobuf" href="protobuf/index.html">note_seq.protobuf</a></code></li>
+<li><code><a title="note_seq.sequences_lib" href="sequences_lib.html">note_seq.sequences_lib</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test" href="sequences_lib_test.html">note_seq.sequences_lib_test</a></code></li>
+<li><code><a title="note_seq.testing_lib" href="testing_lib.html">note_seq.testing_lib</a></code></li>
+<li><code><a title="note_seq.version" href="version.html">note_seq.version</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/lead_sheets_lib.html
+++ b/docs/lead_sheets_lib.html
@@ -1,0 +1,952 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.lead_sheets_lib API documentation</title>
+<meta name="description" content="Utility functions for working with lead sheets." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.lead_sheets_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with lead sheets.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with lead sheets.&#34;&#34;&#34;
+
+import copy
+import itertools
+
+from note_seq import chords_lib
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import melodies_lib
+from note_seq.protobuf import music_pb2
+
+# Constants.
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+
+# Shortcut to CHORD_SYMBOL annotation type.
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+class MelodyChordsMismatchError(Exception):
+  pass
+
+
+class LeadSheet(events_lib.EventSequence):
+  &#34;&#34;&#34;A wrapper around Melody and ChordProgression.
+
+  Attributes:
+    melody: A Melody object, the lead sheet melody.
+    chords: A ChordProgression object, the underlying chords.
+  &#34;&#34;&#34;
+
+  def __init__(self, melody=None, chords=None):
+    &#34;&#34;&#34;Construct a LeadSheet.
+
+    If `melody` and `chords` are specified, instantiate with the provided
+    melody and chords.  Otherwise, create an empty LeadSheet.
+
+    Args:
+      melody: A Melody object.
+      chords: A ChordProgression object.
+
+    Raises:
+      MelodyChordsMismatchError: If the melody and chord progression differ
+          in temporal resolution or position in the source sequence, or if only
+          one of melody or chords is specified.
+    &#34;&#34;&#34;
+    if (melody is None) != (chords is None):
+      raise MelodyChordsMismatchError(
+          &#39;melody and chords must be both specified or both unspecified&#39;)
+    if melody is not None:
+      self._from_melody_and_chords(melody, chords)
+    else:
+      self._reset()
+
+  def _reset(self):
+    &#34;&#34;&#34;Clear events and reset object state.&#34;&#34;&#34;
+    self._melody = melodies_lib.Melody()
+    self._chords = chords_lib.ChordProgression()
+
+  def _from_melody_and_chords(self, melody, chords):
+    &#34;&#34;&#34;Initializes a LeadSheet with a given melody and chords.
+
+    Args:
+      melody: A Melody object.
+      chords: A ChordProgression object.
+
+    Raises:
+      MelodyChordsMismatchError: If the melody and chord progression differ
+          in temporal resolution or position in the source sequence.
+    &#34;&#34;&#34;
+    if (len(melody) != len(chords) or
+        melody.steps_per_bar != chords.steps_per_bar or
+        melody.steps_per_quarter != chords.steps_per_quarter or
+        melody.start_step != chords.start_step or
+        melody.end_step != chords.end_step):
+      raise MelodyChordsMismatchError()
+    self._melody = melody
+    self._chords = chords
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over (melody, chord) tuples in this LeadSheet.
+
+    Returns:
+      Python iterator over (melody, chord) event tuples.
+    &#34;&#34;&#34;
+    return itertools.izip(self._melody, self._chords)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the melody-chord tuple at the given index.&#34;&#34;&#34;
+    return self._melody[i], self._chords[i]
+
+  def __getslice__(self, i, j):
+    &#34;&#34;&#34;Returns a LeadSheet object for the given slice range.&#34;&#34;&#34;
+    return LeadSheet(self._melody[i:j], self._chords[i:j])
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events (melody-chord tuples) are in this LeadSheet.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._melody)
+
+  def __deepcopy__(self, memo=None):
+    return LeadSheet(copy.deepcopy(self._melody, memo),
+                     copy.deepcopy(self._chords, memo))
+
+  def __eq__(self, other):
+    if not isinstance(other, LeadSheet):
+      return False
+    return (self._melody == other.melody and
+            self._chords == other.chords)
+
+  @property
+  def start_step(self):
+    return self._melody.start_step
+
+  @property
+  def end_step(self):
+    return self._melody.end_step
+
+  @property
+  def steps(self):
+    return self._melody.steps
+
+  @property
+  def steps_per_bar(self):
+    return self._melody.steps_per_bar
+
+  @property
+  def steps_per_quarter(self):
+    return self._melody.steps_per_quarter
+
+  @property
+  def melody(self):
+    &#34;&#34;&#34;Return the melody of the lead sheet.
+
+    Returns:
+        The lead sheet melody, a Melody object.
+    &#34;&#34;&#34;
+    return self._melody
+
+  @property
+  def chords(self):
+    &#34;&#34;&#34;Return the chord progression of the lead sheet.
+
+    Returns:
+        The lead sheet chords, a ChordProgression object.
+    &#34;&#34;&#34;
+    return self._chords
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+    Args:
+      event: The event (a melody-chord tuple) to append to the end.
+    &#34;&#34;&#34;
+    melody_event, chord_event = event
+    self._melody.append(melody_event)
+    self._chords.append(chord_event)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the LeadSheet to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each melody note. Between 1 and 127
+          (inclusive).
+      instrument: Midi instrument to give each melody note.
+      sequence_start_time: A time in seconds (float) that the first note (and
+          chord) in the sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the melody and chords from the lead sheet.
+    &#34;&#34;&#34;
+    sequence = self._melody.to_sequence(
+        velocity=velocity, instrument=instrument,
+        sequence_start_time=sequence_start_time, qpm=qpm)
+    chord_sequence = self._chords.to_sequence(
+        sequence_start_time=sequence_start_time, qpm=qpm)
+    # A little ugly, but just add the chord annotations to the melody sequence.
+    for text_annotation in chord_sequence.text_annotations:
+      if text_annotation.annotation_type == CHORD_SYMBOL:
+        chord = sequence.text_annotations.add()
+        chord.CopyFrom(text_annotation)
+    return sequence
+
+  def transpose(self, transpose_amount, min_note=0, max_note=128):
+    &#34;&#34;&#34;Transpose notes and chords in this LeadSheet.
+
+    All notes and chords are transposed the specified amount. Additionally,
+    all notes are octave shifted to lie within the [min_note, max_note) range.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this
+          LeadSheet. Positive values transpose up. Negative values
+          transpose down.
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    &#34;&#34;&#34;
+    self._melody.transpose(transpose_amount, min_note, max_note)
+    self._chords.transpose(transpose_amount)
+
+  def squash(self, min_note, max_note, transpose_to_key):
+    &#34;&#34;&#34;Transpose and octave shift the notes and chords in this LeadSheet.
+
+    Args:
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+      transpose_to_key: The lead sheet is transposed to be in this key.
+
+    Returns:
+      The transpose amount, in half steps.
+    &#34;&#34;&#34;
+    transpose_amount = self._melody.squash(min_note, max_note,
+                                           transpose_to_key)
+    self._chords.transpose(transpose_amount)
+    return transpose_amount
+
+  def set_length(self, steps):
+    &#34;&#34;&#34;Sets the length of the lead sheet to the specified number of steps.
+
+    Args:
+      steps: How many steps long the lead sheet should be.
+    &#34;&#34;&#34;
+    self._melody.set_length(steps)
+    self._chords.set_length(steps)
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a LeadSheet.
+
+    Increases the resolution of a LeadSheet object by a factor of `k`. This
+    increases the resolution of the melody and chords separately, which uses
+    MELODY_NO_EVENT to extend each event in the melody, and simply repeats each
+    chord event `k` times.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the lead
+          sheet.
+    &#34;&#34;&#34;
+    self._melody.increase_resolution(k)
+    self._chords.increase_resolution(k)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.lead_sheets_lib.LeadSheet"><code class="flex name class">
+<span>class <span class="ident">LeadSheet</span></span>
+<span>(</span><span>melody=None, chords=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A wrapper around Melody and ChordProgression.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>melody</code></strong></dt>
+<dd>A Melody object, the lead sheet melody.</dd>
+<dt><strong><code>chords</code></strong></dt>
+<dd>A ChordProgression object, the underlying chords.</dd>
+</dl>
+<p>Construct a LeadSheet.</p>
+<p>If <code>melody</code> and <code>chords</code> are specified, instantiate with the provided
+melody and chords.
+Otherwise, create an empty LeadSheet.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>melody</code></strong></dt>
+<dd>A Melody object.</dd>
+<dt><strong><code>chords</code></strong></dt>
+<dd>A ChordProgression object.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.lead_sheets_lib.MelodyChordsMismatchError" href="#note_seq.lead_sheets_lib.MelodyChordsMismatchError">MelodyChordsMismatchError</a></code></dt>
+<dd>If the melody and chord progression differ
+in temporal resolution or position in the source sequence, or if only
+one of melody or chords is specified.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class LeadSheet(events_lib.EventSequence):
+  &#34;&#34;&#34;A wrapper around Melody and ChordProgression.
+
+  Attributes:
+    melody: A Melody object, the lead sheet melody.
+    chords: A ChordProgression object, the underlying chords.
+  &#34;&#34;&#34;
+
+  def __init__(self, melody=None, chords=None):
+    &#34;&#34;&#34;Construct a LeadSheet.
+
+    If `melody` and `chords` are specified, instantiate with the provided
+    melody and chords.  Otherwise, create an empty LeadSheet.
+
+    Args:
+      melody: A Melody object.
+      chords: A ChordProgression object.
+
+    Raises:
+      MelodyChordsMismatchError: If the melody and chord progression differ
+          in temporal resolution or position in the source sequence, or if only
+          one of melody or chords is specified.
+    &#34;&#34;&#34;
+    if (melody is None) != (chords is None):
+      raise MelodyChordsMismatchError(
+          &#39;melody and chords must be both specified or both unspecified&#39;)
+    if melody is not None:
+      self._from_melody_and_chords(melody, chords)
+    else:
+      self._reset()
+
+  def _reset(self):
+    &#34;&#34;&#34;Clear events and reset object state.&#34;&#34;&#34;
+    self._melody = melodies_lib.Melody()
+    self._chords = chords_lib.ChordProgression()
+
+  def _from_melody_and_chords(self, melody, chords):
+    &#34;&#34;&#34;Initializes a LeadSheet with a given melody and chords.
+
+    Args:
+      melody: A Melody object.
+      chords: A ChordProgression object.
+
+    Raises:
+      MelodyChordsMismatchError: If the melody and chord progression differ
+          in temporal resolution or position in the source sequence.
+    &#34;&#34;&#34;
+    if (len(melody) != len(chords) or
+        melody.steps_per_bar != chords.steps_per_bar or
+        melody.steps_per_quarter != chords.steps_per_quarter or
+        melody.start_step != chords.start_step or
+        melody.end_step != chords.end_step):
+      raise MelodyChordsMismatchError()
+    self._melody = melody
+    self._chords = chords
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over (melody, chord) tuples in this LeadSheet.
+
+    Returns:
+      Python iterator over (melody, chord) event tuples.
+    &#34;&#34;&#34;
+    return itertools.izip(self._melody, self._chords)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the melody-chord tuple at the given index.&#34;&#34;&#34;
+    return self._melody[i], self._chords[i]
+
+  def __getslice__(self, i, j):
+    &#34;&#34;&#34;Returns a LeadSheet object for the given slice range.&#34;&#34;&#34;
+    return LeadSheet(self._melody[i:j], self._chords[i:j])
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events (melody-chord tuples) are in this LeadSheet.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._melody)
+
+  def __deepcopy__(self, memo=None):
+    return LeadSheet(copy.deepcopy(self._melody, memo),
+                     copy.deepcopy(self._chords, memo))
+
+  def __eq__(self, other):
+    if not isinstance(other, LeadSheet):
+      return False
+    return (self._melody == other.melody and
+            self._chords == other.chords)
+
+  @property
+  def start_step(self):
+    return self._melody.start_step
+
+  @property
+  def end_step(self):
+    return self._melody.end_step
+
+  @property
+  def steps(self):
+    return self._melody.steps
+
+  @property
+  def steps_per_bar(self):
+    return self._melody.steps_per_bar
+
+  @property
+  def steps_per_quarter(self):
+    return self._melody.steps_per_quarter
+
+  @property
+  def melody(self):
+    &#34;&#34;&#34;Return the melody of the lead sheet.
+
+    Returns:
+        The lead sheet melody, a Melody object.
+    &#34;&#34;&#34;
+    return self._melody
+
+  @property
+  def chords(self):
+    &#34;&#34;&#34;Return the chord progression of the lead sheet.
+
+    Returns:
+        The lead sheet chords, a ChordProgression object.
+    &#34;&#34;&#34;
+    return self._chords
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+    Args:
+      event: The event (a melody-chord tuple) to append to the end.
+    &#34;&#34;&#34;
+    melody_event, chord_event = event
+    self._melody.append(melody_event)
+    self._chords.append(chord_event)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the LeadSheet to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each melody note. Between 1 and 127
+          (inclusive).
+      instrument: Midi instrument to give each melody note.
+      sequence_start_time: A time in seconds (float) that the first note (and
+          chord) in the sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the melody and chords from the lead sheet.
+    &#34;&#34;&#34;
+    sequence = self._melody.to_sequence(
+        velocity=velocity, instrument=instrument,
+        sequence_start_time=sequence_start_time, qpm=qpm)
+    chord_sequence = self._chords.to_sequence(
+        sequence_start_time=sequence_start_time, qpm=qpm)
+    # A little ugly, but just add the chord annotations to the melody sequence.
+    for text_annotation in chord_sequence.text_annotations:
+      if text_annotation.annotation_type == CHORD_SYMBOL:
+        chord = sequence.text_annotations.add()
+        chord.CopyFrom(text_annotation)
+    return sequence
+
+  def transpose(self, transpose_amount, min_note=0, max_note=128):
+    &#34;&#34;&#34;Transpose notes and chords in this LeadSheet.
+
+    All notes and chords are transposed the specified amount. Additionally,
+    all notes are octave shifted to lie within the [min_note, max_note) range.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this
+          LeadSheet. Positive values transpose up. Negative values
+          transpose down.
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    &#34;&#34;&#34;
+    self._melody.transpose(transpose_amount, min_note, max_note)
+    self._chords.transpose(transpose_amount)
+
+  def squash(self, min_note, max_note, transpose_to_key):
+    &#34;&#34;&#34;Transpose and octave shift the notes and chords in this LeadSheet.
+
+    Args:
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+      transpose_to_key: The lead sheet is transposed to be in this key.
+
+    Returns:
+      The transpose amount, in half steps.
+    &#34;&#34;&#34;
+    transpose_amount = self._melody.squash(min_note, max_note,
+                                           transpose_to_key)
+    self._chords.transpose(transpose_amount)
+    return transpose_amount
+
+  def set_length(self, steps):
+    &#34;&#34;&#34;Sets the length of the lead sheet to the specified number of steps.
+
+    Args:
+      steps: How many steps long the lead sheet should be.
+    &#34;&#34;&#34;
+    self._melody.set_length(steps)
+    self._chords.set_length(steps)
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a LeadSheet.
+
+    Increases the resolution of a LeadSheet object by a factor of `k`. This
+    increases the resolution of the melody and chords separately, which uses
+    MELODY_NO_EVENT to extend each event in the melody, and simply repeats each
+    chord event `k` times.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the lead
+          sheet.
+    &#34;&#34;&#34;
+    self._melody.increase_resolution(k)
+    self._chords.increase_resolution(k)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.chords"><code class="name">var <span class="ident">chords</span></code></dt>
+<dd>
+<div class="desc"><p>Return the chord progression of the lead sheet.</p>
+<h2 id="returns">Returns</h2>
+<p>The lead sheet chords, a ChordProgression object.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def chords(self):
+  &#34;&#34;&#34;Return the chord progression of the lead sheet.
+
+  Returns:
+      The lead sheet chords, a ChordProgression object.
+  &#34;&#34;&#34;
+  return self._chords</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.end_step"><code class="name">var <span class="ident">end_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def end_step(self):
+  return self._melody.end_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.melody"><code class="name">var <span class="ident">melody</span></code></dt>
+<dd>
+<div class="desc"><p>Return the melody of the lead sheet.</p>
+<h2 id="returns">Returns</h2>
+<p>The lead sheet melody, a Melody object.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def melody(self):
+  &#34;&#34;&#34;Return the melody of the lead sheet.
+
+  Returns:
+      The lead sheet melody, a Melody object.
+  &#34;&#34;&#34;
+  return self._melody</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.start_step"><code class="name">var <span class="ident">start_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def start_step(self):
+  return self._melody.start_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.steps"><code class="name">var <span class="ident">steps</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps(self):
+  return self._melody.steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.steps_per_bar"><code class="name">var <span class="ident">steps_per_bar</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_bar(self):
+  return self._melody.steps_per_bar</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.steps_per_quarter"><code class="name">var <span class="ident">steps_per_quarter</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_quarter(self):
+  return self._melody.steps_per_quarter</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends event to the end of the sequence and increments the end step.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The event (a melody-chord tuple) to append to the end.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends event to the end of the sequence and increments the end step.
+
+  Args:
+    event: The event (a melody-chord tuple) to append to the end.
+  &#34;&#34;&#34;
+  melody_event, chord_event = event
+  self._melody.append(melody_event)
+  self._chords.append(chord_event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.increase_resolution"><code class="name flex">
+<span>def <span class="ident">increase_resolution</span></span>(<span>self, k)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Increase the resolution of a LeadSheet.</p>
+<p>Increases the resolution of a LeadSheet object by a factor of <code>k</code>. This
+increases the resolution of the melody and chords separately, which uses
+MELODY_NO_EVENT to extend each event in the melody, and simply repeats each
+chord event <code>k</code> times.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>k</code></strong></dt>
+<dd>An integer, the factor by which to increase the resolution of the lead
+sheet.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def increase_resolution(self, k):
+  &#34;&#34;&#34;Increase the resolution of a LeadSheet.
+
+  Increases the resolution of a LeadSheet object by a factor of `k`. This
+  increases the resolution of the melody and chords separately, which uses
+  MELODY_NO_EVENT to extend each event in the melody, and simply repeats each
+  chord event `k` times.
+
+  Args:
+    k: An integer, the factor by which to increase the resolution of the lead
+        sheet.
+  &#34;&#34;&#34;
+  self._melody.increase_resolution(k)
+  self._chords.increase_resolution(k)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the lead sheet to the specified number of steps.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many steps long the lead sheet should be.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_length(self, steps):
+  &#34;&#34;&#34;Sets the length of the lead sheet to the specified number of steps.
+
+  Args:
+    steps: How many steps long the lead sheet should be.
+  &#34;&#34;&#34;
+  self._melody.set_length(steps)
+  self._chords.set_length(steps)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.squash"><code class="name flex">
+<span>def <span class="ident">squash</span></span>(<span>self, min_note, max_note, transpose_to_key)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transpose and octave shift the notes and chords in this LeadSheet.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>Minimum pitch (inclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>Maximum pitch (exclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>transpose_to_key</code></strong></dt>
+<dd>The lead sheet is transposed to be in this key.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The transpose amount, in half steps.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def squash(self, min_note, max_note, transpose_to_key):
+  &#34;&#34;&#34;Transpose and octave shift the notes and chords in this LeadSheet.
+
+  Args:
+    min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+    max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    transpose_to_key: The lead sheet is transposed to be in this key.
+
+  Returns:
+    The transpose amount, in half steps.
+  &#34;&#34;&#34;
+  transpose_amount = self._melody.squash(min_note, max_note,
+                                         transpose_to_key)
+  self._chords.transpose(transpose_amount)
+  return transpose_amount</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity=100, instrument=0, sequence_start_time=0.0, qpm=120.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the LeadSheet to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Midi velocity to give each melody note. Between 1 and 127
+(inclusive).</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Midi instrument to give each melody note.</dd>
+<dt><strong><code>sequence_start_time</code></strong></dt>
+<dd>A time in seconds (float) that the first note (and
+chord) in the sequence will land on.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Quarter notes per minute (float).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto encoding the melody and chords from the lead sheet.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                velocity=100,
+                instrument=0,
+                sequence_start_time=0.0,
+                qpm=120.0):
+  &#34;&#34;&#34;Converts the LeadSheet to NoteSequence proto.
+
+  Args:
+    velocity: Midi velocity to give each melody note. Between 1 and 127
+        (inclusive).
+    instrument: Midi instrument to give each melody note.
+    sequence_start_time: A time in seconds (float) that the first note (and
+        chord) in the sequence will land on.
+    qpm: Quarter notes per minute (float).
+
+  Returns:
+    A NoteSequence proto encoding the melody and chords from the lead sheet.
+  &#34;&#34;&#34;
+  sequence = self._melody.to_sequence(
+      velocity=velocity, instrument=instrument,
+      sequence_start_time=sequence_start_time, qpm=qpm)
+  chord_sequence = self._chords.to_sequence(
+      sequence_start_time=sequence_start_time, qpm=qpm)
+  # A little ugly, but just add the chord annotations to the melody sequence.
+  for text_annotation in chord_sequence.text_annotations:
+    if text_annotation.annotation_type == CHORD_SYMBOL:
+      chord = sequence.text_annotations.add()
+      chord.CopyFrom(text_annotation)
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib.LeadSheet.transpose"><code class="name flex">
+<span>def <span class="ident">transpose</span></span>(<span>self, transpose_amount, min_note=0, max_note=128)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transpose notes and chords in this LeadSheet.</p>
+<p>All notes and chords are transposed the specified amount. Additionally,
+all notes are octave shifted to lie within the [min_note, max_note) range.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>transpose_amount</code></strong></dt>
+<dd>The number of half steps to transpose this
+LeadSheet. Positive values transpose up. Negative values
+transpose down.</dd>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>Minimum pitch (inclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>Maximum pitch (exclusive) that the resulting notes will take on.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transpose(self, transpose_amount, min_note=0, max_note=128):
+  &#34;&#34;&#34;Transpose notes and chords in this LeadSheet.
+
+  All notes and chords are transposed the specified amount. Additionally,
+  all notes are octave shifted to lie within the [min_note, max_note) range.
+
+  Args:
+    transpose_amount: The number of half steps to transpose this
+        LeadSheet. Positive values transpose up. Negative values
+        transpose down.
+    min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+    max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+  &#34;&#34;&#34;
+  self._melody.transpose(transpose_amount, min_note, max_note)
+  self._chords.transpose(transpose_amount)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.lead_sheets_lib.MelodyChordsMismatchError"><code class="flex name class">
+<span>class <span class="ident">MelodyChordsMismatchError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyChordsMismatchError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.lead_sheets_lib.LeadSheet" href="#note_seq.lead_sheets_lib.LeadSheet">LeadSheet</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.append" href="#note_seq.lead_sheets_lib.LeadSheet.append">append</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.chords" href="#note_seq.lead_sheets_lib.LeadSheet.chords">chords</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.end_step" href="#note_seq.lead_sheets_lib.LeadSheet.end_step">end_step</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.increase_resolution" href="#note_seq.lead_sheets_lib.LeadSheet.increase_resolution">increase_resolution</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.melody" href="#note_seq.lead_sheets_lib.LeadSheet.melody">melody</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.set_length" href="#note_seq.lead_sheets_lib.LeadSheet.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.squash" href="#note_seq.lead_sheets_lib.LeadSheet.squash">squash</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.start_step" href="#note_seq.lead_sheets_lib.LeadSheet.start_step">start_step</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.steps" href="#note_seq.lead_sheets_lib.LeadSheet.steps">steps</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.steps_per_bar" href="#note_seq.lead_sheets_lib.LeadSheet.steps_per_bar">steps_per_bar</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.steps_per_quarter" href="#note_seq.lead_sheets_lib.LeadSheet.steps_per_quarter">steps_per_quarter</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.to_sequence" href="#note_seq.lead_sheets_lib.LeadSheet.to_sequence">to_sequence</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib.LeadSheet.transpose" href="#note_seq.lead_sheets_lib.LeadSheet.transpose">transpose</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.lead_sheets_lib.MelodyChordsMismatchError" href="#note_seq.lead_sheets_lib.MelodyChordsMismatchError">MelodyChordsMismatchError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/lead_sheets_lib_test.html
+++ b/docs/lead_sheets_lib_test.html
@@ -1,0 +1,437 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.lead_sheets_lib_test API documentation</title>
+<meta name="description" content="Tests for lead_sheets." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.lead_sheets_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for lead_sheets.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for lead_sheets.&#34;&#34;&#34;
+
+import copy
+
+from absl.testing import absltest
+from note_seq import chords_lib
+from note_seq import constants
+from note_seq import lead_sheets_lib
+from note_seq import melodies_lib
+from note_seq import testing_lib
+
+NOTE_OFF = constants.MELODY_NOTE_OFF
+NO_EVENT = constants.MELODY_NO_EVENT
+NO_CHORD = constants.NO_CHORD
+
+
+class LeadSheetsLibTest(testing_lib.ProtoTestCase):
+
+  def testTranspose(self):
+    # LeadSheet transposition should agree with melody &amp; chords transpositions.
+    melody_events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5,
+                     NOTE_OFF, 12 * 6, NO_EVENT]
+    chord_events = [NO_CHORD, &#39;C&#39;, &#39;F&#39;, &#39;Dm&#39;, &#39;D&#39;, &#39;G&#39;]
+    melody = melodies_lib.Melody(melody_events)
+    chords = chords_lib.ChordProgression(chord_events)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected_melody.transpose(
+        transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected_chords.transpose(transpose_amount=-5)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+
+  def testSquash(self):
+    # LeadSheet squash should agree with melody squash &amp; chords transpose.
+    melody_events = [12 * 5, NO_EVENT, 12 * 5 + 2,
+                     NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+    chord_events = [&#39;C&#39;, &#39;Am&#39;, &#39;Dm&#39;, &#39;G&#39;, &#39;C&#39;, NO_CHORD]
+    melody = melodies_lib.Melody(melody_events)
+    chords = chords_lib.ChordProgression(chord_events)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    transpose_amount = expected_melody.squash(
+        min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected_chords.transpose(transpose_amount=transpose_amount)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+
+  def testSetLength(self):
+    # Setting LeadSheet length should agree with setting length on melody and
+    # chords separately.
+    melody_events = [60]
+    chord_events = [&#39;C7&#39;]
+    melody = melodies_lib.Melody(melody_events, start_step=9)
+    chords = chords_lib.ChordProgression(chord_events, start_step=9)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.set_length(5)
+    expected_melody.set_length(5)
+    expected_chords.set_length(5)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+    self.assertEqual(9, lead_sheet.start_step)
+    self.assertEqual(14, lead_sheet.end_step)
+    self.assertListEqual([9, 10, 11, 12, 13], lead_sheet.steps)
+
+  def testToSequence(self):
+    # Sequence produced from lead sheet should contain notes from melody
+    # sequence and chords from chord sequence as text annotations.
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+    chords = chords_lib.ChordProgression(
+        [NO_CHORD, &#39;A&#39;, &#39;A&#39;, &#39;C#m&#39;, &#39;C#m&#39;, &#39;D&#39;, &#39;B&#39;, &#39;B&#39;, &#39;B&#39;])
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+
+    sequence = lead_sheet.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+    melody_sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+    chords_sequence = chords.to_sequence(
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertEqual(melody_sequence.ticks_per_quarter,
+                     sequence.ticks_per_quarter)
+    self.assertProtoEquals(melody_sequence.tempos, sequence.tempos)
+    self.assertEqual(melody_sequence.total_time, sequence.total_time)
+    self.assertProtoEquals(melody_sequence.notes, sequence.notes)
+    self.assertProtoEquals(chords_sequence.text_annotations,
+                           sequence.text_annotations)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.lead_sheets_lib_test.LeadSheetsLibTest"><code class="flex name class">
+<span>class <span class="ident">LeadSheetsLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class LeadSheetsLibTest(testing_lib.ProtoTestCase):
+
+  def testTranspose(self):
+    # LeadSheet transposition should agree with melody &amp; chords transpositions.
+    melody_events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5,
+                     NOTE_OFF, 12 * 6, NO_EVENT]
+    chord_events = [NO_CHORD, &#39;C&#39;, &#39;F&#39;, &#39;Dm&#39;, &#39;D&#39;, &#39;G&#39;]
+    melody = melodies_lib.Melody(melody_events)
+    chords = chords_lib.ChordProgression(chord_events)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected_melody.transpose(
+        transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected_chords.transpose(transpose_amount=-5)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+
+  def testSquash(self):
+    # LeadSheet squash should agree with melody squash &amp; chords transpose.
+    melody_events = [12 * 5, NO_EVENT, 12 * 5 + 2,
+                     NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+    chord_events = [&#39;C&#39;, &#39;Am&#39;, &#39;Dm&#39;, &#39;G&#39;, &#39;C&#39;, NO_CHORD]
+    melody = melodies_lib.Melody(melody_events)
+    chords = chords_lib.ChordProgression(chord_events)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    transpose_amount = expected_melody.squash(
+        min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected_chords.transpose(transpose_amount=transpose_amount)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+
+  def testSetLength(self):
+    # Setting LeadSheet length should agree with setting length on melody and
+    # chords separately.
+    melody_events = [60]
+    chord_events = [&#39;C7&#39;]
+    melody = melodies_lib.Melody(melody_events, start_step=9)
+    chords = chords_lib.ChordProgression(chord_events, start_step=9)
+    expected_melody = copy.deepcopy(melody)
+    expected_chords = copy.deepcopy(chords)
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+    lead_sheet.set_length(5)
+    expected_melody.set_length(5)
+    expected_chords.set_length(5)
+    self.assertEqual(expected_melody, lead_sheet.melody)
+    self.assertEqual(expected_chords, lead_sheet.chords)
+    self.assertEqual(9, lead_sheet.start_step)
+    self.assertEqual(14, lead_sheet.end_step)
+    self.assertListEqual([9, 10, 11, 12, 13], lead_sheet.steps)
+
+  def testToSequence(self):
+    # Sequence produced from lead sheet should contain notes from melody
+    # sequence and chords from chord sequence as text annotations.
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+    chords = chords_lib.ChordProgression(
+        [NO_CHORD, &#39;A&#39;, &#39;A&#39;, &#39;C#m&#39;, &#39;C#m&#39;, &#39;D&#39;, &#39;B&#39;, &#39;B&#39;, &#39;B&#39;])
+    lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+
+    sequence = lead_sheet.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+    melody_sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+    chords_sequence = chords.to_sequence(
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertEqual(melody_sequence.ticks_per_quarter,
+                     sequence.ticks_per_quarter)
+    self.assertProtoEquals(melody_sequence.tempos, sequence.tempos)
+    self.assertEqual(melody_sequence.total_time, sequence.total_time)
+    self.assertProtoEquals(melody_sequence.notes, sequence.notes)
+    self.assertProtoEquals(chords_sequence.text_annotations,
+                           sequence.text_annotations)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSetLength"><code class="name flex">
+<span>def <span class="ident">testSetLength</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLength(self):
+  # Setting LeadSheet length should agree with setting length on melody and
+  # chords separately.
+  melody_events = [60]
+  chord_events = [&#39;C7&#39;]
+  melody = melodies_lib.Melody(melody_events, start_step=9)
+  chords = chords_lib.ChordProgression(chord_events, start_step=9)
+  expected_melody = copy.deepcopy(melody)
+  expected_chords = copy.deepcopy(chords)
+  lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+  lead_sheet.set_length(5)
+  expected_melody.set_length(5)
+  expected_chords.set_length(5)
+  self.assertEqual(expected_melody, lead_sheet.melody)
+  self.assertEqual(expected_chords, lead_sheet.chords)
+  self.assertEqual(9, lead_sheet.start_step)
+  self.assertEqual(14, lead_sheet.end_step)
+  self.assertListEqual([9, 10, 11, 12, 13], lead_sheet.steps)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSquash"><code class="name flex">
+<span>def <span class="ident">testSquash</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSquash(self):
+  # LeadSheet squash should agree with melody squash &amp; chords transpose.
+  melody_events = [12 * 5, NO_EVENT, 12 * 5 + 2,
+                   NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+  chord_events = [&#39;C&#39;, &#39;Am&#39;, &#39;Dm&#39;, &#39;G&#39;, &#39;C&#39;, NO_CHORD]
+  melody = melodies_lib.Melody(melody_events)
+  chords = chords_lib.ChordProgression(chord_events)
+  expected_melody = copy.deepcopy(melody)
+  expected_chords = copy.deepcopy(chords)
+  lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+  lead_sheet.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+  transpose_amount = expected_melody.squash(
+      min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+  expected_chords.transpose(transpose_amount=transpose_amount)
+  self.assertEqual(expected_melody, lead_sheet.melody)
+  self.assertEqual(expected_chords, lead_sheet.chords)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testToSequence"><code class="name flex">
+<span>def <span class="ident">testToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequence(self):
+  # Sequence produced from lead sheet should contain notes from melody
+  # sequence and chords from chord sequence as text annotations.
+  melody = melodies_lib.Melody(
+      [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+  chords = chords_lib.ChordProgression(
+      [NO_CHORD, &#39;A&#39;, &#39;A&#39;, &#39;C#m&#39;, &#39;C#m&#39;, &#39;D&#39;, &#39;B&#39;, &#39;B&#39;, &#39;B&#39;])
+  lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+
+  sequence = lead_sheet.to_sequence(
+      velocity=10,
+      instrument=1,
+      sequence_start_time=2,
+      qpm=60.0)
+  melody_sequence = melody.to_sequence(
+      velocity=10,
+      instrument=1,
+      sequence_start_time=2,
+      qpm=60.0)
+  chords_sequence = chords.to_sequence(
+      sequence_start_time=2,
+      qpm=60.0)
+
+  self.assertEqual(melody_sequence.ticks_per_quarter,
+                   sequence.ticks_per_quarter)
+  self.assertProtoEquals(melody_sequence.tempos, sequence.tempos)
+  self.assertEqual(melody_sequence.total_time, sequence.total_time)
+  self.assertProtoEquals(melody_sequence.notes, sequence.notes)
+  self.assertProtoEquals(chords_sequence.text_annotations,
+                         sequence.text_annotations)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testTranspose"><code class="name flex">
+<span>def <span class="ident">testTranspose</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTranspose(self):
+  # LeadSheet transposition should agree with melody &amp; chords transpositions.
+  melody_events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5,
+                   NOTE_OFF, 12 * 6, NO_EVENT]
+  chord_events = [NO_CHORD, &#39;C&#39;, &#39;F&#39;, &#39;Dm&#39;, &#39;D&#39;, &#39;G&#39;]
+  melody = melodies_lib.Melody(melody_events)
+  chords = chords_lib.ChordProgression(chord_events)
+  expected_melody = copy.deepcopy(melody)
+  expected_chords = copy.deepcopy(chords)
+  lead_sheet = lead_sheets_lib.LeadSheet(melody, chords)
+  lead_sheet.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+  expected_melody.transpose(
+      transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+  expected_chords.transpose(transpose_amount=-5)
+  self.assertEqual(expected_melody, lead_sheet.melody)
+  self.assertEqual(expected_chords, lead_sheet.chords)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest" href="#note_seq.lead_sheets_lib_test.LeadSheetsLibTest">LeadSheetsLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSetLength" href="#note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSetLength">testSetLength</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSquash" href="#note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testSquash">testSquash</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testToSequence" href="#note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testToSequence">testToSequence</a></code></li>
+<li><code><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testTranspose" href="#note_seq.lead_sheets_lib_test.LeadSheetsLibTest.testTranspose">testTranspose</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melodies_lib.html
+++ b/docs/melodies_lib.html
@@ -1,0 +1,1852 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melodies_lib API documentation</title>
+<meta name="description" content="Utility functions for working with melodies …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melodies_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with melodies.</p>
+<p>Use extract_melodies to extract monophonic melodies from a quantized
+NoteSequence proto.</p>
+<p>Use Melody.to_sequence to write a melody to a NoteSequence proto. Then use
+midi_io.sequence_proto_to_midi_file to write that NoteSequence to a midi file.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with melodies.
+
+Use extract_melodies to extract monophonic melodies from a quantized
+NoteSequence proto.
+
+Use Melody.to_sequence to write a melody to a NoteSequence proto. Then use
+midi_io.sequence_proto_to_midi_file to write that NoteSequence to a midi file.
+&#34;&#34;&#34;
+
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import midi_io
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+import numpy as np
+
+MELODY_NOTE_OFF = constants.MELODY_NOTE_OFF
+MELODY_NO_EVENT = constants.MELODY_NO_EVENT
+MIN_MELODY_EVENT = constants.MIN_MELODY_EVENT
+MAX_MELODY_EVENT = constants.MAX_MELODY_EVENT
+MIN_MIDI_PITCH = constants.MIN_MIDI_PITCH
+MAX_MIDI_PITCH = constants.MAX_MIDI_PITCH
+NOTES_PER_OCTAVE = constants.NOTES_PER_OCTAVE
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+STANDARD_PPQ = constants.STANDARD_PPQ
+NOTE_KEYS = constants.NOTE_KEYS
+
+
+class PolyphonicMelodyError(Exception):
+  pass
+
+
+class BadNoteError(Exception):
+  pass
+
+
+class Melody(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of monophonic melody events.
+
+  Melody is an intermediate representation that all melody models can use.
+  Quantized sequence to Melody code will do work to align notes and extract
+  extract monophonic melodies. Model-specific code then needs to convert Melody
+  to SequenceExample protos for TensorFlow.
+
+  Melody implements an iterable object. Simply iterate to retrieve the melody
+  events.
+
+  Melody events are integers in range [-2, 127] (inclusive), where negative
+  values are the special event events: MELODY_NOTE_OFF, and MELODY_NO_EVENT.
+  Non-negative values [0, 127] are note-on events for that midi pitch. A note
+  starts at a non-negative value (that is the pitch), and is held through
+  subsequent MELODY_NO_EVENT events until either another non-negative value is
+  reached (even if the pitch is the same as the previous note), or a
+  MELODY_NOTE_OFF event is reached. A MELODY_NOTE_OFF starts at least one step
+  of silence, which continues through MELODY_NO_EVENT events until the next
+  non-negative value.
+
+  MELODY_NO_EVENT values are treated as default filler. Notes must be inserted
+  in ascending order by start time. Note end times will be truncated if the next
+  note overlaps.
+
+  Any sustained notes are implicitly turned off at the end of a melody.
+
+  Melodies can start at any non-negative time, and are shifted left so that
+  the bar containing the first note-on event is the first bar.
+
+  Attributes:
+    start_step: The offset of the first step of the melody relative to the
+        beginning of the source sequence. Will always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the melody relative the beginning of the source sequence. Will always
+       be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a Melody.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(Melody, self).__init__(pad_event=MELODY_NO_EVENT,
+                                 events=events, **kwargs)
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.
+
+    Args:
+      events: List of Melody events to set melody to.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+
+    Raises:
+      ValueError: If `events` contains an event that is not in the proper range.
+    &#34;&#34;&#34;
+    for event in events:
+      if not MIN_MELODY_EVENT &lt;= event &lt;= MAX_MELODY_EVENT:
+        raise ValueError(&#39;Melody event out of range: %d&#39; % event)
+    # Replace MELODY_NOTE_OFF events with MELODY_NO_EVENT before first note.
+    cleaned_events = list(events)
+    for i, e in enumerate(events):
+      if e not in (MELODY_NO_EVENT, MELODY_NOTE_OFF):
+        break
+      cleaned_events[i] = MELODY_NO_EVENT
+
+    super(Melody, self)._from_event_list(
+        cleaned_events, start_step=start_step, steps_per_bar=steps_per_bar,
+        steps_per_quarter=steps_per_quarter)
+
+  def _add_note(self, pitch, start_step, end_step):
+    &#34;&#34;&#34;Adds the given note to the `events` list.
+
+    `start_step` is set to the given pitch. `end_step` is set to NOTE_OFF.
+    Everything after `start_step` in `events` is deleted before the note is
+    added. `events`&#39;s length will be changed so that the last event has index
+    `end_step`.
+
+    Args:
+      pitch: Midi pitch. An integer between 0 and 127 inclusive.
+      start_step: A non-negative integer step that the note begins on.
+      end_step: An integer step that the note ends on. The note is considered to
+          end at the onset of the end step. `end_step` must be greater than
+          `start_step`.
+
+    Raises:
+      BadNoteError: If `start_step` does not precede `end_step`.
+    &#34;&#34;&#34;
+    if start_step &gt;= end_step:
+      raise BadNoteError(
+          &#39;Start step does not precede end step: start=%d, end=%d&#39; %
+          (start_step, end_step))
+
+    self.set_length(end_step + 1)
+
+    self._events[start_step] = pitch
+    self._events[end_step] = MELODY_NOTE_OFF
+    for i in range(start_step + 1, end_step):
+      self._events[i] = MELODY_NO_EVENT
+
+  def _get_last_on_off_events(self):
+    &#34;&#34;&#34;Returns indexes of the most recent pitch and NOTE_OFF events.
+
+    Returns:
+      A tuple (start_step, end_step) of the last note&#39;s on and off event
+          indices.
+
+    Raises:
+      ValueError: If `events` contains no NOTE_OFF or pitch events.
+    &#34;&#34;&#34;
+    last_off = len(self)
+    for i in range(len(self) - 1, -1, -1):
+      if self._events[i] == MELODY_NOTE_OFF:
+        last_off = i
+      if self._events[i] &gt;= MIN_MIDI_PITCH:
+        return (i, last_off)
+    raise ValueError(&#39;No events in the stream&#39;)
+
+  def get_note_histogram(self):
+    &#34;&#34;&#34;Gets a histogram of the note occurrences in a melody.
+
+    Returns:
+      A list of 12 ints, one for each note value (C at index 0 through B at
+      index 11). Each int is the total number of times that note occurred in
+      the melody.
+    &#34;&#34;&#34;
+    np_melody = np.array(self._events, dtype=int)
+    return np.bincount(np_melody[np_melody &gt;= MIN_MIDI_PITCH] %
+                       NOTES_PER_OCTAVE,
+                       minlength=NOTES_PER_OCTAVE)
+
+  def get_major_key_histogram(self):
+    &#34;&#34;&#34;Gets a histogram of the how many notes fit into each key.
+
+    Returns:
+      A list of 12 ints, one for each Major key (C Major at index 0 through
+      B Major at index 11). Each int is the total number of notes that could
+      fit into that key.
+    &#34;&#34;&#34;
+    note_histogram = self.get_note_histogram()
+    key_histogram = np.zeros(NOTES_PER_OCTAVE)
+    for note, count in enumerate(note_histogram):
+      key_histogram[NOTE_KEYS[note]] += count
+    return key_histogram
+
+  def get_major_key(self):
+    &#34;&#34;&#34;Finds the major key that this melody most likely belongs to.
+
+    If multiple keys match equally, the key with the lowest index is returned,
+    where the indexes of the keys are C Major = 0 through B Major = 11.
+
+    Returns:
+      An int for the most likely key (C Major = 0 through B Major = 11)
+    &#34;&#34;&#34;
+    key_histogram = self.get_major_key_histogram()
+    return key_histogram.argmax()
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the melody and increments the end step.
+
+    An implicit NOTE_OFF at the end of the melody will not be respected by this
+    modification.
+
+    Args:
+      event: The integer Melody event to append to the end.
+    Raises:
+      ValueError: If `event` is not in the proper range.
+    &#34;&#34;&#34;
+    if not MIN_MELODY_EVENT &lt;= event &lt;= MAX_MELODY_EVENT:
+      raise ValueError(&#39;Event out of range: %d&#39; % event)
+    super(Melody, self).append(event)
+
+  def from_quantized_sequence(self,
+                              quantized_sequence,
+                              search_start_step=0,
+                              instrument=0,
+                              gap_bars=1,
+                              ignore_polyphonic_notes=False,
+                              pad_end=False,
+                              filter_drums=True):
+    &#34;&#34;&#34;Populate self with a melody from the given quantized NoteSequence.
+
+    A monophonic melody is extracted from the given `instrument` starting at
+    `search_start_step`. `instrument` and `search_start_step` can be used to
+    drive extraction of multiple melodies from the same quantized sequence. The
+    end step of the extracted melody will be stored in `self._end_step`.
+
+    0 velocity notes are ignored. The melody extraction is ended when there are
+    no held notes for a time stretch of `gap_bars` in bars (measures) of music.
+    The number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    `ignore_polyphonic_notes` determines what happens when polyphonic (multiple
+    notes start at the same time) data is encountered. If
+    `ignore_polyphonic_notes` is true, the highest pitch is used in the melody
+    when multiple notes start at the same time. If false, an exception is
+    raised.
+
+    Args:
+      quantized_sequence: A NoteSequence quantized with
+          sequences_lib.quantize_note_sequence.
+      search_start_step: Start searching for a melody at this time step. Assumed
+          to be the first step of a bar.
+      instrument: Search for a melody in this instrument number.
+      gap_bars: If this many bars or more follow a NOTE_OFF event, the melody
+          is ended.
+      ignore_polyphonic_notes: If True, the highest pitch is used in the melody
+          when multiple notes start at the same time. If False,
+          PolyphonicMelodyError will be raised if multiple notes start at
+          the same time.
+      pad_end: If True, the end of the melody will be padded with NO_EVENTs so
+          that it will end at a bar boundary.
+      filter_drums: If True, notes for which `is_drum` is True will be ignored.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+      PolyphonicMelodyError: If any of the notes start on the same step
+          and `ignore_polyphonic_notes` is False.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+           quantized_sequence.time_signatures[0].denominator))
+    self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Sort track by note start times, and secondarily by pitch descending.
+    notes = sorted([n for n in quantized_sequence.notes
+                    if n.instrument == instrument and
+                    n.quantized_start_step &gt;= search_start_step],
+                   key=lambda note: (note.quantized_start_step, -note.pitch))
+
+    if not notes:
+      return
+
+    # The first step in the melody, beginning at the first step of a bar.
+    melody_start_step = (
+        notes[0].quantized_start_step -
+        (notes[0].quantized_start_step - search_start_step) % steps_per_bar)
+    for note in notes:
+      if filter_drums and note.is_drum:
+        continue
+
+      # Ignore 0 velocity notes.
+      if not note.velocity:
+        continue
+
+      start_index = note.quantized_start_step - melody_start_step
+      end_index = note.quantized_end_step - melody_start_step
+
+      if not self._events:
+        # If there are no events, we don&#39;t need to check for polyphony.
+        self._add_note(note.pitch, start_index, end_index)
+        continue
+
+      # If `start_index` comes before or lands on an already added note&#39;s start
+      # step, we cannot add it. In that case either discard the melody or keep
+      # the highest pitch.
+      last_on, last_off = self._get_last_on_off_events()
+      on_distance = start_index - last_on
+      off_distance = start_index - last_off
+      if on_distance == 0:
+        if ignore_polyphonic_notes:
+          # Keep highest note.
+          # Notes are sorted by pitch descending, so if a note is already at
+          # this position its the highest pitch.
+          continue
+        else:
+          self._reset()
+          raise PolyphonicMelodyError()
+      elif on_distance &lt; 0:
+        raise PolyphonicMelodyError(
+            &#39;Unexpected note. Not in ascending order.&#39;)
+
+      # If a gap of `gap` or more steps is found, end the melody.
+      if len(self) and off_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+        break
+
+      # Add the note-on and off events to the melody.
+      self._add_note(note.pitch, start_index, end_index)
+
+    if not self._events:
+      # If no notes were added, don&#39;t set `_start_step` and `_end_step`.
+      return
+
+    self._start_step = melody_start_step
+
+    # Strip final MELODY_NOTE_OFF event.
+    if self._events[-1] == MELODY_NOTE_OFF:
+      del self._events[-1]
+
+    length = len(self)
+    # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+    if pad_end:
+      length += -len(self) % steps_per_bar
+    self.set_length(length)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the Melody to NoteSequence proto.
+
+    The end of the melody is treated as a NOTE_OFF event for any sustained
+    notes.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      sequence_start_time: A time in seconds (float) that the first note in the
+          sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given melody.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    sequence_start_time += self.start_step * seconds_per_step
+    current_sequence_note = None
+    for step, note in enumerate(self):
+      if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH:
+        # End any sustained notes.
+        if current_sequence_note is not None:
+          current_sequence_note.end_time = (
+              step * seconds_per_step + sequence_start_time)
+
+        # Add a note.
+        current_sequence_note = sequence.notes.add()
+        current_sequence_note.start_time = (
+            step * seconds_per_step + sequence_start_time)
+        current_sequence_note.pitch = note
+        current_sequence_note.velocity = velocity
+        current_sequence_note.instrument = instrument
+        current_sequence_note.program = program
+
+      elif note == MELODY_NOTE_OFF:
+        # End any sustained notes.
+        if current_sequence_note is not None:
+          current_sequence_note.end_time = (
+              step * seconds_per_step + sequence_start_time)
+          current_sequence_note = None
+
+    # End any sustained notes.
+    if current_sequence_note is not None:
+      current_sequence_note.end_time = (
+          len(self) * seconds_per_step + sequence_start_time)
+
+    if sequence.notes:
+      sequence.total_time = sequence.notes[-1].end_time
+
+    return sequence
+
+  def transpose(self, transpose_amount, min_note=0, max_note=128):
+    &#34;&#34;&#34;Transpose notes in this Melody.
+
+    All notes are transposed the specified amount. Additionally, all notes
+    are octave shifted to lie within the [min_note, max_note) range.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this Melody.
+          Positive values transpose up. Negative values transpose down.
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    &#34;&#34;&#34;
+    for i in range(len(self)):
+      # Transpose MIDI pitches. Special events below MIN_MIDI_PITCH are not
+      # changed.
+      if self._events[i] &gt;= MIN_MIDI_PITCH:
+        self._events[i] += transpose_amount
+        if self._events[i] &lt; min_note:
+          self._events[i] = (
+              min_note + (self._events[i] - min_note) % NOTES_PER_OCTAVE)
+        elif self._events[i] &gt;= max_note:
+          self._events[i] = (max_note - NOTES_PER_OCTAVE +
+                             (self._events[i] - max_note) % NOTES_PER_OCTAVE)
+
+  def squash(self, min_note, max_note, transpose_to_key=None):
+    &#34;&#34;&#34;Transpose and octave shift the notes in this Melody.
+
+    The key center of this melody is computed with a heuristic, and the notes
+    are transposed to be in the given key. The melody is also octave shifted
+    to be centered in the given range. Additionally, all notes are octave
+    shifted to lie within a given range.
+
+    Args:
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+      transpose_to_key: The melody is transposed to be in this key or None if
+         should not be transposed. 0 = C Major.
+
+    Returns:
+      How much notes are transposed by.
+    &#34;&#34;&#34;
+    if transpose_to_key is None:
+      transpose_amount = 0
+    else:
+      melody_key = self.get_major_key()
+      key_diff = transpose_to_key - melody_key
+      midi_notes = [note for note in self._events
+                    if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH]
+      if not midi_notes:
+        return 0
+      melody_min_note = min(midi_notes)
+      melody_max_note = max(midi_notes)
+      melody_center = (melody_min_note + melody_max_note) / 2
+      target_center = (min_note + max_note - 1) / 2
+      center_diff = target_center - (melody_center + key_diff)
+      transpose_amount = (
+          key_diff +
+          NOTES_PER_OCTAVE * int(round(center_diff / float(NOTES_PER_OCTAVE))))
+    self.transpose(transpose_amount, min_note, max_note)
+
+    return transpose_amount
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the melody to the specified number of steps.
+
+    If the melody is not long enough, ends any sustained notes and adds NO_EVENT
+    steps for padding. If it is too long, it will be truncated to the requested
+    length.
+
+    Args:
+      steps: How many steps long the melody should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    old_len = len(self)
+    super(Melody, self).set_length(steps, from_left=from_left)
+    if steps &gt; old_len and not from_left:
+      # When extending the melody on the right, we end any sustained notes.
+      for i in reversed(range(old_len)):
+        if self._events[i] == MELODY_NOTE_OFF:
+          break
+        elif self._events[i] != MELODY_NO_EVENT:
+          self._events[old_len] = MELODY_NOTE_OFF
+          break
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a Melody.
+
+    Increases the resolution of a Melody object by a factor of `k`. This uses
+    MELODY_NO_EVENT to extend each event in the melody to be `k` steps long.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          melody.
+    &#34;&#34;&#34;
+    super(Melody, self).increase_resolution(
+        k, fill_event=MELODY_NO_EVENT)
+
+
+def midi_file_to_melody(midi_file, steps_per_quarter=4, qpm=None,
+                        ignore_polyphonic_notes=True):
+  &#34;&#34;&#34;Loads a melody from a MIDI file.
+
+  Args:
+    midi_file: Absolute path to MIDI file.
+    steps_per_quarter: Quantization of Melody. For example, 4 = 16th notes.
+    qpm: Tempo in quarters per a minute. If not set, tries to use the first
+        tempo of the midi track and defaults to
+        note_seq.DEFAULT_QUARTERS_PER_MINUTE if fails.
+    ignore_polyphonic_notes: Only use the highest simultaneous note if True.
+
+  Returns:
+    A Melody object extracted from the MIDI file.
+  &#34;&#34;&#34;
+  sequence = midi_io.midi_file_to_sequence_proto(midi_file)
+  if qpm is None:
+    if sequence.tempos:
+      qpm = sequence.tempos[0].qpm
+    else:
+      qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=steps_per_quarter)
+  melody = Melody()
+  melody.from_quantized_sequence(
+      quantized_sequence, ignore_polyphonic_notes=ignore_polyphonic_notes)
+  return melody</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.melodies_lib.midi_file_to_melody"><code class="name flex">
+<span>def <span class="ident">midi_file_to_melody</span></span>(<span>midi_file, steps_per_quarter=4, qpm=None, ignore_polyphonic_notes=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Loads a melody from a MIDI file.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>midi_file</code></strong></dt>
+<dd>Absolute path to MIDI file.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Quantization of Melody. For example, 4 = 16th notes.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Tempo in quarters per a minute. If not set, tries to use the first
+tempo of the midi track and defaults to
+note_seq.DEFAULT_QUARTERS_PER_MINUTE if fails.</dd>
+<dt><strong><code>ignore_polyphonic_notes</code></strong></dt>
+<dd>Only use the highest simultaneous note if True.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Melody object extracted from the MIDI file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_file_to_melody(midi_file, steps_per_quarter=4, qpm=None,
+                        ignore_polyphonic_notes=True):
+  &#34;&#34;&#34;Loads a melody from a MIDI file.
+
+  Args:
+    midi_file: Absolute path to MIDI file.
+    steps_per_quarter: Quantization of Melody. For example, 4 = 16th notes.
+    qpm: Tempo in quarters per a minute. If not set, tries to use the first
+        tempo of the midi track and defaults to
+        note_seq.DEFAULT_QUARTERS_PER_MINUTE if fails.
+    ignore_polyphonic_notes: Only use the highest simultaneous note if True.
+
+  Returns:
+    A Melody object extracted from the MIDI file.
+  &#34;&#34;&#34;
+  sequence = midi_io.midi_file_to_sequence_proto(midi_file)
+  if qpm is None:
+    if sequence.tempos:
+      qpm = sequence.tempos[0].qpm
+    else:
+      qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      sequence, steps_per_quarter=steps_per_quarter)
+  melody = Melody()
+  melody.from_quantized_sequence(
+      quantized_sequence, ignore_polyphonic_notes=ignore_polyphonic_notes)
+  return melody</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melodies_lib.BadNoteError"><code class="flex name class">
+<span>class <span class="ident">BadNoteError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BadNoteError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.melodies_lib.Melody"><code class="flex name class">
+<span>class <span class="ident">Melody</span></span>
+<span>(</span><span>events=None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a quantized stream of monophonic melody events.</p>
+<p>Melody is an intermediate representation that all melody models can use.
+Quantized sequence to Melody code will do work to align notes and extract
+extract monophonic melodies. Model-specific code then needs to convert Melody
+to SequenceExample protos for TensorFlow.</p>
+<p>Melody implements an iterable object. Simply iterate to retrieve the melody
+events.</p>
+<p>Melody events are integers in range [-2, 127] (inclusive), where negative
+values are the special event events: MELODY_NOTE_OFF, and MELODY_NO_EVENT.
+Non-negative values [0, 127] are note-on events for that midi pitch. A note
+starts at a non-negative value (that is the pitch), and is held through
+subsequent MELODY_NO_EVENT events until either another non-negative value is
+reached (even if the pitch is the same as the previous note), or a
+MELODY_NOTE_OFF event is reached. A MELODY_NOTE_OFF starts at least one step
+of silence, which continues through MELODY_NO_EVENT events until the next
+non-negative value.</p>
+<p>MELODY_NO_EVENT values are treated as default filler. Notes must be inserted
+in ascending order by start time. Note end times will be truncated if the next
+note overlaps.</p>
+<p>Any sustained notes are implicitly turned off at the end of a melody.</p>
+<p>Melodies can start at any non-negative time, and are shifted left so that
+the bar containing the first note-on event is the first bar.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of the first step of the melody relative to the
+beginning of the source sequence. Will always be the first step of a
+bar.</dd>
+<dt><strong><code>end_step</code></strong></dt>
+<dd>The offset to the beginning of the bar following the last step
+of the melody relative the beginning of the source sequence. Will always
+be the first step of a bar.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Number of steps in in a quarter note.</dd>
+<dt><strong><code>steps_per_bar</code></strong></dt>
+<dd>Number of steps in a bar (measure) of music.</dd>
+</dl>
+<p>Construct a Melody.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Melody(events_lib.SimpleEventSequence):
+  &#34;&#34;&#34;Stores a quantized stream of monophonic melody events.
+
+  Melody is an intermediate representation that all melody models can use.
+  Quantized sequence to Melody code will do work to align notes and extract
+  extract monophonic melodies. Model-specific code then needs to convert Melody
+  to SequenceExample protos for TensorFlow.
+
+  Melody implements an iterable object. Simply iterate to retrieve the melody
+  events.
+
+  Melody events are integers in range [-2, 127] (inclusive), where negative
+  values are the special event events: MELODY_NOTE_OFF, and MELODY_NO_EVENT.
+  Non-negative values [0, 127] are note-on events for that midi pitch. A note
+  starts at a non-negative value (that is the pitch), and is held through
+  subsequent MELODY_NO_EVENT events until either another non-negative value is
+  reached (even if the pitch is the same as the previous note), or a
+  MELODY_NOTE_OFF event is reached. A MELODY_NOTE_OFF starts at least one step
+  of silence, which continues through MELODY_NO_EVENT events until the next
+  non-negative value.
+
+  MELODY_NO_EVENT values are treated as default filler. Notes must be inserted
+  in ascending order by start time. Note end times will be truncated if the next
+  note overlaps.
+
+  Any sustained notes are implicitly turned off at the end of a melody.
+
+  Melodies can start at any non-negative time, and are shifted left so that
+  the bar containing the first note-on event is the first bar.
+
+  Attributes:
+    start_step: The offset of the first step of the melody relative to the
+        beginning of the source sequence. Will always be the first step of a
+        bar.
+    end_step: The offset to the beginning of the bar following the last step
+       of the melody relative the beginning of the source sequence. Will always
+       be the first step of a bar.
+    steps_per_quarter: Number of steps in in a quarter note.
+    steps_per_bar: Number of steps in a bar (measure) of music.
+  &#34;&#34;&#34;
+
+  def __init__(self, events=None, **kwargs):
+    &#34;&#34;&#34;Construct a Melody.&#34;&#34;&#34;
+    if &#39;pad_event&#39; in kwargs:
+      del kwargs[&#39;pad_event&#39;]
+    super(Melody, self).__init__(pad_event=MELODY_NO_EVENT,
+                                 events=events, **kwargs)
+
+  def _from_event_list(self, events, start_step=0,
+                       steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                       steps_per_quarter=DEFAULT_STEPS_PER_QUARTER):
+    &#34;&#34;&#34;Initializes with a list of event values and sets attributes.
+
+    Args:
+      events: List of Melody events to set melody to.
+      start_step: The integer starting step offset.
+      steps_per_bar: The number of steps in a bar.
+      steps_per_quarter: The number of steps in a quarter note.
+
+    Raises:
+      ValueError: If `events` contains an event that is not in the proper range.
+    &#34;&#34;&#34;
+    for event in events:
+      if not MIN_MELODY_EVENT &lt;= event &lt;= MAX_MELODY_EVENT:
+        raise ValueError(&#39;Melody event out of range: %d&#39; % event)
+    # Replace MELODY_NOTE_OFF events with MELODY_NO_EVENT before first note.
+    cleaned_events = list(events)
+    for i, e in enumerate(events):
+      if e not in (MELODY_NO_EVENT, MELODY_NOTE_OFF):
+        break
+      cleaned_events[i] = MELODY_NO_EVENT
+
+    super(Melody, self)._from_event_list(
+        cleaned_events, start_step=start_step, steps_per_bar=steps_per_bar,
+        steps_per_quarter=steps_per_quarter)
+
+  def _add_note(self, pitch, start_step, end_step):
+    &#34;&#34;&#34;Adds the given note to the `events` list.
+
+    `start_step` is set to the given pitch. `end_step` is set to NOTE_OFF.
+    Everything after `start_step` in `events` is deleted before the note is
+    added. `events`&#39;s length will be changed so that the last event has index
+    `end_step`.
+
+    Args:
+      pitch: Midi pitch. An integer between 0 and 127 inclusive.
+      start_step: A non-negative integer step that the note begins on.
+      end_step: An integer step that the note ends on. The note is considered to
+          end at the onset of the end step. `end_step` must be greater than
+          `start_step`.
+
+    Raises:
+      BadNoteError: If `start_step` does not precede `end_step`.
+    &#34;&#34;&#34;
+    if start_step &gt;= end_step:
+      raise BadNoteError(
+          &#39;Start step does not precede end step: start=%d, end=%d&#39; %
+          (start_step, end_step))
+
+    self.set_length(end_step + 1)
+
+    self._events[start_step] = pitch
+    self._events[end_step] = MELODY_NOTE_OFF
+    for i in range(start_step + 1, end_step):
+      self._events[i] = MELODY_NO_EVENT
+
+  def _get_last_on_off_events(self):
+    &#34;&#34;&#34;Returns indexes of the most recent pitch and NOTE_OFF events.
+
+    Returns:
+      A tuple (start_step, end_step) of the last note&#39;s on and off event
+          indices.
+
+    Raises:
+      ValueError: If `events` contains no NOTE_OFF or pitch events.
+    &#34;&#34;&#34;
+    last_off = len(self)
+    for i in range(len(self) - 1, -1, -1):
+      if self._events[i] == MELODY_NOTE_OFF:
+        last_off = i
+      if self._events[i] &gt;= MIN_MIDI_PITCH:
+        return (i, last_off)
+    raise ValueError(&#39;No events in the stream&#39;)
+
+  def get_note_histogram(self):
+    &#34;&#34;&#34;Gets a histogram of the note occurrences in a melody.
+
+    Returns:
+      A list of 12 ints, one for each note value (C at index 0 through B at
+      index 11). Each int is the total number of times that note occurred in
+      the melody.
+    &#34;&#34;&#34;
+    np_melody = np.array(self._events, dtype=int)
+    return np.bincount(np_melody[np_melody &gt;= MIN_MIDI_PITCH] %
+                       NOTES_PER_OCTAVE,
+                       minlength=NOTES_PER_OCTAVE)
+
+  def get_major_key_histogram(self):
+    &#34;&#34;&#34;Gets a histogram of the how many notes fit into each key.
+
+    Returns:
+      A list of 12 ints, one for each Major key (C Major at index 0 through
+      B Major at index 11). Each int is the total number of notes that could
+      fit into that key.
+    &#34;&#34;&#34;
+    note_histogram = self.get_note_histogram()
+    key_histogram = np.zeros(NOTES_PER_OCTAVE)
+    for note, count in enumerate(note_histogram):
+      key_histogram[NOTE_KEYS[note]] += count
+    return key_histogram
+
+  def get_major_key(self):
+    &#34;&#34;&#34;Finds the major key that this melody most likely belongs to.
+
+    If multiple keys match equally, the key with the lowest index is returned,
+    where the indexes of the keys are C Major = 0 through B Major = 11.
+
+    Returns:
+      An int for the most likely key (C Major = 0 through B Major = 11)
+    &#34;&#34;&#34;
+    key_histogram = self.get_major_key_histogram()
+    return key_histogram.argmax()
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the melody and increments the end step.
+
+    An implicit NOTE_OFF at the end of the melody will not be respected by this
+    modification.
+
+    Args:
+      event: The integer Melody event to append to the end.
+    Raises:
+      ValueError: If `event` is not in the proper range.
+    &#34;&#34;&#34;
+    if not MIN_MELODY_EVENT &lt;= event &lt;= MAX_MELODY_EVENT:
+      raise ValueError(&#39;Event out of range: %d&#39; % event)
+    super(Melody, self).append(event)
+
+  def from_quantized_sequence(self,
+                              quantized_sequence,
+                              search_start_step=0,
+                              instrument=0,
+                              gap_bars=1,
+                              ignore_polyphonic_notes=False,
+                              pad_end=False,
+                              filter_drums=True):
+    &#34;&#34;&#34;Populate self with a melody from the given quantized NoteSequence.
+
+    A monophonic melody is extracted from the given `instrument` starting at
+    `search_start_step`. `instrument` and `search_start_step` can be used to
+    drive extraction of multiple melodies from the same quantized sequence. The
+    end step of the extracted melody will be stored in `self._end_step`.
+
+    0 velocity notes are ignored. The melody extraction is ended when there are
+    no held notes for a time stretch of `gap_bars` in bars (measures) of music.
+    The number of time steps per bar is computed from the time signature in
+    `quantized_sequence`.
+
+    `ignore_polyphonic_notes` determines what happens when polyphonic (multiple
+    notes start at the same time) data is encountered. If
+    `ignore_polyphonic_notes` is true, the highest pitch is used in the melody
+    when multiple notes start at the same time. If false, an exception is
+    raised.
+
+    Args:
+      quantized_sequence: A NoteSequence quantized with
+          sequences_lib.quantize_note_sequence.
+      search_start_step: Start searching for a melody at this time step. Assumed
+          to be the first step of a bar.
+      instrument: Search for a melody in this instrument number.
+      gap_bars: If this many bars or more follow a NOTE_OFF event, the melody
+          is ended.
+      ignore_polyphonic_notes: If True, the highest pitch is used in the melody
+          when multiple notes start at the same time. If False,
+          PolyphonicMelodyError will be raised if multiple notes start at
+          the same time.
+      pad_end: If True, the end of the melody will be padded with NO_EVENTs so
+          that it will end at a bar boundary.
+      filter_drums: If True, notes for which `is_drum` is True will be ignored.
+
+    Raises:
+      NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+          (derived from its time signature) is not an integer number of time
+          steps.
+      PolyphonicMelodyError: If any of the notes start on the same step
+          and `ignore_polyphonic_notes` is False.
+    &#34;&#34;&#34;
+    sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+    self._reset()
+
+    steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+        quantized_sequence)
+    if steps_per_bar_float % 1 != 0:
+      raise events_lib.NonIntegerStepsPerBarError(
+          &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+          (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+           quantized_sequence.time_signatures[0].denominator))
+    self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+    self._steps_per_quarter = (
+        quantized_sequence.quantization_info.steps_per_quarter)
+
+    # Sort track by note start times, and secondarily by pitch descending.
+    notes = sorted([n for n in quantized_sequence.notes
+                    if n.instrument == instrument and
+                    n.quantized_start_step &gt;= search_start_step],
+                   key=lambda note: (note.quantized_start_step, -note.pitch))
+
+    if not notes:
+      return
+
+    # The first step in the melody, beginning at the first step of a bar.
+    melody_start_step = (
+        notes[0].quantized_start_step -
+        (notes[0].quantized_start_step - search_start_step) % steps_per_bar)
+    for note in notes:
+      if filter_drums and note.is_drum:
+        continue
+
+      # Ignore 0 velocity notes.
+      if not note.velocity:
+        continue
+
+      start_index = note.quantized_start_step - melody_start_step
+      end_index = note.quantized_end_step - melody_start_step
+
+      if not self._events:
+        # If there are no events, we don&#39;t need to check for polyphony.
+        self._add_note(note.pitch, start_index, end_index)
+        continue
+
+      # If `start_index` comes before or lands on an already added note&#39;s start
+      # step, we cannot add it. In that case either discard the melody or keep
+      # the highest pitch.
+      last_on, last_off = self._get_last_on_off_events()
+      on_distance = start_index - last_on
+      off_distance = start_index - last_off
+      if on_distance == 0:
+        if ignore_polyphonic_notes:
+          # Keep highest note.
+          # Notes are sorted by pitch descending, so if a note is already at
+          # this position its the highest pitch.
+          continue
+        else:
+          self._reset()
+          raise PolyphonicMelodyError()
+      elif on_distance &lt; 0:
+        raise PolyphonicMelodyError(
+            &#39;Unexpected note. Not in ascending order.&#39;)
+
+      # If a gap of `gap` or more steps is found, end the melody.
+      if len(self) and off_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+        break
+
+      # Add the note-on and off events to the melody.
+      self._add_note(note.pitch, start_index, end_index)
+
+    if not self._events:
+      # If no notes were added, don&#39;t set `_start_step` and `_end_step`.
+      return
+
+    self._start_step = melody_start_step
+
+    # Strip final MELODY_NOTE_OFF event.
+    if self._events[-1] == MELODY_NOTE_OFF:
+      del self._events[-1]
+
+    length = len(self)
+    # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+    if pad_end:
+      length += -len(self) % steps_per_bar
+    self.set_length(length)
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=0,
+                  sequence_start_time=0.0,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the Melody to NoteSequence proto.
+
+    The end of the melody is treated as a NOTE_OFF event for any sustained
+    notes.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      sequence_start_time: A time in seconds (float) that the first note in the
+          sequence will land on.
+      qpm: Quarter notes per minute (float).
+
+    Returns:
+      A NoteSequence proto encoding the given melody.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    sequence_start_time += self.start_step * seconds_per_step
+    current_sequence_note = None
+    for step, note in enumerate(self):
+      if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH:
+        # End any sustained notes.
+        if current_sequence_note is not None:
+          current_sequence_note.end_time = (
+              step * seconds_per_step + sequence_start_time)
+
+        # Add a note.
+        current_sequence_note = sequence.notes.add()
+        current_sequence_note.start_time = (
+            step * seconds_per_step + sequence_start_time)
+        current_sequence_note.pitch = note
+        current_sequence_note.velocity = velocity
+        current_sequence_note.instrument = instrument
+        current_sequence_note.program = program
+
+      elif note == MELODY_NOTE_OFF:
+        # End any sustained notes.
+        if current_sequence_note is not None:
+          current_sequence_note.end_time = (
+              step * seconds_per_step + sequence_start_time)
+          current_sequence_note = None
+
+    # End any sustained notes.
+    if current_sequence_note is not None:
+      current_sequence_note.end_time = (
+          len(self) * seconds_per_step + sequence_start_time)
+
+    if sequence.notes:
+      sequence.total_time = sequence.notes[-1].end_time
+
+    return sequence
+
+  def transpose(self, transpose_amount, min_note=0, max_note=128):
+    &#34;&#34;&#34;Transpose notes in this Melody.
+
+    All notes are transposed the specified amount. Additionally, all notes
+    are octave shifted to lie within the [min_note, max_note) range.
+
+    Args:
+      transpose_amount: The number of half steps to transpose this Melody.
+          Positive values transpose up. Negative values transpose down.
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    &#34;&#34;&#34;
+    for i in range(len(self)):
+      # Transpose MIDI pitches. Special events below MIN_MIDI_PITCH are not
+      # changed.
+      if self._events[i] &gt;= MIN_MIDI_PITCH:
+        self._events[i] += transpose_amount
+        if self._events[i] &lt; min_note:
+          self._events[i] = (
+              min_note + (self._events[i] - min_note) % NOTES_PER_OCTAVE)
+        elif self._events[i] &gt;= max_note:
+          self._events[i] = (max_note - NOTES_PER_OCTAVE +
+                             (self._events[i] - max_note) % NOTES_PER_OCTAVE)
+
+  def squash(self, min_note, max_note, transpose_to_key=None):
+    &#34;&#34;&#34;Transpose and octave shift the notes in this Melody.
+
+    The key center of this melody is computed with a heuristic, and the notes
+    are transposed to be in the given key. The melody is also octave shifted
+    to be centered in the given range. Additionally, all notes are octave
+    shifted to lie within a given range.
+
+    Args:
+      min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+      max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+      transpose_to_key: The melody is transposed to be in this key or None if
+         should not be transposed. 0 = C Major.
+
+    Returns:
+      How much notes are transposed by.
+    &#34;&#34;&#34;
+    if transpose_to_key is None:
+      transpose_amount = 0
+    else:
+      melody_key = self.get_major_key()
+      key_diff = transpose_to_key - melody_key
+      midi_notes = [note for note in self._events
+                    if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH]
+      if not midi_notes:
+        return 0
+      melody_min_note = min(midi_notes)
+      melody_max_note = max(midi_notes)
+      melody_center = (melody_min_note + melody_max_note) / 2
+      target_center = (min_note + max_note - 1) / 2
+      center_diff = target_center - (melody_center + key_diff)
+      transpose_amount = (
+          key_diff +
+          NOTES_PER_OCTAVE * int(round(center_diff / float(NOTES_PER_OCTAVE))))
+    self.transpose(transpose_amount, min_note, max_note)
+
+    return transpose_amount
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the melody to the specified number of steps.
+
+    If the melody is not long enough, ends any sustained notes and adds NO_EVENT
+    steps for padding. If it is too long, it will be truncated to the requested
+    length.
+
+    Args:
+      steps: How many steps long the melody should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    old_len = len(self)
+    super(Melody, self).set_length(steps, from_left=from_left)
+    if steps &gt; old_len and not from_left:
+      # When extending the melody on the right, we end any sustained notes.
+      for i in reversed(range(old_len)):
+        if self._events[i] == MELODY_NOTE_OFF:
+          break
+        elif self._events[i] != MELODY_NO_EVENT:
+          self._events[old_len] = MELODY_NOTE_OFF
+          break
+
+  def increase_resolution(self, k):
+    &#34;&#34;&#34;Increase the resolution of a Melody.
+
+    Increases the resolution of a Melody object by a factor of `k`. This uses
+    MELODY_NO_EVENT to extend each event in the melody to be `k` steps long.
+
+    Args:
+      k: An integer, the factor by which to increase the resolution of the
+          melody.
+    &#34;&#34;&#34;
+    super(Melody, self).increase_resolution(
+        k, fill_event=MELODY_NO_EVENT)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.SimpleEventSequence" href="events_lib.html#note_seq.events_lib.SimpleEventSequence">SimpleEventSequence</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melodies_lib.Melody.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends the event to the end of the melody and increments the end step.</p>
+<p>An implicit NOTE_OFF at the end of the melody will not be respected by this
+modification.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The integer Melody event to append to the end.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is not in the proper range.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends the event to the end of the melody and increments the end step.
+
+  An implicit NOTE_OFF at the end of the melody will not be respected by this
+  modification.
+
+  Args:
+    event: The integer Melody event to append to the end.
+  Raises:
+    ValueError: If `event` is not in the proper range.
+  &#34;&#34;&#34;
+  if not MIN_MELODY_EVENT &lt;= event &lt;= MAX_MELODY_EVENT:
+    raise ValueError(&#39;Event out of range: %d&#39; % event)
+  super(Melody, self).append(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.from_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">from_quantized_sequence</span></span>(<span>self, quantized_sequence, search_start_step=0, instrument=0, gap_bars=1, ignore_polyphonic_notes=False, pad_end=False, filter_drums=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Populate self with a melody from the given quantized NoteSequence.</p>
+<p>A monophonic melody is extracted from the given <code>instrument</code> starting at
+<code>search_start_step</code>. <code>instrument</code> and <code>search_start_step</code> can be used to
+drive extraction of multiple melodies from the same quantized sequence. The
+end step of the extracted melody will be stored in <code>self._end_step</code>.</p>
+<p>0 velocity notes are ignored. The melody extraction is ended when there are
+no held notes for a time stretch of <code>gap_bars</code> in bars (measures) of music.
+The number of time steps per bar is computed from the time signature in
+<code>quantized_sequence</code>.</p>
+<p><code>ignore_polyphonic_notes</code> determines what happens when polyphonic (multiple
+notes start at the same time) data is encountered. If
+<code>ignore_polyphonic_notes</code> is true, the highest pitch is used in the melody
+when multiple notes start at the same time. If false, an exception is
+raised.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A NoteSequence quantized with
+sequences_lib.quantize_note_sequence.</dd>
+<dt><strong><code>search_start_step</code></strong></dt>
+<dd>Start searching for a melody at this time step. Assumed
+to be the first step of a bar.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Search for a melody in this instrument number.</dd>
+<dt><strong><code>gap_bars</code></strong></dt>
+<dd>If this many bars or more follow a NOTE_OFF event, the melody
+is ended.</dd>
+<dt><strong><code>ignore_polyphonic_notes</code></strong></dt>
+<dd>If True, the highest pitch is used in the melody
+when multiple notes start at the same time. If False,
+PolyphonicMelodyError will be raised if multiple notes start at
+the same time.</dd>
+<dt><strong><code>pad_end</code></strong></dt>
+<dd>If True, the end of the melody will be padded with NO_EVENTs so
+that it will end at a bar boundary.</dd>
+<dt><strong><code>filter_drums</code></strong></dt>
+<dd>If True, notes for which <code>is_drum</code> is True will be ignored.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NonIntegerStepsPerBarError</code></dt>
+<dd>If <code>quantized_sequence</code>'s bar length
+(derived from its time signature) is not an integer number of time
+steps.</dd>
+<dt><code><a title="note_seq.melodies_lib.PolyphonicMelodyError" href="#note_seq.melodies_lib.PolyphonicMelodyError">PolyphonicMelodyError</a></code></dt>
+<dd>If any of the notes start on the same step
+and <code>ignore_polyphonic_notes</code> is False.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def from_quantized_sequence(self,
+                            quantized_sequence,
+                            search_start_step=0,
+                            instrument=0,
+                            gap_bars=1,
+                            ignore_polyphonic_notes=False,
+                            pad_end=False,
+                            filter_drums=True):
+  &#34;&#34;&#34;Populate self with a melody from the given quantized NoteSequence.
+
+  A monophonic melody is extracted from the given `instrument` starting at
+  `search_start_step`. `instrument` and `search_start_step` can be used to
+  drive extraction of multiple melodies from the same quantized sequence. The
+  end step of the extracted melody will be stored in `self._end_step`.
+
+  0 velocity notes are ignored. The melody extraction is ended when there are
+  no held notes for a time stretch of `gap_bars` in bars (measures) of music.
+  The number of time steps per bar is computed from the time signature in
+  `quantized_sequence`.
+
+  `ignore_polyphonic_notes` determines what happens when polyphonic (multiple
+  notes start at the same time) data is encountered. If
+  `ignore_polyphonic_notes` is true, the highest pitch is used in the melody
+  when multiple notes start at the same time. If false, an exception is
+  raised.
+
+  Args:
+    quantized_sequence: A NoteSequence quantized with
+        sequences_lib.quantize_note_sequence.
+    search_start_step: Start searching for a melody at this time step. Assumed
+        to be the first step of a bar.
+    instrument: Search for a melody in this instrument number.
+    gap_bars: If this many bars or more follow a NOTE_OFF event, the melody
+        is ended.
+    ignore_polyphonic_notes: If True, the highest pitch is used in the melody
+        when multiple notes start at the same time. If False,
+        PolyphonicMelodyError will be raised if multiple notes start at
+        the same time.
+    pad_end: If True, the end of the melody will be padded with NO_EVENTs so
+        that it will end at a bar boundary.
+    filter_drums: If True, notes for which `is_drum` is True will be ignored.
+
+  Raises:
+    NonIntegerStepsPerBarError: If `quantized_sequence`&#39;s bar length
+        (derived from its time signature) is not an integer number of time
+        steps.
+    PolyphonicMelodyError: If any of the notes start on the same step
+        and `ignore_polyphonic_notes` is False.
+  &#34;&#34;&#34;
+  sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+  self._reset()
+
+  steps_per_bar_float = sequences_lib.steps_per_bar_in_quantized_sequence(
+      quantized_sequence)
+  if steps_per_bar_float % 1 != 0:
+    raise events_lib.NonIntegerStepsPerBarError(
+        &#39;There are %f timesteps per bar. Time signature: %d/%d&#39; %
+        (steps_per_bar_float, quantized_sequence.time_signatures[0].numerator,
+         quantized_sequence.time_signatures[0].denominator))
+  self._steps_per_bar = steps_per_bar = int(steps_per_bar_float)
+  self._steps_per_quarter = (
+      quantized_sequence.quantization_info.steps_per_quarter)
+
+  # Sort track by note start times, and secondarily by pitch descending.
+  notes = sorted([n for n in quantized_sequence.notes
+                  if n.instrument == instrument and
+                  n.quantized_start_step &gt;= search_start_step],
+                 key=lambda note: (note.quantized_start_step, -note.pitch))
+
+  if not notes:
+    return
+
+  # The first step in the melody, beginning at the first step of a bar.
+  melody_start_step = (
+      notes[0].quantized_start_step -
+      (notes[0].quantized_start_step - search_start_step) % steps_per_bar)
+  for note in notes:
+    if filter_drums and note.is_drum:
+      continue
+
+    # Ignore 0 velocity notes.
+    if not note.velocity:
+      continue
+
+    start_index = note.quantized_start_step - melody_start_step
+    end_index = note.quantized_end_step - melody_start_step
+
+    if not self._events:
+      # If there are no events, we don&#39;t need to check for polyphony.
+      self._add_note(note.pitch, start_index, end_index)
+      continue
+
+    # If `start_index` comes before or lands on an already added note&#39;s start
+    # step, we cannot add it. In that case either discard the melody or keep
+    # the highest pitch.
+    last_on, last_off = self._get_last_on_off_events()
+    on_distance = start_index - last_on
+    off_distance = start_index - last_off
+    if on_distance == 0:
+      if ignore_polyphonic_notes:
+        # Keep highest note.
+        # Notes are sorted by pitch descending, so if a note is already at
+        # this position its the highest pitch.
+        continue
+      else:
+        self._reset()
+        raise PolyphonicMelodyError()
+    elif on_distance &lt; 0:
+      raise PolyphonicMelodyError(
+          &#39;Unexpected note. Not in ascending order.&#39;)
+
+    # If a gap of `gap` or more steps is found, end the melody.
+    if len(self) and off_distance &gt;= gap_bars * steps_per_bar:  # pylint:disable=len-as-condition
+      break
+
+    # Add the note-on and off events to the melody.
+    self._add_note(note.pitch, start_index, end_index)
+
+  if not self._events:
+    # If no notes were added, don&#39;t set `_start_step` and `_end_step`.
+    return
+
+  self._start_step = melody_start_step
+
+  # Strip final MELODY_NOTE_OFF event.
+  if self._events[-1] == MELODY_NOTE_OFF:
+    del self._events[-1]
+
+  length = len(self)
+  # Optionally round up `_end_step` to a multiple of `steps_per_bar`.
+  if pad_end:
+    length += -len(self) % steps_per_bar
+  self.set_length(length)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.get_major_key"><code class="name flex">
+<span>def <span class="ident">get_major_key</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Finds the major key that this melody most likely belongs to.</p>
+<p>If multiple keys match equally, the key with the lowest index is returned,
+where the indexes of the keys are C Major = 0 through B Major = 11.</p>
+<h2 id="returns">Returns</h2>
+<p>An int for the most likely key (C Major = 0 through B Major = 11)</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_major_key(self):
+  &#34;&#34;&#34;Finds the major key that this melody most likely belongs to.
+
+  If multiple keys match equally, the key with the lowest index is returned,
+  where the indexes of the keys are C Major = 0 through B Major = 11.
+
+  Returns:
+    An int for the most likely key (C Major = 0 through B Major = 11)
+  &#34;&#34;&#34;
+  key_histogram = self.get_major_key_histogram()
+  return key_histogram.argmax()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.get_major_key_histogram"><code class="name flex">
+<span>def <span class="ident">get_major_key_histogram</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Gets a histogram of the how many notes fit into each key.</p>
+<h2 id="returns">Returns</h2>
+<p>A list of 12 ints, one for each Major key (C Major at index 0 through
+B Major at index 11). Each int is the total number of notes that could
+fit into that key.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_major_key_histogram(self):
+  &#34;&#34;&#34;Gets a histogram of the how many notes fit into each key.
+
+  Returns:
+    A list of 12 ints, one for each Major key (C Major at index 0 through
+    B Major at index 11). Each int is the total number of notes that could
+    fit into that key.
+  &#34;&#34;&#34;
+  note_histogram = self.get_note_histogram()
+  key_histogram = np.zeros(NOTES_PER_OCTAVE)
+  for note, count in enumerate(note_histogram):
+    key_histogram[NOTE_KEYS[note]] += count
+  return key_histogram</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.get_note_histogram"><code class="name flex">
+<span>def <span class="ident">get_note_histogram</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Gets a histogram of the note occurrences in a melody.</p>
+<h2 id="returns">Returns</h2>
+<p>A list of 12 ints, one for each note value (C at index 0 through B at
+index 11). Each int is the total number of times that note occurred in
+the melody.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_note_histogram(self):
+  &#34;&#34;&#34;Gets a histogram of the note occurrences in a melody.
+
+  Returns:
+    A list of 12 ints, one for each note value (C at index 0 through B at
+    index 11). Each int is the total number of times that note occurred in
+    the melody.
+  &#34;&#34;&#34;
+  np_melody = np.array(self._events, dtype=int)
+  return np.bincount(np_melody[np_melody &gt;= MIN_MIDI_PITCH] %
+                     NOTES_PER_OCTAVE,
+                     minlength=NOTES_PER_OCTAVE)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.increase_resolution"><code class="name flex">
+<span>def <span class="ident">increase_resolution</span></span>(<span>self, k)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Increase the resolution of a Melody.</p>
+<p>Increases the resolution of a Melody object by a factor of <code>k</code>. This uses
+MELODY_NO_EVENT to extend each event in the melody to be <code>k</code> steps long.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>k</code></strong></dt>
+<dd>An integer, the factor by which to increase the resolution of the
+melody.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def increase_resolution(self, k):
+  &#34;&#34;&#34;Increase the resolution of a Melody.
+
+  Increases the resolution of a Melody object by a factor of `k`. This uses
+  MELODY_NO_EVENT to extend each event in the melody to be `k` steps long.
+
+  Args:
+    k: An integer, the factor by which to increase the resolution of the
+        melody.
+  &#34;&#34;&#34;
+  super(Melody, self).increase_resolution(
+      k, fill_event=MELODY_NO_EVENT)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps, from_left=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the melody to the specified number of steps.</p>
+<p>If the melody is not long enough, ends any sustained notes and adds NO_EVENT
+steps for padding. If it is too long, it will be truncated to the requested
+length.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many steps long the melody should be.</dd>
+<dt><strong><code>from_left</code></strong></dt>
+<dd>Whether to add/remove from the left instead of right.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_length(self, steps, from_left=False):
+  &#34;&#34;&#34;Sets the length of the melody to the specified number of steps.
+
+  If the melody is not long enough, ends any sustained notes and adds NO_EVENT
+  steps for padding. If it is too long, it will be truncated to the requested
+  length.
+
+  Args:
+    steps: How many steps long the melody should be.
+    from_left: Whether to add/remove from the left instead of right.
+  &#34;&#34;&#34;
+  old_len = len(self)
+  super(Melody, self).set_length(steps, from_left=from_left)
+  if steps &gt; old_len and not from_left:
+    # When extending the melody on the right, we end any sustained notes.
+    for i in reversed(range(old_len)):
+      if self._events[i] == MELODY_NOTE_OFF:
+        break
+      elif self._events[i] != MELODY_NO_EVENT:
+        self._events[old_len] = MELODY_NOTE_OFF
+        break</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.squash"><code class="name flex">
+<span>def <span class="ident">squash</span></span>(<span>self, min_note, max_note, transpose_to_key=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transpose and octave shift the notes in this Melody.</p>
+<p>The key center of this melody is computed with a heuristic, and the notes
+are transposed to be in the given key. The melody is also octave shifted
+to be centered in the given range. Additionally, all notes are octave
+shifted to lie within a given range.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>Minimum pitch (inclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>Maximum pitch (exclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>transpose_to_key</code></strong></dt>
+<dd>The melody is transposed to be in this key or None if
+should not be transposed. 0 = C Major.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>How much notes are transposed by.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def squash(self, min_note, max_note, transpose_to_key=None):
+  &#34;&#34;&#34;Transpose and octave shift the notes in this Melody.
+
+  The key center of this melody is computed with a heuristic, and the notes
+  are transposed to be in the given key. The melody is also octave shifted
+  to be centered in the given range. Additionally, all notes are octave
+  shifted to lie within a given range.
+
+  Args:
+    min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+    max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+    transpose_to_key: The melody is transposed to be in this key or None if
+       should not be transposed. 0 = C Major.
+
+  Returns:
+    How much notes are transposed by.
+  &#34;&#34;&#34;
+  if transpose_to_key is None:
+    transpose_amount = 0
+  else:
+    melody_key = self.get_major_key()
+    key_diff = transpose_to_key - melody_key
+    midi_notes = [note for note in self._events
+                  if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH]
+    if not midi_notes:
+      return 0
+    melody_min_note = min(midi_notes)
+    melody_max_note = max(midi_notes)
+    melody_center = (melody_min_note + melody_max_note) / 2
+    target_center = (min_note + max_note - 1) / 2
+    center_diff = target_center - (melody_center + key_diff)
+    transpose_amount = (
+        key_diff +
+        NOTES_PER_OCTAVE * int(round(center_diff / float(NOTES_PER_OCTAVE))))
+  self.transpose(transpose_amount, min_note, max_note)
+
+  return transpose_amount</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity=100, instrument=0, program=0, sequence_start_time=0.0, qpm=120.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the Melody to NoteSequence proto.</p>
+<p>The end of the melody is treated as a NOTE_OFF event for any sustained
+notes.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Midi velocity to give each note. Between 1 and 127 (inclusive).</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Midi instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>Midi program to give each note.</dd>
+<dt><strong><code>sequence_start_time</code></strong></dt>
+<dd>A time in seconds (float) that the first note in the
+sequence will land on.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Quarter notes per minute (float).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto encoding the given melody.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                velocity=100,
+                instrument=0,
+                program=0,
+                sequence_start_time=0.0,
+                qpm=120.0):
+  &#34;&#34;&#34;Converts the Melody to NoteSequence proto.
+
+  The end of the melody is treated as a NOTE_OFF event for any sustained
+  notes.
+
+  Args:
+    velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+    instrument: Midi instrument to give each note.
+    program: Midi program to give each note.
+    sequence_start_time: A time in seconds (float) that the first note in the
+        sequence will land on.
+    qpm: Quarter notes per minute (float).
+
+  Returns:
+    A NoteSequence proto encoding the given melody.
+  &#34;&#34;&#34;
+  seconds_per_step = 60.0 / qpm / self.steps_per_quarter
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = STANDARD_PPQ
+
+  sequence_start_time += self.start_step * seconds_per_step
+  current_sequence_note = None
+  for step, note in enumerate(self):
+    if MIN_MIDI_PITCH &lt;= note &lt;= MAX_MIDI_PITCH:
+      # End any sustained notes.
+      if current_sequence_note is not None:
+        current_sequence_note.end_time = (
+            step * seconds_per_step + sequence_start_time)
+
+      # Add a note.
+      current_sequence_note = sequence.notes.add()
+      current_sequence_note.start_time = (
+          step * seconds_per_step + sequence_start_time)
+      current_sequence_note.pitch = note
+      current_sequence_note.velocity = velocity
+      current_sequence_note.instrument = instrument
+      current_sequence_note.program = program
+
+    elif note == MELODY_NOTE_OFF:
+      # End any sustained notes.
+      if current_sequence_note is not None:
+        current_sequence_note.end_time = (
+            step * seconds_per_step + sequence_start_time)
+        current_sequence_note = None
+
+  # End any sustained notes.
+  if current_sequence_note is not None:
+    current_sequence_note.end_time = (
+        len(self) * seconds_per_step + sequence_start_time)
+
+  if sequence.notes:
+    sequence.total_time = sequence.notes[-1].end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib.Melody.transpose"><code class="name flex">
+<span>def <span class="ident">transpose</span></span>(<span>self, transpose_amount, min_note=0, max_note=128)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transpose notes in this Melody.</p>
+<p>All notes are transposed the specified amount. Additionally, all notes
+are octave shifted to lie within the [min_note, max_note) range.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>transpose_amount</code></strong></dt>
+<dd>The number of half steps to transpose this Melody.
+Positive values transpose up. Negative values transpose down.</dd>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>Minimum pitch (inclusive) that the resulting notes will take on.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>Maximum pitch (exclusive) that the resulting notes will take on.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transpose(self, transpose_amount, min_note=0, max_note=128):
+  &#34;&#34;&#34;Transpose notes in this Melody.
+
+  All notes are transposed the specified amount. Additionally, all notes
+  are octave shifted to lie within the [min_note, max_note) range.
+
+  Args:
+    transpose_amount: The number of half steps to transpose this Melody.
+        Positive values transpose up. Negative values transpose down.
+    min_note: Minimum pitch (inclusive) that the resulting notes will take on.
+    max_note: Maximum pitch (exclusive) that the resulting notes will take on.
+  &#34;&#34;&#34;
+  for i in range(len(self)):
+    # Transpose MIDI pitches. Special events below MIN_MIDI_PITCH are not
+    # changed.
+    if self._events[i] &gt;= MIN_MIDI_PITCH:
+      self._events[i] += transpose_amount
+      if self._events[i] &lt; min_note:
+        self._events[i] = (
+            min_note + (self._events[i] - min_note) % NOTES_PER_OCTAVE)
+      elif self._events[i] &gt;= max_note:
+        self._events[i] = (max_note - NOTES_PER_OCTAVE +
+                           (self._events[i] - max_note) % NOTES_PER_OCTAVE)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.melodies_lib.PolyphonicMelodyError"><code class="flex name class">
+<span>class <span class="ident">PolyphonicMelodyError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PolyphonicMelodyError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.melodies_lib.midi_file_to_melody" href="#note_seq.melodies_lib.midi_file_to_melody">midi_file_to_melody</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melodies_lib.BadNoteError" href="#note_seq.melodies_lib.BadNoteError">BadNoteError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.melodies_lib.Melody" href="#note_seq.melodies_lib.Melody">Melody</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melodies_lib.Melody.append" href="#note_seq.melodies_lib.Melody.append">append</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.from_quantized_sequence" href="#note_seq.melodies_lib.Melody.from_quantized_sequence">from_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.get_major_key" href="#note_seq.melodies_lib.Melody.get_major_key">get_major_key</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.get_major_key_histogram" href="#note_seq.melodies_lib.Melody.get_major_key_histogram">get_major_key_histogram</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.get_note_histogram" href="#note_seq.melodies_lib.Melody.get_note_histogram">get_note_histogram</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.increase_resolution" href="#note_seq.melodies_lib.Melody.increase_resolution">increase_resolution</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.set_length" href="#note_seq.melodies_lib.Melody.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.squash" href="#note_seq.melodies_lib.Melody.squash">squash</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.to_sequence" href="#note_seq.melodies_lib.Melody.to_sequence">to_sequence</a></code></li>
+<li><code><a title="note_seq.melodies_lib.Melody.transpose" href="#note_seq.melodies_lib.Melody.transpose">transpose</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.melodies_lib.PolyphonicMelodyError" href="#note_seq.melodies_lib.PolyphonicMelodyError">PolyphonicMelodyError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melodies_lib_test.html
+++ b/docs/melodies_lib_test.html
@@ -1,0 +1,1615 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melodies_lib_test API documentation</title>
+<meta name="description" content="Tests for melodies_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melodies_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for melodies_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for melodies_lib.&#34;&#34;&#34;
+
+import os
+
+from absl.testing import absltest
+from note_seq import constants
+from note_seq import melodies_lib
+from note_seq import sequences_lib
+from note_seq import testing_lib
+
+NOTE_OFF = constants.MELODY_NOTE_OFF
+NO_EVENT = constants.MELODY_NO_EVENT
+
+
+class MelodiesLibTest(testing_lib.ProtoTestCase):
+
+  def testGetNoteHistogram(self):
+    events = [NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 5 + 11, 12 * 6 + 3,
+              12 * 4 + 11]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+    events = [0, 1, NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 6 + 3,
+              12 * 5 + 11, NO_EVENT, 12 * 4 + 11, 12 * 7 + 1]
+    melody = melodies_lib.Melody(events)
+    expected = [2, 3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+    melody = melodies_lib.Melody()
+    expected = [0] * 12
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+  def testGetKeyHistogram(self):
+    # One C.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+    # One C and one C#.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+    # One C, one C#, and one D.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NO_EVENT, 12 * 9 + 2]
+    melody = melodies_lib.Melody(events)
+    expected = [2, 2, 2, 2, 1, 2, 1, 2, 2, 2, 2, 1]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+  def testGetMajorKey(self):
+    # D Major.
+    events = [NO_EVENT, 12 * 2 + 2, 12 * 3 + 4, 12 * 5 + 1, 12 * 6 + 6,
+              12 * 4 + 11, 12 * 3 + 9, 12 * 5 + 7, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(2, melody.get_major_key())
+
+    # C# Major with accidentals.
+    events = [NO_EVENT, 12 * 2 + 1, 12 * 4 + 8, 12 * 5 + 5, 12 * 6 + 6,
+              12 * 3 + 3, 12 * 2 + 11, 12 * 3 + 10, 12 * 5, 12 * 2 + 8,
+              12 * 4 + 1, 12 * 3 + 5, 12 * 5 + 9, 12 * 4 + 3, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(1, melody.get_major_key())
+
+    # One note in C Major.
+    events = [NO_EVENT, 12 * 2 + 11, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(0, melody.get_major_key())
+
+  def testTranspose(self):
+    # Melody transposed down 5 half steps. 2 octave range.
+    events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected = [12 * 5 + 11, NO_EVENT, 12 * 5, NOTE_OFF, 12 * 5 + 7, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody transposed up 19 half steps. 2 octave range.
+    events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=19, min_note=12 * 5, max_note=12 * 7)
+    expected = [12 * 6 + 11, NO_EVENT, 12 * 6, NOTE_OFF, 12 * 6 + 7, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody transposed zero half steps. 1 octave range.
+    events = [12 * 4 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=0, min_note=12 * 5, max_note=12 * 6)
+    expected = [12 * 5 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 5, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+  def testSquash(self):
+    # Melody in C, transposed to C, and squashed to 1 octave.
+    events = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody in D, transposed to C, and squashed to 1 octave.
+    events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 5 + 1]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 5, 12 * 5 + 4, 12 * 5 + 11]
+    self.assertEqual(expected, list(melody))
+
+    # Melody in D, transposed to E, and squashed to 1 octave.
+    events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 4 + 11]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=4)
+    expected = [12 * 5 + 4, 12 * 5 + 6, 12 * 5 + 9, 12 * 5 + 8, 12 * 5 + 1]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashCenterOctaves(self):
+    # Move up an octave.
+    events = [12 * 4, NO_EVENT, 12 * 4 + 2, NOTE_OFF, 12 * 4 + 4, NO_EVENT,
+              12 * 4 + 5, 12 * 5 + 2, 12 * 4 - 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+                12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+    self.assertEqual(expected, list(melody))
+
+    # Move down an octave.
+    events = [12 * 6, NO_EVENT, 12 * 6 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT,
+              12 * 6 + 5, 12 * 7 + 2, 12 * 6 - 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+                12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashMaxNote(self):
+    events = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 6,
+              12 * 6 + 1]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 5,
+                12 * 5 + 1]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashAllNotesOff(self):
+    events = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    self.assertEqual(events, list(melody))
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0)
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0)
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(14, melody.steps_per_bar)
+
+  def testFromNotesPolyphonic(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.0, 0.50)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+      melody.from_quantized_sequence(quantized_sequence,
+                                     search_start_step=0, instrument=0,
+                                     ignore_polyphonic_notes=False)
+    self.assertFalse(list(melody))
+
+  def testFromNotesPolyphonicWithIgnorePolyphonicNotes(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 2.0), (19, 100, 0.0, 3.0),
+         (12, 100, 1.0, 3.0), (19, 100, 1.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=True)
+    expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11)
+
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromNotesChord(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 1.25), (19, 100, 1, 1.25),
+         (20, 100, 1, 1.25), (25, 100, 1, 1.25)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+      melody.from_quantized_sequence(quantized_sequence,
+                                     search_start_step=0, instrument=0,
+                                     ignore_polyphonic_notes=False)
+    self.assertFalse(list(melody))
+
+  def testFromNotesTrimEmptyMeasures(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12,
+                NOTE_OFF, 11]
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromNotesTimeOverlap(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 3.25, 3.75),
+         (13, 100, 2, 4)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12, NO_EVENT, NO_EVENT,
+                NO_EVENT, 13, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 11,
+                NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+  def testFromNotesStepsPerBar(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=12)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    self.assertEqual(42, melody.steps_per_bar)
+
+  def testFromNotesStartAndEndStep(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+         (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=18, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, 14, NOTE_OFF, 15, NO_EVENT, NO_EVENT, NO_EVENT,
+                NO_EVENT, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(34, melody.start_step)
+    self.assertEqual(43, melody.end_step)
+
+  def testSetLength(self):
+    events = [60]
+    melody = melodies_lib.Melody(events, start_step=9)
+    melody.set_length(5)
+    self.assertListEqual([60, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
+                         list(melody))
+    self.assertEqual(9, melody.start_step)
+    self.assertEqual(14, melody.end_step)
+
+    melody = melodies_lib.Melody(events, start_step=9)
+    melody.set_length(5, from_left=True)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 60],
+                         list(melody))
+    self.assertEqual(5, melody.start_step)
+    self.assertEqual(10, melody.end_step)
+
+    events = [60, NO_EVENT, NO_EVENT, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.set_length(3)
+    self.assertListEqual([60, NO_EVENT, NO_EVENT], list(melody))
+    self.assertEqual(0, melody.start_step)
+    self.assertEqual(3, melody.end_step)
+
+    melody = melodies_lib.Melody(events)
+    melody.set_length(3, from_left=True)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NOTE_OFF], list(melody))
+    self.assertEqual(1, melody.start_step)
+    self.assertEqual(4, melody.end_step)
+
+  def testToSequenceSimple(self):
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+    sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 3.75 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 10 instrument: 1 start_time: 2.25 end_time: 2.75 &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 1 start_time: 3.25 end_time: 3.5 &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 3 velocity: 10 instrument: 1 start_time: 3.5 end_time: 3.75 &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithSustainedNote(self):
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NO_EVENT, NO_EVENT])
+    sequence = melody.to_sequence(
+        velocity=100,
+        instrument=0,
+        sequence_start_time=0,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.25 &#39;
+        &#39;notes &lt; pitch: 1 velocity: 100 start_time: 0.25 end_time: 0.75 &gt; &#39;
+        &#39;notes &lt; pitch: 2 velocity: 100 start_time: 1.25 end_time: 1.5 &gt; &#39;
+        &#39;notes &lt; pitch: 3 velocity: 100 start_time: 1.5 end_time: 2.25 &gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithNonzeroStart(self):
+    melody = melodies_lib.Melody([NO_EVENT, 1, NO_EVENT], start_step=4)
+    sequence = melody.to_sequence(
+        velocity=100,
+        instrument=0,
+        sequence_start_time=0.5,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.25 &#39;
+        &#39;notes &lt; pitch: 1 velocity: 100 start_time: 1.75 end_time: 2.25 &gt; &#39;,
+        sequence)
+
+  def testToSequenceEmpty(self):
+    melody = melodies_lib.Melody()
+    sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+        sequence)
+
+  def testMidiFileToMelody(self):
+    filename = os.path.join(testing_lib.get_testdata_dir(), &#39;melody.mid&#39;)
+    melody = melodies_lib.midi_file_to_melody(filename)
+    expected = melodies_lib.Melody([60, 62, 64, 66, 68, 70,
+                                    72, 70, 68, 66, 64, 62])
+    self.assertEqual(expected, melody)
+
+  def testSlice(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 3), (11, 100, 5, 7), (13, 100, 9, 10)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11, NO_EVENT,
+                NOTE_OFF, NO_EVENT, 13]
+    self.assertEqual(expected, list(melody))
+
+    expected_slice = [NO_EVENT, NO_EVENT, NO_EVENT, 11, NO_EVENT, NOTE_OFF,
+                      NO_EVENT]
+    self.assertEqual(expected_slice, list(melody[2:-1]))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest"><code class="flex name class">
+<span>class <span class="ident">MelodiesLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodiesLibTest(testing_lib.ProtoTestCase):
+
+  def testGetNoteHistogram(self):
+    events = [NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 5 + 11, 12 * 6 + 3,
+              12 * 4 + 11]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+    events = [0, 1, NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 6 + 3,
+              12 * 5 + 11, NO_EVENT, 12 * 4 + 11, 12 * 7 + 1]
+    melody = melodies_lib.Melody(events)
+    expected = [2, 3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+    melody = melodies_lib.Melody()
+    expected = [0] * 12
+    self.assertEqual(expected, list(melody.get_note_histogram()))
+
+  def testGetKeyHistogram(self):
+    # One C.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+    # One C and one C#.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    expected = [1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+    # One C, one C#, and one D.
+    events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NO_EVENT, 12 * 9 + 2]
+    melody = melodies_lib.Melody(events)
+    expected = [2, 2, 2, 2, 1, 2, 1, 2, 2, 2, 2, 1]
+    self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+  def testGetMajorKey(self):
+    # D Major.
+    events = [NO_EVENT, 12 * 2 + 2, 12 * 3 + 4, 12 * 5 + 1, 12 * 6 + 6,
+              12 * 4 + 11, 12 * 3 + 9, 12 * 5 + 7, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(2, melody.get_major_key())
+
+    # C# Major with accidentals.
+    events = [NO_EVENT, 12 * 2 + 1, 12 * 4 + 8, 12 * 5 + 5, 12 * 6 + 6,
+              12 * 3 + 3, 12 * 2 + 11, 12 * 3 + 10, 12 * 5, 12 * 2 + 8,
+              12 * 4 + 1, 12 * 3 + 5, 12 * 5 + 9, 12 * 4 + 3, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(1, melody.get_major_key())
+
+    # One note in C Major.
+    events = [NO_EVENT, 12 * 2 + 11, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    self.assertEqual(0, melody.get_major_key())
+
+  def testTranspose(self):
+    # Melody transposed down 5 half steps. 2 octave range.
+    events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+    expected = [12 * 5 + 11, NO_EVENT, 12 * 5, NOTE_OFF, 12 * 5 + 7, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody transposed up 19 half steps. 2 octave range.
+    events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=19, min_note=12 * 5, max_note=12 * 7)
+    expected = [12 * 6 + 11, NO_EVENT, 12 * 6, NOTE_OFF, 12 * 6 + 7, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody transposed zero half steps. 1 octave range.
+    events = [12 * 4 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 6, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.transpose(transpose_amount=0, min_note=12 * 5, max_note=12 * 6)
+    expected = [12 * 5 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 5, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+  def testSquash(self):
+    # Melody in C, transposed to C, and squashed to 1 octave.
+    events = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+    # Melody in D, transposed to C, and squashed to 1 octave.
+    events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 5 + 1]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 5, 12 * 5 + 4, 12 * 5 + 11]
+    self.assertEqual(expected, list(melody))
+
+    # Melody in D, transposed to E, and squashed to 1 octave.
+    events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 4 + 11]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=4)
+    expected = [12 * 5 + 4, 12 * 5 + 6, 12 * 5 + 9, 12 * 5 + 8, 12 * 5 + 1]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashCenterOctaves(self):
+    # Move up an octave.
+    events = [12 * 4, NO_EVENT, 12 * 4 + 2, NOTE_OFF, 12 * 4 + 4, NO_EVENT,
+              12 * 4 + 5, 12 * 5 + 2, 12 * 4 - 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+                12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+    self.assertEqual(expected, list(melody))
+
+    # Move down an octave.
+    events = [12 * 6, NO_EVENT, 12 * 6 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT,
+              12 * 6 + 5, 12 * 7 + 2, 12 * 6 - 1, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+                12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashMaxNote(self):
+    events = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 6,
+              12 * 6 + 1]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+    expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 5,
+                12 * 5 + 1]
+    self.assertEqual(expected, list(melody))
+
+  def testSquashAllNotesOff(self):
+    events = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+    self.assertEqual(events, list(melody))
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0)
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0)
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(14, melody.steps_per_bar)
+
+  def testFromNotesPolyphonic(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.0, 0.50)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+      melody.from_quantized_sequence(quantized_sequence,
+                                     search_start_step=0, instrument=0,
+                                     ignore_polyphonic_notes=False)
+    self.assertFalse(list(melody))
+
+  def testFromNotesPolyphonicWithIgnorePolyphonicNotes(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 2.0), (19, 100, 0.0, 3.0),
+         (12, 100, 1.0, 3.0), (19, 100, 1.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=True)
+    expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11)
+
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromNotesChord(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 1.25), (19, 100, 1, 1.25),
+         (20, 100, 1, 1.25), (25, 100, 1, 1.25)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+      melody.from_quantized_sequence(quantized_sequence,
+                                     search_start_step=0, instrument=0,
+                                     ignore_polyphonic_notes=False)
+    self.assertFalse(list(melody))
+
+  def testFromNotesTrimEmptyMeasures(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12,
+                NOTE_OFF, 11]
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
+
+  def testFromNotesTimeOverlap(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 3.25, 3.75),
+         (13, 100, 2, 4)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12, NO_EVENT, NO_EVENT,
+                NO_EVENT, 13, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 11,
+                NO_EVENT]
+    self.assertEqual(expected, list(melody))
+
+  def testFromNotesStepsPerBar(self):
+    self.note_sequence.time_signatures[0].numerator = 7
+    self.note_sequence.time_signatures[0].denominator = 8
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=12)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    self.assertEqual(42, melody.steps_per_bar)
+
+  def testFromNotesStartAndEndStep(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+         (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=18, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, 14, NOTE_OFF, 15, NO_EVENT, NO_EVENT, NO_EVENT,
+                NO_EVENT, NO_EVENT]
+    self.assertEqual(expected, list(melody))
+    self.assertEqual(34, melody.start_step)
+    self.assertEqual(43, melody.end_step)
+
+  def testSetLength(self):
+    events = [60]
+    melody = melodies_lib.Melody(events, start_step=9)
+    melody.set_length(5)
+    self.assertListEqual([60, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
+                         list(melody))
+    self.assertEqual(9, melody.start_step)
+    self.assertEqual(14, melody.end_step)
+
+    melody = melodies_lib.Melody(events, start_step=9)
+    melody.set_length(5, from_left=True)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 60],
+                         list(melody))
+    self.assertEqual(5, melody.start_step)
+    self.assertEqual(10, melody.end_step)
+
+    events = [60, NO_EVENT, NO_EVENT, NOTE_OFF]
+    melody = melodies_lib.Melody(events)
+    melody.set_length(3)
+    self.assertListEqual([60, NO_EVENT, NO_EVENT], list(melody))
+    self.assertEqual(0, melody.start_step)
+    self.assertEqual(3, melody.end_step)
+
+    melody = melodies_lib.Melody(events)
+    melody.set_length(3, from_left=True)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NOTE_OFF], list(melody))
+    self.assertEqual(1, melody.start_step)
+    self.assertEqual(4, melody.end_step)
+
+  def testToSequenceSimple(self):
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+    sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 3.75 &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 1 velocity: 10 instrument: 1 start_time: 2.25 end_time: 2.75 &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 2 velocity: 10 instrument: 1 start_time: 3.25 end_time: 3.5 &#39;
+        &#39;&gt; &#39;
+        &#39;notes &lt; &#39;
+        &#39;  pitch: 3 velocity: 10 instrument: 1 start_time: 3.5 end_time: 3.75 &#39;
+        &#39;&gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithSustainedNote(self):
+    melody = melodies_lib.Melody(
+        [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NO_EVENT, NO_EVENT])
+    sequence = melody.to_sequence(
+        velocity=100,
+        instrument=0,
+        sequence_start_time=0,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.25 &#39;
+        &#39;notes &lt; pitch: 1 velocity: 100 start_time: 0.25 end_time: 0.75 &gt; &#39;
+        &#39;notes &lt; pitch: 2 velocity: 100 start_time: 1.25 end_time: 1.5 &gt; &#39;
+        &#39;notes &lt; pitch: 3 velocity: 100 start_time: 1.5 end_time: 2.25 &gt; &#39;,
+        sequence)
+
+  def testToSequenceEndsWithNonzeroStart(self):
+    melody = melodies_lib.Melody([NO_EVENT, 1, NO_EVENT], start_step=4)
+    sequence = melody.to_sequence(
+        velocity=100,
+        instrument=0,
+        sequence_start_time=0.5,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+        &#39;total_time: 2.25 &#39;
+        &#39;notes &lt; pitch: 1 velocity: 100 start_time: 1.75 end_time: 2.25 &gt; &#39;,
+        sequence)
+
+  def testToSequenceEmpty(self):
+    melody = melodies_lib.Melody()
+    sequence = melody.to_sequence(
+        velocity=10,
+        instrument=1,
+        sequence_start_time=2,
+        qpm=60.0)
+
+    self.assertProtoEquals(
+        &#39;ticks_per_quarter: 220 &#39;
+        &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+        sequence)
+
+  def testMidiFileToMelody(self):
+    filename = os.path.join(testing_lib.get_testdata_dir(), &#39;melody.mid&#39;)
+    melody = melodies_lib.midi_file_to_melody(filename)
+    expected = melodies_lib.Melody([60, 62, 64, 66, 68, 70,
+                                    72, 70, 68, 66, 64, 62])
+    self.assertEqual(expected, melody)
+
+  def testSlice(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1, 3), (11, 100, 5, 7), (13, 100, 9, 10)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+
+    melody = melodies_lib.Melody()
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+    expected = [NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11, NO_EVENT,
+                NOTE_OFF, NO_EVENT, 13]
+    self.assertEqual(expected, list(melody))
+
+    expected_slice = [NO_EVENT, NO_EVENT, NO_EVENT, 11, NO_EVENT, NOTE_OFF,
+                      NO_EVENT]
+    self.assertEqual(expected_slice, list(melody[2:-1]))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesChord"><code class="name flex">
+<span>def <span class="ident">testFromNotesChord</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesChord(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1, 1.25), (19, 100, 1, 1.25),
+       (20, 100, 1, 1.25), (25, 100, 1, 1.25)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+  self.assertFalse(list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonic"><code class="name flex">
+<span>def <span class="ident">testFromNotesPolyphonic</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesPolyphonic(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.0, 10.0), (11, 55, 0.0, 0.50)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  with self.assertRaises(melodies_lib.PolyphonicMelodyError):
+    melody.from_quantized_sequence(quantized_sequence,
+                                   search_start_step=0, instrument=0,
+                                   ignore_polyphonic_notes=False)
+  self.assertFalse(list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonicWithIgnorePolyphonicNotes"><code class="name flex">
+<span>def <span class="ident">testFromNotesPolyphonicWithIgnorePolyphonicNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesPolyphonicWithIgnorePolyphonicNotes(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.0, 2.0), (19, 100, 0.0, 3.0),
+       (12, 100, 1.0, 3.0), (19, 100, 1.0, 4.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0,
+                                 ignore_polyphonic_notes=True)
+  expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11)
+
+  self.assertEqual(expected, list(melody))
+  self.assertEqual(16, melody.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStartAndEndStep"><code class="name flex">
+<span>def <span class="ident">testFromNotesStartAndEndStep</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesStartAndEndStep(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1, 2), (11, 100, 2.25, 2.5), (13, 100, 3.25, 3.75),
+       (14, 100, 8.75, 9), (15, 100, 9.25, 10.75)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=18, instrument=0,
+                                 ignore_polyphonic_notes=False)
+  expected = [NO_EVENT, 14, NOTE_OFF, 15, NO_EVENT, NO_EVENT, NO_EVENT,
+              NO_EVENT, NO_EVENT]
+  self.assertEqual(expected, list(melody))
+  self.assertEqual(34, melody.start_step)
+  self.assertEqual(43, melody.end_step)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStepsPerBar"><code class="name flex">
+<span>def <span class="ident">testFromNotesStepsPerBar</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesStepsPerBar(self):
+  self.note_sequence.time_signatures[0].numerator = 7
+  self.note_sequence.time_signatures[0].denominator = 8
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=12)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0,
+                                 ignore_polyphonic_notes=False)
+  self.assertEqual(42, melody.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTimeOverlap"><code class="name flex">
+<span>def <span class="ident">testFromNotesTimeOverlap</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesTimeOverlap(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1, 2), (11, 100, 3.25, 3.75),
+       (13, 100, 2, 4)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0,
+                                 ignore_polyphonic_notes=False)
+  expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12, NO_EVENT, NO_EVENT,
+              NO_EVENT, 13, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 11,
+              NO_EVENT]
+  self.assertEqual(expected, list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTrimEmptyMeasures"><code class="name flex">
+<span>def <span class="ident">testFromNotesTrimEmptyMeasures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNotesTrimEmptyMeasures(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1.5, 1.75), (11, 100, 2, 2.25)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0,
+                                 ignore_polyphonic_notes=False)
+  expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12,
+              NOTE_OFF, 11]
+  self.assertEqual(expected, list(melody))
+  self.assertEqual(16, melody.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0)
+  expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+               NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+               NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+  self.assertEqual(expected, list(melody))
+  self.assertEqual(16, melody.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceNotCommonTimeSig</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceNotCommonTimeSig(self):
+  self.note_sequence.time_signatures[0].numerator = 7
+  self.note_sequence.time_signatures[0].denominator = 8
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0)
+  expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+               NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+               NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
+  self.assertEqual(expected, list(melody))
+  self.assertEqual(14, melody.steps_per_bar)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testGetKeyHistogram"><code class="name flex">
+<span>def <span class="ident">testGetKeyHistogram</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetKeyHistogram(self):
+  # One C.
+  events = [NO_EVENT, 12 * 5, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  expected = [1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0]
+  self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+  # One C and one C#.
+  events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  expected = [1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1]
+  self.assertListEqual(expected, list(melody.get_major_key_histogram()))
+
+  # One C, one C#, and one D.
+  events = [NO_EVENT, 12 * 5, NOTE_OFF, 12 * 7 + 1, NO_EVENT, 12 * 9 + 2]
+  melody = melodies_lib.Melody(events)
+  expected = [2, 2, 2, 2, 1, 2, 1, 2, 2, 2, 2, 1]
+  self.assertListEqual(expected, list(melody.get_major_key_histogram()))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testGetMajorKey"><code class="name flex">
+<span>def <span class="ident">testGetMajorKey</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetMajorKey(self):
+  # D Major.
+  events = [NO_EVENT, 12 * 2 + 2, 12 * 3 + 4, 12 * 5 + 1, 12 * 6 + 6,
+            12 * 4 + 11, 12 * 3 + 9, 12 * 5 + 7, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  self.assertEqual(2, melody.get_major_key())
+
+  # C# Major with accidentals.
+  events = [NO_EVENT, 12 * 2 + 1, 12 * 4 + 8, 12 * 5 + 5, 12 * 6 + 6,
+            12 * 3 + 3, 12 * 2 + 11, 12 * 3 + 10, 12 * 5, 12 * 2 + 8,
+            12 * 4 + 1, 12 * 3 + 5, 12 * 5 + 9, 12 * 4 + 3, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  self.assertEqual(1, melody.get_major_key())
+
+  # One note in C Major.
+  events = [NO_EVENT, 12 * 2 + 11, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  self.assertEqual(0, melody.get_major_key())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testGetNoteHistogram"><code class="name flex">
+<span>def <span class="ident">testGetNoteHistogram</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetNoteHistogram(self):
+  events = [NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 5 + 11, 12 * 6 + 3,
+            12 * 4 + 11]
+  melody = melodies_lib.Melody(events)
+  expected = [1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+  self.assertEqual(expected, list(melody.get_note_histogram()))
+
+  events = [0, 1, NO_EVENT, NOTE_OFF, 12 * 2 + 1, 12 * 3, 12 * 6 + 3,
+            12 * 5 + 11, NO_EVENT, 12 * 4 + 11, 12 * 7 + 1]
+  melody = melodies_lib.Melody(events)
+  expected = [2, 3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]
+  self.assertEqual(expected, list(melody.get_note_histogram()))
+
+  melody = melodies_lib.Melody()
+  expected = [0] * 12
+  self.assertEqual(expected, list(melody.get_note_histogram()))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testMidiFileToMelody"><code class="name flex">
+<span>def <span class="ident">testMidiFileToMelody</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMidiFileToMelody(self):
+  filename = os.path.join(testing_lib.get_testdata_dir(), &#39;melody.mid&#39;)
+  melody = melodies_lib.midi_file_to_melody(filename)
+  expected = melodies_lib.Melody([60, 62, 64, 66, 68, 70,
+                                  72, 70, 68, 66, 64, 62])
+  self.assertEqual(expected, melody)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSetLength"><code class="name flex">
+<span>def <span class="ident">testSetLength</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLength(self):
+  events = [60]
+  melody = melodies_lib.Melody(events, start_step=9)
+  melody.set_length(5)
+  self.assertListEqual([60, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
+                       list(melody))
+  self.assertEqual(9, melody.start_step)
+  self.assertEqual(14, melody.end_step)
+
+  melody = melodies_lib.Melody(events, start_step=9)
+  melody.set_length(5, from_left=True)
+  self.assertListEqual([NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 60],
+                       list(melody))
+  self.assertEqual(5, melody.start_step)
+  self.assertEqual(10, melody.end_step)
+
+  events = [60, NO_EVENT, NO_EVENT, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  melody.set_length(3)
+  self.assertListEqual([60, NO_EVENT, NO_EVENT], list(melody))
+  self.assertEqual(0, melody.start_step)
+  self.assertEqual(3, melody.end_step)
+
+  melody = melodies_lib.Melody(events)
+  melody.set_length(3, from_left=True)
+  self.assertListEqual([NO_EVENT, NO_EVENT, NOTE_OFF], list(melody))
+  self.assertEqual(1, melody.start_step)
+  self.assertEqual(4, melody.end_step)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSlice"><code class="name flex">
+<span>def <span class="ident">testSlice</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSlice(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1, 3), (11, 100, 5, 7), (13, 100, 9, 10)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=1)
+
+  melody = melodies_lib.Melody()
+  melody.from_quantized_sequence(quantized_sequence,
+                                 search_start_step=0, instrument=0,
+                                 ignore_polyphonic_notes=False)
+  expected = [NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11, NO_EVENT,
+              NOTE_OFF, NO_EVENT, 13]
+  self.assertEqual(expected, list(melody))
+
+  expected_slice = [NO_EVENT, NO_EVENT, NO_EVENT, 11, NO_EVENT, NOTE_OFF,
+                    NO_EVENT]
+  self.assertEqual(expected_slice, list(melody[2:-1]))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSquash"><code class="name flex">
+<span>def <span class="ident">testSquash</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSquash(self):
+  # Melody in C, transposed to C, and squashed to 1 octave.
+  events = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+  expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT]
+  self.assertEqual(expected, list(melody))
+
+  # Melody in D, transposed to C, and squashed to 1 octave.
+  events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 5 + 1]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+  expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 5, 12 * 5 + 4, 12 * 5 + 11]
+  self.assertEqual(expected, list(melody))
+
+  # Melody in D, transposed to E, and squashed to 1 octave.
+  events = [12 * 5 + 2, 12 * 5 + 4, 12 * 6 + 7, 12 * 6 + 6, 12 * 4 + 11]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=4)
+  expected = [12 * 5 + 4, 12 * 5 + 6, 12 * 5 + 9, 12 * 5 + 8, 12 * 5 + 1]
+  self.assertEqual(expected, list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSquashAllNotesOff"><code class="name flex">
+<span>def <span class="ident">testSquashAllNotesOff</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSquashAllNotesOff(self):
+  events = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+  self.assertEqual(events, list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSquashCenterOctaves"><code class="name flex">
+<span>def <span class="ident">testSquashCenterOctaves</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSquashCenterOctaves(self):
+  # Move up an octave.
+  events = [12 * 4, NO_EVENT, 12 * 4 + 2, NOTE_OFF, 12 * 4 + 4, NO_EVENT,
+            12 * 4 + 5, 12 * 5 + 2, 12 * 4 - 1, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+  expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+              12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+  self.assertEqual(expected, list(melody))
+
+  # Move down an octave.
+  events = [12 * 6, NO_EVENT, 12 * 6 + 2, NOTE_OFF, 12 * 6 + 4, NO_EVENT,
+            12 * 6 + 5, 12 * 7 + 2, 12 * 6 - 1, NOTE_OFF]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 4, max_note=12 * 7, transpose_to_key=0)
+  expected = [12 * 5, NO_EVENT, 12 * 5 + 2, NOTE_OFF, 12 * 5 + 4, NO_EVENT,
+              12 * 5 + 5, 12 * 6 + 2, 12 * 5 - 1, NOTE_OFF]
+  self.assertEqual(expected, list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testSquashMaxNote"><code class="name flex">
+<span>def <span class="ident">testSquashMaxNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSquashMaxNote(self):
+  events = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 6,
+            12 * 6 + 1]
+  melody = melodies_lib.Melody(events)
+  melody.squash(min_note=12 * 5, max_note=12 * 6, transpose_to_key=0)
+  expected = [12 * 5, 12 * 5 + 2, 12 * 5 + 4, 12 * 5 + 5, 12 * 5 + 11, 12 * 5,
+              12 * 5 + 1]
+  self.assertEqual(expected, list(melody))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEmpty"><code class="name flex">
+<span>def <span class="ident">testToSequenceEmpty</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceEmpty(self):
+  melody = melodies_lib.Melody()
+  sequence = melody.to_sequence(
+      velocity=10,
+      instrument=1,
+      sequence_start_time=2,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithNonzeroStart"><code class="name flex">
+<span>def <span class="ident">testToSequenceEndsWithNonzeroStart</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceEndsWithNonzeroStart(self):
+  melody = melodies_lib.Melody([NO_EVENT, 1, NO_EVENT], start_step=4)
+  sequence = melody.to_sequence(
+      velocity=100,
+      instrument=0,
+      sequence_start_time=0.5,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;total_time: 2.25 &#39;
+      &#39;notes &lt; pitch: 1 velocity: 100 start_time: 1.75 end_time: 2.25 &gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithSustainedNote"><code class="name flex">
+<span>def <span class="ident">testToSequenceEndsWithSustainedNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceEndsWithSustainedNote(self):
+  melody = melodies_lib.Melody(
+      [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NO_EVENT, NO_EVENT])
+  sequence = melody.to_sequence(
+      velocity=100,
+      instrument=0,
+      sequence_start_time=0,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;total_time: 2.25 &#39;
+      &#39;notes &lt; pitch: 1 velocity: 100 start_time: 0.25 end_time: 0.75 &gt; &#39;
+      &#39;notes &lt; pitch: 2 velocity: 100 start_time: 1.25 end_time: 1.5 &gt; &#39;
+      &#39;notes &lt; pitch: 3 velocity: 100 start_time: 1.5 end_time: 2.25 &gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceSimple"><code class="name flex">
+<span>def <span class="ident">testToSequenceSimple</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceSimple(self):
+  melody = melodies_lib.Melody(
+      [NO_EVENT, 1, NO_EVENT, NOTE_OFF, NO_EVENT, 2, 3, NOTE_OFF, NO_EVENT])
+  sequence = melody.to_sequence(
+      velocity=10,
+      instrument=1,
+      sequence_start_time=2,
+      qpm=60.0)
+
+  self.assertProtoEquals(
+      &#39;ticks_per_quarter: 220 &#39;
+      &#39;tempos &lt; qpm: 60.0 &gt; &#39;
+      &#39;total_time: 3.75 &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 1 velocity: 10 instrument: 1 start_time: 2.25 end_time: 2.75 &#39;
+      &#39;&gt; &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 2 velocity: 10 instrument: 1 start_time: 3.25 end_time: 3.5 &#39;
+      &#39;&gt; &#39;
+      &#39;notes &lt; &#39;
+      &#39;  pitch: 3 velocity: 10 instrument: 1 start_time: 3.5 end_time: 3.75 &#39;
+      &#39;&gt; &#39;,
+      sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melodies_lib_test.MelodiesLibTest.testTranspose"><code class="name flex">
+<span>def <span class="ident">testTranspose</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTranspose(self):
+  # Melody transposed down 5 half steps. 2 octave range.
+  events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.transpose(transpose_amount=-5, min_note=12 * 5, max_note=12 * 7)
+  expected = [12 * 5 + 11, NO_EVENT, 12 * 5, NOTE_OFF, 12 * 5 + 7, NO_EVENT]
+  self.assertEqual(expected, list(melody))
+
+  # Melody transposed up 19 half steps. 2 octave range.
+  events = [12 * 5 + 4, NO_EVENT, 12 * 5 + 5, NOTE_OFF, 12 * 6, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.transpose(transpose_amount=19, min_note=12 * 5, max_note=12 * 7)
+  expected = [12 * 6 + 11, NO_EVENT, 12 * 6, NOTE_OFF, 12 * 6 + 7, NO_EVENT]
+  self.assertEqual(expected, list(melody))
+
+  # Melody transposed zero half steps. 1 octave range.
+  events = [12 * 4 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 6, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.transpose(transpose_amount=0, min_note=12 * 5, max_note=12 * 6)
+  expected = [12 * 5 + 11, 12 * 5, 12 * 5 + 11, NOTE_OFF, 12 * 5, NO_EVENT]
+  self.assertEqual(expected, list(melody))</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melodies_lib_test.MelodiesLibTest" href="#note_seq.melodies_lib_test.MelodiesLibTest">MelodiesLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesChord" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesChord">testFromNotesChord</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonic" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonic">testFromNotesPolyphonic</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonicWithIgnorePolyphonicNotes" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesPolyphonicWithIgnorePolyphonicNotes">testFromNotesPolyphonicWithIgnorePolyphonicNotes</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStartAndEndStep" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStartAndEndStep">testFromNotesStartAndEndStep</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStepsPerBar" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesStepsPerBar">testFromNotesStepsPerBar</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTimeOverlap" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTimeOverlap">testFromNotesTimeOverlap</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTrimEmptyMeasures" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromNotesTrimEmptyMeasures">testFromNotesTrimEmptyMeasures</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequence" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequence">testFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig" href="#note_seq.melodies_lib_test.MelodiesLibTest.testFromQuantizedNoteSequenceNotCommonTimeSig">testFromQuantizedNoteSequenceNotCommonTimeSig</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testGetKeyHistogram" href="#note_seq.melodies_lib_test.MelodiesLibTest.testGetKeyHistogram">testGetKeyHistogram</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testGetMajorKey" href="#note_seq.melodies_lib_test.MelodiesLibTest.testGetMajorKey">testGetMajorKey</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testGetNoteHistogram" href="#note_seq.melodies_lib_test.MelodiesLibTest.testGetNoteHistogram">testGetNoteHistogram</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testMidiFileToMelody" href="#note_seq.melodies_lib_test.MelodiesLibTest.testMidiFileToMelody">testMidiFileToMelody</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSetLength" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSetLength">testSetLength</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSlice" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSlice">testSlice</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSquash" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSquash">testSquash</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSquashAllNotesOff" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSquashAllNotesOff">testSquashAllNotesOff</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSquashCenterOctaves" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSquashCenterOctaves">testSquashCenterOctaves</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testSquashMaxNote" href="#note_seq.melodies_lib_test.MelodiesLibTest.testSquashMaxNote">testSquashMaxNote</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEmpty" href="#note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEmpty">testToSequenceEmpty</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithNonzeroStart" href="#note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithNonzeroStart">testToSequenceEndsWithNonzeroStart</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithSustainedNote" href="#note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceEndsWithSustainedNote">testToSequenceEndsWithSustainedNote</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceSimple" href="#note_seq.melodies_lib_test.MelodiesLibTest.testToSequenceSimple">testToSequenceSimple</a></code></li>
+<li><code><a title="note_seq.melodies_lib_test.MelodiesLibTest.testTranspose" href="#note_seq.melodies_lib_test.MelodiesLibTest.testTranspose">testTranspose</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melody_encoder_decoder.html
+++ b/docs/melody_encoder_decoder.html
@@ -1,0 +1,1212 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melody_encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between Melody objects and models inputs/outputs …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melody_encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between Melody objects and models inputs/outputs.</p>
+<p>MelodyOneHotEncoding is an encoder_decoder.OneHotEncoding that specifies a one-
+hot encoding for Melody events, i.e. MIDI pitch values plus note-off and no-
+event.</p>
+<p>KeyMelodyEncoderDecoder is an encoder_decoder.EventSequenceEncoderDecoder that
+specifies an encoding of Melody objects into input vectors and output labels for
+use by melody models.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between Melody objects and models inputs/outputs.
+
+MelodyOneHotEncoding is an encoder_decoder.OneHotEncoding that specifies a one-
+hot encoding for Melody events, i.e. MIDI pitch values plus note-off and no-
+event.
+
+KeyMelodyEncoderDecoder is an encoder_decoder.EventSequenceEncoderDecoder that
+specifies an encoding of Melody objects into input vectors and output labels for
+use by melody models.
+&#34;&#34;&#34;
+
+import collections
+
+from note_seq import constants
+from note_seq import encoder_decoder
+from note_seq import melodies_lib
+
+NUM_SPECIAL_MELODY_EVENTS = constants.NUM_SPECIAL_MELODY_EVENTS
+MELODY_NOTE_OFF = constants.MELODY_NOTE_OFF
+MELODY_NO_EVENT = constants.MELODY_NO_EVENT
+MIN_MIDI_PITCH = constants.MIN_MIDI_PITCH
+MAX_MIDI_PITCH = constants.MAX_MIDI_PITCH
+NOTES_PER_OCTAVE = constants.NOTES_PER_OCTAVE
+DEFAULT_STEPS_PER_BAR = constants.DEFAULT_STEPS_PER_BAR
+
+DEFAULT_LOOKBACK_DISTANCES = encoder_decoder.DEFAULT_LOOKBACK_DISTANCES
+
+
+class MelodyOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Basic one hot encoding for melody events.
+
+  Encodes melody events as follows:
+    0 = no event,
+    1 = note-off event,
+    [2, self.num_classes) = note-on event for that pitch relative to the
+        [self._min_note, self._max_note) range.
+  &#34;&#34;&#34;
+
+  def __init__(self, min_note, max_note):
+    &#34;&#34;&#34;Initializes a MelodyOneHotEncoding object.
+
+    Args:
+      min_note: The minimum midi pitch the encoded melody events can have.
+      max_note: The maximum midi pitch (exclusive) the encoded melody events
+          can have.
+
+    Raises:
+      ValueError: If `min_note` or `max_note` are outside the midi range, or if
+          `max_note` is not greater than `min_note`.
+    &#34;&#34;&#34;
+    if min_note &lt; MIN_MIDI_PITCH:
+      raise ValueError(&#39;min_note must be &gt;= 0. min_note is %d.&#39; % min_note)
+    if max_note &gt; MAX_MIDI_PITCH + 1:
+      raise ValueError(&#39;max_note must be &lt;= 128. max_note is %d.&#39; % max_note)
+    if max_note &lt;= min_note:
+      raise ValueError(&#39;max_note must be greater than min_note&#39;)
+
+    self._min_note = min_note
+    self._max_note = max_note
+
+  @property
+  def num_classes(self):
+    return self._max_note - self._min_note + NUM_SPECIAL_MELODY_EVENTS
+
+  @property
+  def default_event(self):
+    return MELODY_NO_EVENT
+
+  def encode_event(self, event):
+    &#34;&#34;&#34;Collapses a melody event value into a zero-based index range.
+
+    Args:
+      event: A Melody event value. -2 = no event, -1 = note-off event,
+          [0, 127] = note-on event for that midi pitch.
+
+    Returns:
+      An int in the range [0, self.num_classes). 0 = no event,
+      1 = note-off event, [2, self.num_classes) = note-on event for
+      that pitch relative to the [self._min_note, self._max_note) range.
+
+    Raises:
+      ValueError: If `event` is a MIDI note not between self._min_note and
+          self._max_note, or an invalid special event value.
+    &#34;&#34;&#34;
+    if event &lt; -NUM_SPECIAL_MELODY_EVENTS:
+      raise ValueError(&#39;invalid melody event value: %d&#39; % event)
+    if 0 &lt;= event &lt; self._min_note:
+      raise ValueError(&#39;melody event less than min note: %d &lt; %d&#39; % (
+          event, self._min_note))
+    if event &gt;= self._max_note:
+      raise ValueError(&#39;melody event greater than max note: %d &gt;= %d&#39; % (
+          event, self._max_note))
+
+    if event &lt; 0:
+      return event + NUM_SPECIAL_MELODY_EVENTS
+    return event - self._min_note + NUM_SPECIAL_MELODY_EVENTS
+
+  def decode_event(self, index):
+    &#34;&#34;&#34;Expands a zero-based index value to its equivalent melody event value.
+
+    Args:
+      index: An int in the range [0, self._num_model_events).
+          0 = no event, 1 = note-off event,
+          [2, self._num_model_events) = note-on event for that pitch relative
+          to the [self._min_note, self._max_note) range.
+
+    Returns:
+      A Melody event value. -2 = no event, -1 = note-off event,
+      [0, 127] = note-on event for that midi pitch.
+    &#34;&#34;&#34;
+    if index &lt; NUM_SPECIAL_MELODY_EVENTS:
+      return index - NUM_SPECIAL_MELODY_EVENTS
+    return index - NUM_SPECIAL_MELODY_EVENTS + self._min_note
+
+
+class KeyMelodyEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;A MelodyEncoderDecoder that encodes repeated events, time, and key.&#34;&#34;&#34;
+
+  def __init__(self, min_note, max_note, lookback_distances=None,
+               binary_counter_bits=7):
+    &#34;&#34;&#34;Initializes the KeyMelodyEncoderDecoder.
+
+    Args:
+      min_note: The minimum midi pitch the encoded melody events can have.
+      max_note: The maximum midi pitch (exclusive) the encoded melody events can
+          have.
+      lookback_distances: A list of step intervals to look back in history to
+          encode both the following event and whether the current step is a
+          repeat. If None, use default lookback distances.
+      binary_counter_bits: The number of input bits to use as a counter for the
+          metric position of the next note.
+    &#34;&#34;&#34;
+    if lookback_distances is None:
+      self._lookback_distances = DEFAULT_LOOKBACK_DISTANCES
+    else:
+      self._lookback_distances = lookback_distances
+    self._binary_counter_bits = binary_counter_bits
+    self._min_note = min_note
+    self._note_range = max_note - min_note
+
+  @property
+  def input_size(self):
+    return (self._note_range +                # current note
+            2 +                               # note vs. silence
+            1 +                               # attack or not
+            1 +                               # ascending or not
+            len(self._lookback_distances) +   # whether note matches lookbacks
+            self._binary_counter_bits +       # binary counters
+            1 +                               # start of bar or not
+            NOTES_PER_OCTAVE +                # total key estimate
+            NOTES_PER_OCTAVE)                 # recent key estimate
+
+  @property
+  def num_classes(self):
+    return (self._note_range + NUM_SPECIAL_MELODY_EVENTS +
+            len(self._lookback_distances))
+
+  @property
+  def default_event_label(self):
+    return self._note_range
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the melody.
+
+    Returns a self.input_size length list of floats. Assuming
+    self._min_note = 48, self._note_range = 36, two lookback distances, and
+    seven binary counters, then self.input_size = 74. Each index represents a
+    different input signal to the model.
+
+    Indices [0, 73]:
+    [0, 35]: A note is playing at that pitch [48, 84).
+    36: Any note is playing.
+    37: Silence is playing.
+    38: The current event is the note-on event of the currently playing note.
+    39: Whether the melody is currently ascending or descending.
+    40: The last event is repeating (first lookback distance).
+    41: The last event is repeating (second lookback distance).
+    [42, 48]: Time keeping toggles.
+    49: The next event is the start of a bar.
+    [50, 61]: The keys the current melody is in.
+    [62, 73]: The keys the last 3 notes are in.
+    Args:
+      events: A note_seq.Melody object.
+      position: An integer event position in the melody.
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    current_note = None
+    is_attack = False
+    is_ascending = None
+    last_3_notes = collections.deque(maxlen=3)
+    sub_melody = melodies_lib.Melody(events[:position + 1])
+    for note in sub_melody:
+      if note == MELODY_NO_EVENT:
+        is_attack = False
+      elif note == MELODY_NOTE_OFF:
+        current_note = None
+      else:
+        is_attack = True
+        current_note = note
+        if last_3_notes:
+          if note &gt; last_3_notes[-1]:
+            is_ascending = True
+          if note &lt; last_3_notes[-1]:
+            is_ascending = False
+        if note in last_3_notes:
+          last_3_notes.remove(note)
+        last_3_notes.append(note)
+
+    input_ = [0.0] * self.input_size
+    offset = 0
+    if current_note:
+      # The pitch of current note if a note is playing.
+      input_[offset + current_note - self._min_note] = 1.0
+      # A note is playing.
+      input_[offset + self._note_range] = 1.0
+    else:
+      # Silence is playing.
+      input_[offset + self._note_range + 1] = 1.0
+    offset += self._note_range + 2
+
+    # The current event is the note-on event of the currently playing note.
+    if is_attack:
+      input_[offset] = 1.0
+    offset += 1
+
+    # Whether the melody is currently ascending or descending.
+    if is_ascending is not None:
+      input_[offset] = 1.0 if is_ascending else -1.0
+    offset += 1
+
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        input_[offset] = 1.0
+      offset += 1
+
+    # Binary time counter giving the metric location of the *next* note.
+    n = len(sub_melody)
+    for i in range(self._binary_counter_bits):
+      input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+      offset += 1
+
+    # The next event is the start of a bar.
+    if len(sub_melody) % DEFAULT_STEPS_PER_BAR == 0:
+      input_[offset] = 1.0
+    offset += 1
+
+    # The keys the current melody is in.
+    key_histogram = sub_melody.get_major_key_histogram()
+    max_val = max(key_histogram)
+    for i, key_val in enumerate(key_histogram):
+      if key_val == max_val:
+        input_[offset] = 1.0
+      offset += 1
+
+    # The keys the last 3 notes are in.
+    last_3_note_melody = melodies_lib.Melody(list(last_3_notes))
+    key_histogram = last_3_note_melody.get_major_key_histogram()
+    max_val = max(key_histogram)
+    for i, key_val in enumerate(key_histogram):
+      if key_val == max_val:
+        input_[offset] = 1.0
+      offset += 1
+
+    assert offset == self.input_size
+
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the melody.
+
+    Returns an int in the range [0, self.num_classes). Assuming
+    self._min_note = 48, self._note_range = 36, and two lookback distances,
+    then self.num_classes = 40.
+    Values [0, 39]:
+    [0, 35]: Note-on event for midi pitch [48, 84).
+    36: No event.
+    37: Note-off event.
+    38: Repeat first lookback (takes precedence over above values).
+    39: Repeat second lookback (takes precedence over above values).
+
+    Args:
+      events: A note_seq.Melody object.
+      position: An integer event position in the melody.
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    if (position &lt; self._lookback_distances[-1] and
+        events[position] == MELODY_NO_EVENT):
+      return self._note_range + len(self._lookback_distances) + 1
+
+    # If the last event repeated N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        return self._note_range + 2 + i
+
+    # If last event was a note-off event.
+    if events[position] == MELODY_NOTE_OFF:
+      return self._note_range + 1
+
+    # If last event was a no event.
+    if events[position] == MELODY_NO_EVENT:
+      return self._note_range
+
+    # If last event was a note-on event, the pitch of that note.
+    return events[position] - self._min_note
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the melody event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An int in the range [0, self.num_classes).
+      events: The note_seq.Melody events list of the current melody.
+    Returns:
+      A note_seq.Melody event value.
+    &#34;&#34;&#34;
+    # Repeat N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      if class_index == self._note_range + 2 + i:
+        if len(events) &lt; lookback_distance:
+          return MELODY_NO_EVENT
+        return events[-lookback_distance]
+
+    # Note-off event.
+    if class_index == self._note_range + 1:
+      return MELODY_NOTE_OFF
+
+    # No event:
+    if class_index == self._note_range:
+      return MELODY_NO_EVENT
+
+    # Note-on event for that midi pitch.
+    return self._min_note + class_index</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">KeyMelodyEncoderDecoder</span></span>
+<span>(</span><span>min_note, max_note, lookback_distances=None, binary_counter_bits=7)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A MelodyEncoderDecoder that encodes repeated events, time, and key.</p>
+<p>Initializes the KeyMelodyEncoderDecoder.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>The minimum midi pitch the encoded melody events can have.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>The maximum midi pitch (exclusive) the encoded melody events can
+have.</dd>
+<dt><strong><code>lookback_distances</code></strong></dt>
+<dd>A list of step intervals to look back in history to
+encode both the following event and whether the current step is a
+repeat. If None, use default lookback distances.</dd>
+<dt><strong><code>binary_counter_bits</code></strong></dt>
+<dd>The number of input bits to use as a counter for the
+metric position of the next note.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class KeyMelodyEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;A MelodyEncoderDecoder that encodes repeated events, time, and key.&#34;&#34;&#34;
+
+  def __init__(self, min_note, max_note, lookback_distances=None,
+               binary_counter_bits=7):
+    &#34;&#34;&#34;Initializes the KeyMelodyEncoderDecoder.
+
+    Args:
+      min_note: The minimum midi pitch the encoded melody events can have.
+      max_note: The maximum midi pitch (exclusive) the encoded melody events can
+          have.
+      lookback_distances: A list of step intervals to look back in history to
+          encode both the following event and whether the current step is a
+          repeat. If None, use default lookback distances.
+      binary_counter_bits: The number of input bits to use as a counter for the
+          metric position of the next note.
+    &#34;&#34;&#34;
+    if lookback_distances is None:
+      self._lookback_distances = DEFAULT_LOOKBACK_DISTANCES
+    else:
+      self._lookback_distances = lookback_distances
+    self._binary_counter_bits = binary_counter_bits
+    self._min_note = min_note
+    self._note_range = max_note - min_note
+
+  @property
+  def input_size(self):
+    return (self._note_range +                # current note
+            2 +                               # note vs. silence
+            1 +                               # attack or not
+            1 +                               # ascending or not
+            len(self._lookback_distances) +   # whether note matches lookbacks
+            self._binary_counter_bits +       # binary counters
+            1 +                               # start of bar or not
+            NOTES_PER_OCTAVE +                # total key estimate
+            NOTES_PER_OCTAVE)                 # recent key estimate
+
+  @property
+  def num_classes(self):
+    return (self._note_range + NUM_SPECIAL_MELODY_EVENTS +
+            len(self._lookback_distances))
+
+  @property
+  def default_event_label(self):
+    return self._note_range
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the melody.
+
+    Returns a self.input_size length list of floats. Assuming
+    self._min_note = 48, self._note_range = 36, two lookback distances, and
+    seven binary counters, then self.input_size = 74. Each index represents a
+    different input signal to the model.
+
+    Indices [0, 73]:
+    [0, 35]: A note is playing at that pitch [48, 84).
+    36: Any note is playing.
+    37: Silence is playing.
+    38: The current event is the note-on event of the currently playing note.
+    39: Whether the melody is currently ascending or descending.
+    40: The last event is repeating (first lookback distance).
+    41: The last event is repeating (second lookback distance).
+    [42, 48]: Time keeping toggles.
+    49: The next event is the start of a bar.
+    [50, 61]: The keys the current melody is in.
+    [62, 73]: The keys the last 3 notes are in.
+    Args:
+      events: A note_seq.Melody object.
+      position: An integer event position in the melody.
+    Returns:
+      An input vector, an self.input_size length list of floats.
+    &#34;&#34;&#34;
+    current_note = None
+    is_attack = False
+    is_ascending = None
+    last_3_notes = collections.deque(maxlen=3)
+    sub_melody = melodies_lib.Melody(events[:position + 1])
+    for note in sub_melody:
+      if note == MELODY_NO_EVENT:
+        is_attack = False
+      elif note == MELODY_NOTE_OFF:
+        current_note = None
+      else:
+        is_attack = True
+        current_note = note
+        if last_3_notes:
+          if note &gt; last_3_notes[-1]:
+            is_ascending = True
+          if note &lt; last_3_notes[-1]:
+            is_ascending = False
+        if note in last_3_notes:
+          last_3_notes.remove(note)
+        last_3_notes.append(note)
+
+    input_ = [0.0] * self.input_size
+    offset = 0
+    if current_note:
+      # The pitch of current note if a note is playing.
+      input_[offset + current_note - self._min_note] = 1.0
+      # A note is playing.
+      input_[offset + self._note_range] = 1.0
+    else:
+      # Silence is playing.
+      input_[offset + self._note_range + 1] = 1.0
+    offset += self._note_range + 2
+
+    # The current event is the note-on event of the currently playing note.
+    if is_attack:
+      input_[offset] = 1.0
+    offset += 1
+
+    # Whether the melody is currently ascending or descending.
+    if is_ascending is not None:
+      input_[offset] = 1.0 if is_ascending else -1.0
+    offset += 1
+
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(self._lookback_distances):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        input_[offset] = 1.0
+      offset += 1
+
+    # Binary time counter giving the metric location of the *next* note.
+    n = len(sub_melody)
+    for i in range(self._binary_counter_bits):
+      input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+      offset += 1
+
+    # The next event is the start of a bar.
+    if len(sub_melody) % DEFAULT_STEPS_PER_BAR == 0:
+      input_[offset] = 1.0
+    offset += 1
+
+    # The keys the current melody is in.
+    key_histogram = sub_melody.get_major_key_histogram()
+    max_val = max(key_histogram)
+    for i, key_val in enumerate(key_histogram):
+      if key_val == max_val:
+        input_[offset] = 1.0
+      offset += 1
+
+    # The keys the last 3 notes are in.
+    last_3_note_melody = melodies_lib.Melody(list(last_3_notes))
+    key_histogram = last_3_note_melody.get_major_key_histogram()
+    max_val = max(key_histogram)
+    for i, key_val in enumerate(key_histogram):
+      if key_val == max_val:
+        input_[offset] = 1.0
+      offset += 1
+
+    assert offset == self.input_size
+
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the melody.
+
+    Returns an int in the range [0, self.num_classes). Assuming
+    self._min_note = 48, self._note_range = 36, and two lookback distances,
+    then self.num_classes = 40.
+    Values [0, 39]:
+    [0, 35]: Note-on event for midi pitch [48, 84).
+    36: No event.
+    37: Note-off event.
+    38: Repeat first lookback (takes precedence over above values).
+    39: Repeat second lookback (takes precedence over above values).
+
+    Args:
+      events: A note_seq.Melody object.
+      position: An integer event position in the melody.
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    if (position &lt; self._lookback_distances[-1] and
+        events[position] == MELODY_NO_EVENT):
+      return self._note_range + len(self._lookback_distances) + 1
+
+    # If the last event repeated N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      lookback_position = position - lookback_distance
+      if (lookback_position &gt;= 0 and
+          events[position] == events[lookback_position]):
+        return self._note_range + 2 + i
+
+    # If last event was a note-off event.
+    if events[position] == MELODY_NOTE_OFF:
+      return self._note_range + 1
+
+    # If last event was a no event.
+    if events[position] == MELODY_NO_EVENT:
+      return self._note_range
+
+    # If last event was a note-on event, the pitch of that note.
+    return events[position] - self._min_note
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the melody event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An int in the range [0, self.num_classes).
+      events: The note_seq.Melody events list of the current melody.
+    Returns:
+      A note_seq.Melody event value.
+    &#34;&#34;&#34;
+    # Repeat N bars ago.
+    for i, lookback_distance in reversed(
+        list(enumerate(self._lookback_distances))):
+      if class_index == self._note_range + 2 + i:
+        if len(events) &lt; lookback_distance:
+          return MELODY_NO_EVENT
+        return events[-lookback_distance]
+
+    # Note-off event.
+    if class_index == self._note_range + 1:
+      return MELODY_NOTE_OFF
+
+    # No event:
+    if class_index == self._note_range:
+      return MELODY_NO_EVENT
+
+    # Note-on event for that midi pitch.
+    return self._min_note + class_index</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the melody event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An int in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>The note_seq.Melody events list of the current melody.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A note_seq.Melody event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the melody event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An int in the range [0, self.num_classes).
+    events: The note_seq.Melody events list of the current melody.
+  Returns:
+    A note_seq.Melody event value.
+  &#34;&#34;&#34;
+  # Repeat N bars ago.
+  for i, lookback_distance in reversed(
+      list(enumerate(self._lookback_distances))):
+    if class_index == self._note_range + 2 + i:
+      if len(events) &lt; lookback_distance:
+        return MELODY_NO_EVENT
+      return events[-lookback_distance]
+
+  # Note-off event.
+  if class_index == self._note_range + 1:
+    return MELODY_NOTE_OFF
+
+  # No event:
+  if class_index == self._note_range:
+    return MELODY_NO_EVENT
+
+  # Note-on event for that midi pitch.
+  return self._min_note + class_index</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the melody.</p>
+<p>Returns a self.input_size length list of floats. Assuming
+self._min_note = 48, self._note_range = 36, two lookback distances, and
+seven binary counters, then self.input_size = 74. Each index represents a
+different input signal to the model.</p>
+<p>Indices [0, 73]:
+[0, 35]: A note is playing at that pitch [48, 84).
+36: Any note is playing.
+37: Silence is playing.
+38: The current event is the note-on event of the currently playing note.
+39: Whether the melody is currently ascending or descending.
+40: The last event is repeating (first lookback distance).
+41: The last event is repeating (second lookback distance).
+[42, 48]: Time keeping toggles.
+49: The next event is the start of a bar.
+[50, 61]: The keys the current melody is in.
+[62, 73]: The keys the last 3 notes are in.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A note_seq.Melody object.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the melody.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, an self.input_size length list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the melody.
+
+  Returns a self.input_size length list of floats. Assuming
+  self._min_note = 48, self._note_range = 36, two lookback distances, and
+  seven binary counters, then self.input_size = 74. Each index represents a
+  different input signal to the model.
+
+  Indices [0, 73]:
+  [0, 35]: A note is playing at that pitch [48, 84).
+  36: Any note is playing.
+  37: Silence is playing.
+  38: The current event is the note-on event of the currently playing note.
+  39: Whether the melody is currently ascending or descending.
+  40: The last event is repeating (first lookback distance).
+  41: The last event is repeating (second lookback distance).
+  [42, 48]: Time keeping toggles.
+  49: The next event is the start of a bar.
+  [50, 61]: The keys the current melody is in.
+  [62, 73]: The keys the last 3 notes are in.
+  Args:
+    events: A note_seq.Melody object.
+    position: An integer event position in the melody.
+  Returns:
+    An input vector, an self.input_size length list of floats.
+  &#34;&#34;&#34;
+  current_note = None
+  is_attack = False
+  is_ascending = None
+  last_3_notes = collections.deque(maxlen=3)
+  sub_melody = melodies_lib.Melody(events[:position + 1])
+  for note in sub_melody:
+    if note == MELODY_NO_EVENT:
+      is_attack = False
+    elif note == MELODY_NOTE_OFF:
+      current_note = None
+    else:
+      is_attack = True
+      current_note = note
+      if last_3_notes:
+        if note &gt; last_3_notes[-1]:
+          is_ascending = True
+        if note &lt; last_3_notes[-1]:
+          is_ascending = False
+      if note in last_3_notes:
+        last_3_notes.remove(note)
+      last_3_notes.append(note)
+
+  input_ = [0.0] * self.input_size
+  offset = 0
+  if current_note:
+    # The pitch of current note if a note is playing.
+    input_[offset + current_note - self._min_note] = 1.0
+    # A note is playing.
+    input_[offset + self._note_range] = 1.0
+  else:
+    # Silence is playing.
+    input_[offset + self._note_range + 1] = 1.0
+  offset += self._note_range + 2
+
+  # The current event is the note-on event of the currently playing note.
+  if is_attack:
+    input_[offset] = 1.0
+  offset += 1
+
+  # Whether the melody is currently ascending or descending.
+  if is_ascending is not None:
+    input_[offset] = 1.0 if is_ascending else -1.0
+  offset += 1
+
+  # Last event is repeating N bars ago.
+  for i, lookback_distance in enumerate(self._lookback_distances):
+    lookback_position = position - lookback_distance
+    if (lookback_position &gt;= 0 and
+        events[position] == events[lookback_position]):
+      input_[offset] = 1.0
+    offset += 1
+
+  # Binary time counter giving the metric location of the *next* note.
+  n = len(sub_melody)
+  for i in range(self._binary_counter_bits):
+    input_[offset] = 1.0 if (n // 2 ** i) % 2 else -1.0
+    offset += 1
+
+  # The next event is the start of a bar.
+  if len(sub_melody) % DEFAULT_STEPS_PER_BAR == 0:
+    input_[offset] = 1.0
+  offset += 1
+
+  # The keys the current melody is in.
+  key_histogram = sub_melody.get_major_key_histogram()
+  max_val = max(key_histogram)
+  for i, key_val in enumerate(key_histogram):
+    if key_val == max_val:
+      input_[offset] = 1.0
+    offset += 1
+
+  # The keys the last 3 notes are in.
+  last_3_note_melody = melodies_lib.Melody(list(last_3_notes))
+  key_histogram = last_3_note_melody.get_major_key_histogram()
+  max_val = max(key_histogram)
+  for i, key_val in enumerate(key_histogram):
+    if key_val == max_val:
+      input_[offset] = 1.0
+    offset += 1
+
+  assert offset == self.input_size
+
+  return input_</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the melody.</p>
+<p>Returns an int in the range [0, self.num_classes). Assuming
+self._min_note = 48, self._note_range = 36, and two lookback distances,
+then self.num_classes = 40.
+Values [0, 39]:
+[0, 35]: Note-on event for midi pitch [48, 84).
+36: No event.
+37: Note-off event.
+38: Repeat first lookback (takes precedence over above values).
+39: Repeat second lookback (takes precedence over above values).</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A note_seq.Melody object.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the melody.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the melody.
+
+  Returns an int in the range [0, self.num_classes). Assuming
+  self._min_note = 48, self._note_range = 36, and two lookback distances,
+  then self.num_classes = 40.
+  Values [0, 39]:
+  [0, 35]: Note-on event for midi pitch [48, 84).
+  36: No event.
+  37: Note-off event.
+  38: Repeat first lookback (takes precedence over above values).
+  39: Repeat second lookback (takes precedence over above values).
+
+  Args:
+    events: A note_seq.Melody object.
+    position: An integer event position in the melody.
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  if (position &lt; self._lookback_distances[-1] and
+      events[position] == MELODY_NO_EVENT):
+    return self._note_range + len(self._lookback_distances) + 1
+
+  # If the last event repeated N bars ago.
+  for i, lookback_distance in reversed(
+      list(enumerate(self._lookback_distances))):
+    lookback_position = position - lookback_distance
+    if (lookback_position &gt;= 0 and
+        events[position] == events[lookback_position]):
+      return self._note_range + 2 + i
+
+  # If last event was a note-off event.
+  if events[position] == MELODY_NOTE_OFF:
+    return self._note_range + 1
+
+  # If last event was a no event.
+  if events[position] == MELODY_NO_EVENT:
+    return self._note_range
+
+  # If last event was a note-on event, the pitch of that note.
+  return events[position] - self._min_note</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.melody_encoder_decoder.MelodyOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">MelodyOneHotEncoding</span></span>
+<span>(</span><span>min_note, max_note)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Basic one hot encoding for melody events.</p>
+<p>Encodes melody events as follows:
+0 = no event,
+1 = note-off event,
+[2, self.num_classes) = note-on event for that pitch relative to the
+[self._min_note, self._max_note) range.</p>
+<p>Initializes a MelodyOneHotEncoding object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>min_note</code></strong></dt>
+<dd>The minimum midi pitch the encoded melody events can have.</dd>
+<dt><strong><code>max_note</code></strong></dt>
+<dd>The maximum midi pitch (exclusive) the encoded melody events
+can have.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>min_note</code> or <code>max_note</code> are outside the midi range, or if
+<code>max_note</code> is not greater than <code>min_note</code>.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;Basic one hot encoding for melody events.
+
+  Encodes melody events as follows:
+    0 = no event,
+    1 = note-off event,
+    [2, self.num_classes) = note-on event for that pitch relative to the
+        [self._min_note, self._max_note) range.
+  &#34;&#34;&#34;
+
+  def __init__(self, min_note, max_note):
+    &#34;&#34;&#34;Initializes a MelodyOneHotEncoding object.
+
+    Args:
+      min_note: The minimum midi pitch the encoded melody events can have.
+      max_note: The maximum midi pitch (exclusive) the encoded melody events
+          can have.
+
+    Raises:
+      ValueError: If `min_note` or `max_note` are outside the midi range, or if
+          `max_note` is not greater than `min_note`.
+    &#34;&#34;&#34;
+    if min_note &lt; MIN_MIDI_PITCH:
+      raise ValueError(&#39;min_note must be &gt;= 0. min_note is %d.&#39; % min_note)
+    if max_note &gt; MAX_MIDI_PITCH + 1:
+      raise ValueError(&#39;max_note must be &lt;= 128. max_note is %d.&#39; % max_note)
+    if max_note &lt;= min_note:
+      raise ValueError(&#39;max_note must be greater than min_note&#39;)
+
+    self._min_note = min_note
+    self._max_note = max_note
+
+  @property
+  def num_classes(self):
+    return self._max_note - self._min_note + NUM_SPECIAL_MELODY_EVENTS
+
+  @property
+  def default_event(self):
+    return MELODY_NO_EVENT
+
+  def encode_event(self, event):
+    &#34;&#34;&#34;Collapses a melody event value into a zero-based index range.
+
+    Args:
+      event: A Melody event value. -2 = no event, -1 = note-off event,
+          [0, 127] = note-on event for that midi pitch.
+
+    Returns:
+      An int in the range [0, self.num_classes). 0 = no event,
+      1 = note-off event, [2, self.num_classes) = note-on event for
+      that pitch relative to the [self._min_note, self._max_note) range.
+
+    Raises:
+      ValueError: If `event` is a MIDI note not between self._min_note and
+          self._max_note, or an invalid special event value.
+    &#34;&#34;&#34;
+    if event &lt; -NUM_SPECIAL_MELODY_EVENTS:
+      raise ValueError(&#39;invalid melody event value: %d&#39; % event)
+    if 0 &lt;= event &lt; self._min_note:
+      raise ValueError(&#39;melody event less than min note: %d &lt; %d&#39; % (
+          event, self._min_note))
+    if event &gt;= self._max_note:
+      raise ValueError(&#39;melody event greater than max note: %d &gt;= %d&#39; % (
+          event, self._max_note))
+
+    if event &lt; 0:
+      return event + NUM_SPECIAL_MELODY_EVENTS
+    return event - self._min_note + NUM_SPECIAL_MELODY_EVENTS
+
+  def decode_event(self, index):
+    &#34;&#34;&#34;Expands a zero-based index value to its equivalent melody event value.
+
+    Args:
+      index: An int in the range [0, self._num_model_events).
+          0 = no event, 1 = note-off event,
+          [2, self._num_model_events) = note-on event for that pitch relative
+          to the [self._min_note, self._max_note) range.
+
+    Returns:
+      A Melody event value. -2 = no event, -1 = note-off event,
+      [0, 127] = note-on event for that midi pitch.
+    &#34;&#34;&#34;
+    if index &lt; NUM_SPECIAL_MELODY_EVENTS:
+      return index - NUM_SPECIAL_MELODY_EVENTS
+    return index - NUM_SPECIAL_MELODY_EVENTS + self._min_note</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder.MelodyOneHotEncoding.decode_event"><code class="name flex">
+<span>def <span class="ident">decode_event</span></span>(<span>self, index)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Expands a zero-based index value to its equivalent melody event value.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>index</code></strong></dt>
+<dd>An int in the range [0, self._num_model_events).
+0 = no event, 1 = note-off event,
+[2, self._num_model_events) = note-on event for that pitch relative
+to the [self._min_note, self._max_note) range.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Melody event value. -2 = no event, -1 = note-off event,
+[0, 127] = note-on event for that midi pitch.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def decode_event(self, index):
+  &#34;&#34;&#34;Expands a zero-based index value to its equivalent melody event value.
+
+  Args:
+    index: An int in the range [0, self._num_model_events).
+        0 = no event, 1 = note-off event,
+        [2, self._num_model_events) = note-on event for that pitch relative
+        to the [self._min_note, self._max_note) range.
+
+  Returns:
+    A Melody event value. -2 = no event, -1 = note-off event,
+    [0, 127] = note-on event for that midi pitch.
+  &#34;&#34;&#34;
+  if index &lt; NUM_SPECIAL_MELODY_EVENTS:
+    return index - NUM_SPECIAL_MELODY_EVENTS
+  return index - NUM_SPECIAL_MELODY_EVENTS + self._min_note</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder.MelodyOneHotEncoding.encode_event"><code class="name flex">
+<span>def <span class="ident">encode_event</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Collapses a melody event value into a zero-based index range.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>A Melody event value. -2 = no event, -1 = note-off event,
+[0, 127] = note-on event for that midi pitch.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An int in the range [0, self.num_classes). 0 = no event,
+1 = note-off event, [2, self.num_classes) = note-on event for
+that pitch relative to the [self._min_note, self._max_note) range.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is a MIDI note not between self._min_note and
+self._max_note, or an invalid special event value.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def encode_event(self, event):
+  &#34;&#34;&#34;Collapses a melody event value into a zero-based index range.
+
+  Args:
+    event: A Melody event value. -2 = no event, -1 = note-off event,
+        [0, 127] = note-on event for that midi pitch.
+
+  Returns:
+    An int in the range [0, self.num_classes). 0 = no event,
+    1 = note-off event, [2, self.num_classes) = note-on event for
+    that pitch relative to the [self._min_note, self._max_note) range.
+
+  Raises:
+    ValueError: If `event` is a MIDI note not between self._min_note and
+        self._max_note, or an invalid special event value.
+  &#34;&#34;&#34;
+  if event &lt; -NUM_SPECIAL_MELODY_EVENTS:
+    raise ValueError(&#39;invalid melody event value: %d&#39; % event)
+  if 0 &lt;= event &lt; self._min_note:
+    raise ValueError(&#39;melody event less than min note: %d &lt; %d&#39; % (
+        event, self._min_note))
+  if event &gt;= self._max_note:
+    raise ValueError(&#39;melody event greater than max note: %d &gt;= %d&#39; % (
+        event, self._max_note))
+
+  if event &lt; 0:
+    return event + NUM_SPECIAL_MELODY_EVENTS
+  return event - self._min_note + NUM_SPECIAL_MELODY_EVENTS</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder" href="#note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder">KeyMelodyEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.class_index_to_event" href="#note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_input" href="#note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_label" href="#note_seq.melody_encoder_decoder.KeyMelodyEncoderDecoder.events_to_label">events_to_label</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder.MelodyOneHotEncoding" href="#note_seq.melody_encoder_decoder.MelodyOneHotEncoding">MelodyOneHotEncoding</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder.MelodyOneHotEncoding.decode_event" href="#note_seq.melody_encoder_decoder.MelodyOneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder.MelodyOneHotEncoding.encode_event" href="#note_seq.melody_encoder_decoder.MelodyOneHotEncoding.encode_event">encode_event</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melody_encoder_decoder_test.html
+++ b/docs/melody_encoder_decoder_test.html
@@ -1,0 +1,2198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melody_encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for melody_encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melody_encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for melody_encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for melody_encoder_decoder.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import constants
+from note_seq import encoder_decoder
+from note_seq import melodies_lib
+from note_seq import melody_encoder_decoder
+
+NOTE_OFF = constants.MELODY_NOTE_OFF
+NO_EVENT = constants.MELODY_NO_EVENT
+
+
+class MelodyOneHotEncodingTest(absltest.TestCase):
+
+  def testInit(self):
+    melody_encoder_decoder.MelodyOneHotEncoding(0, 128)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(-1, 12)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(60, 129)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(72, 72)
+
+  def testNumClasses(self):
+    self.assertEqual(
+        14, melody_encoder_decoder.MelodyOneHotEncoding(60, 72).num_classes)
+    self.assertEqual(
+        130, melody_encoder_decoder.MelodyOneHotEncoding(0, 128).num_classes)
+    self.assertEqual(
+        3, melody_encoder_decoder.MelodyOneHotEncoding(60, 61).num_classes)
+
+  def testDefaultEvent(self):
+    self.assertEqual(
+        NO_EVENT,
+        melody_encoder_decoder.MelodyOneHotEncoding(60, 72).default_event)
+
+  def testEncodeEvent(self):
+    enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+    self.assertEqual(2, enc.encode_event(60))
+    self.assertEqual(13, enc.encode_event(71))
+    self.assertEqual(0, enc.encode_event(NO_EVENT))
+    self.assertEqual(1, enc.encode_event(NOTE_OFF))
+    with self.assertRaises(ValueError):
+      enc.encode_event(-3)
+    with self.assertRaises(ValueError):
+      enc.encode_event(59)
+    with self.assertRaises(ValueError):
+      enc.encode_event(72)
+
+  def testDecodeEvent(self):
+    enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+    self.assertEqual(63, enc.decode_event(5))
+    self.assertEqual(60, enc.decode_event(2))
+    self.assertEqual(71, enc.decode_event(13))
+    self.assertEqual(NO_EVENT, enc.decode_event(0))
+    self.assertEqual(NOTE_OFF, enc.decode_event(1))
+
+
+class MelodyOneHotEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.min_note = 60
+    self.max_note = 72
+    self.transpose_to_key = 0
+    self.med = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(self.min_note,
+                                                    self.max_note))
+
+  def testInitValues(self):
+    self.assertEqual(self.med.input_size, 14)
+    self.assertEqual(self.med.num_classes, 14)
+    self.assertEqual(self.med.default_event_label, 0)
+
+  def testEncode(self):
+    events = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    inputs, labels = self.med.encode(melody)
+    expected_inputs = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_labels = [2, 9, 13, 0, 13, 2, 1, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    events1 = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+    melody1 = melodies_lib.Melody(events1)
+    events2 = [9, 10, 12, 14, 15, 17, 19, 21, 22]
+    melody2 = melodies_lib.Melody(events2)
+    melody1.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    melody2.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    melodies = [melody1, melody2]
+    expected_inputs1 = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_inputs2 = [
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_full_length_inputs_batch = [expected_inputs1, expected_inputs2]
+    expected_last_event_inputs_batch = [expected_inputs1[-1:],
+                                        expected_inputs2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.med.get_inputs_batch(melodies, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.med.get_inputs_batch(melodies))
+
+  def testExtendMelodies(self):
+    melody1 = melodies_lib.Melody([60])
+    melody2 = melodies_lib.Melody([60])
+    melody3 = melodies_lib.Melody([60])
+    melody4 = melodies_lib.Melody([60])
+    melodies = [melody1, melody2, melody3, melody4]
+    softmax = [[
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ], [
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    ], [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ], [
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ]]
+    self.med.extend_event_sequences(melodies, softmax)
+    self.assertListEqual(list(melody1), [60, 60])
+    self.assertListEqual(list(melody2), [60, 71])
+    self.assertListEqual(list(melody3), [60, NO_EVENT])
+    self.assertListEqual(list(melody4), [60, NOTE_OFF])
+
+
+class MelodyLookbackEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def testDefaultRange(self):
+    med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(48, 84))
+    self.assertEqual(med.input_size, 121)
+    self.assertEqual(med.num_classes, 40)
+
+    melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [48, NOTE_OFF, 49, 82])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        # 48, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+        [1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 49, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 83, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # 48, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+        # NOTE_OFF, lookbacks = (49, NO_EVENT)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+        # 48, lookbacks = (NOTE_OFF, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, 49)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+        # 49, lookbacks = (NO_EVENT, 83)
+        [0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+        # 82, lookbacks = (NO_EVENT, NOTE_OFF)
+        [0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+    ]
+    expected_labels = [2, 39, 3, 37, 1, 38, 1, 39, 38, 39, 36]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      print(i)
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+  def testCustomRange(self):
+    med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(min_note=24, max_note=36))
+
+    self.assertEqual(med.input_size, 49)
+    self.assertEqual(med.num_classes, 16)
+
+    melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [24, NOTE_OFF, 25, 34])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        # 24, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 25, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 35, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # 24, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+        # NOTE_OFF, lookbacks = (25, NO_EVENT)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+        # 24, lookbacks = (NOTE_OFF, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, 25)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+        # 25, lookbacks = (NO_EVENT, 35)
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+        # 34, lookbacks = (NO_EVENT, NOTE_OFF)
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+    ]
+    expected_labels = [2, 15, 3, 13, 1, 14, 1, 15, 14, 15, 12]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+
+class KeyMelodyEncoderDecoderTest(absltest.TestCase):
+
+  def testDefaultRange(self):
+    med = melody_encoder_decoder.KeyMelodyEncoderDecoder(48, 84)
+    self.assertEqual(med.input_size, 74)
+    self.assertEqual(med.num_classes, 40)
+
+    melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [48, NOTE_OFF, 49, 82])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 1.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 1.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0]
+    ]
+    expected_labels = [0, 39, 1, 35, 37, 39, 38, 37, 39, 38, 39, 34]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+  def testCustomRange(self):
+    med = melody_encoder_decoder.KeyMelodyEncoderDecoder(min_note=24,
+                                                         max_note=36)
+
+    self.assertEqual(med.input_size, 50)
+    self.assertEqual(med.num_classes, 16)
+
+    melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [24, NOTE_OFF, 25, 34])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 0.0, 1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         0.0, 1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, -1.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, -1.0, 1.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    ]
+    expected_labels = [0, 15, 1, 11, 13, 15, 14, 13, 15, 14, 15, 10]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">KeyMelodyEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class KeyMelodyEncoderDecoderTest(absltest.TestCase):
+
+  def testDefaultRange(self):
+    med = melody_encoder_decoder.KeyMelodyEncoderDecoder(48, 84)
+    self.assertEqual(med.input_size, 74)
+    self.assertEqual(med.num_classes, 40)
+
+    melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [48, NOTE_OFF, 49, 82])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+         0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 1.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 1.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+         1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0]
+    ]
+    expected_labels = [0, 39, 1, 35, 37, 39, 38, 37, 39, 38, 39, 34]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+  def testCustomRange(self):
+    med = melody_encoder_decoder.KeyMelodyEncoderDecoder(min_note=24,
+                                                         max_note=36)
+
+    self.assertEqual(med.input_size, 50)
+    self.assertEqual(med.num_classes, 16)
+
+    melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [24, NOTE_OFF, 25, 34])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 0.0, 1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         0.0, 1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0,
+         1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, -1.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, -1.0, 1.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+         0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+         1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    ]
+    expected_labels = [0, 15, 1, 11, 13, 15, 14, 13, 15, 14, 15, 10]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testCustomRange"><code class="name flex">
+<span>def <span class="ident">testCustomRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testCustomRange(self):
+  med = melody_encoder_decoder.KeyMelodyEncoderDecoder(min_note=24,
+                                                       max_note=36)
+
+  self.assertEqual(med.input_size, 50)
+  self.assertEqual(med.num_classes, 16)
+
+  melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                   [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                   [24, NOTE_OFF, 25, 34])
+  melody = melodies_lib.Melody(melody_events)
+
+  melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+  expected_inputs = [
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+       1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0,
+       1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 0.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, 1.0, 0.0, 0.0, 1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       0.0, 1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0,
+       1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, -1.0, 0.0, 0.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, -1.0, 1.0, 0.0, -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+       0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 0.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+  ]
+  expected_labels = [0, 15, 1, 11, 13, 15, 14, 13, 15, 14, 15, 10]
+  melodies = [melody, melody]
+  full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+  for i, melody_index in enumerate(melody_indices):
+    partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+    self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                         expected_inputs[i])
+    self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                         expected_inputs[i])
+    softmax = [[[0.0] * med.num_classes]]
+    softmax[0][0][expected_labels[i]] = 1.0
+    med.extend_event_sequences([partial_melody], softmax)
+    self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+  self.assertListEqual(
+      [expected_inputs[-1:], expected_inputs[-1:]],
+      med.get_inputs_batch(melodies))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testDefaultRange"><code class="name flex">
+<span>def <span class="ident">testDefaultRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDefaultRange(self):
+  med = melody_encoder_decoder.KeyMelodyEncoderDecoder(48, 84)
+  self.assertEqual(med.input_size, 74)
+  self.assertEqual(med.num_classes, 40)
+
+  melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                   [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                   [48, NOTE_OFF, 49, 82])
+  melody = melodies_lib.Melody(melody_events)
+
+  melody_indices = [0, 1, 2, 3, 4, 15, 16, 17, 32, 33, 34, 35]
+  expected_inputs = [
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+       1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 1.0, 0.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0,
+       1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+       1.0, 1.0, 0.0, 1.0, 0.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+       0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0,
+       1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+       0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0,
+       -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0,
+       0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -1.0, 1.0, 1.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -1.0, 1.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0,
+       1.0, 1.0, 1.0, 0.0, 1.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0]
+  ]
+  expected_labels = [0, 39, 1, 35, 37, 39, 38, 37, 39, 38, 39, 34]
+  melodies = [melody, melody]
+  full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+  for i, melody_index in enumerate(melody_indices):
+    partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+    self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                         expected_inputs[i])
+    self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                         expected_inputs[i])
+    softmax = [[[0.0] * med.num_classes]]
+    softmax[0][0][expected_labels[i]] = 1.0
+    med.extend_event_sequences([partial_melody], softmax)
+    self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+  self.assertListEqual(
+      [expected_inputs[-1:], expected_inputs[-1:]],
+      med.get_inputs_batch(melodies))</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">MelodyLookbackEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyLookbackEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def testDefaultRange(self):
+    med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(48, 84))
+    self.assertEqual(med.input_size, 121)
+    self.assertEqual(med.num_classes, 40)
+
+    melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [48, NOTE_OFF, 49, 82])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        # 48, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+        [1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 49, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 83, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # 48, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+        # NOTE_OFF, lookbacks = (49, NO_EVENT)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+        # 48, lookbacks = (NOTE_OFF, NO_EVENT)
+        [0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, 49)
+        [0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+        # 49, lookbacks = (NO_EVENT, 83)
+        [0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+        # 82, lookbacks = (NO_EVENT, NOTE_OFF)
+        [0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+    ]
+    expected_labels = [2, 39, 3, 37, 1, 38, 1, 39, 38, 39, 36]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      print(i)
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))
+
+  def testCustomRange(self):
+    med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(min_note=24, max_note=36))
+
+    self.assertEqual(med.input_size, 49)
+    self.assertEqual(med.num_classes, 16)
+
+    melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                     [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                     [24, NOTE_OFF, 25, 34])
+    melody = melodies_lib.Melody(melody_events)
+
+    melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+    expected_inputs = [
+        # 24, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 25, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+        # 35, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+        # 24, lookbacks = (NO_EVENT, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+        # NOTE_OFF, lookbacks = (25, NO_EVENT)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+        # 24, lookbacks = (NOTE_OFF, NO_EVENT)
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+        # NOTE_OFF, lookbacks = (NO_EVENT, 25)
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+        # 25, lookbacks = (NO_EVENT, 35)
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+         1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+        # 34, lookbacks = (NO_EVENT, NOTE_OFF)
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+         1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+         -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+    ]
+    expected_labels = [2, 15, 3, 13, 1, 14, 1, 15, 14, 15, 12]
+    melodies = [melody, melody]
+    full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+    for i, melody_index in enumerate(melody_indices):
+      partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+      self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                           expected_inputs[i])
+      self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                           expected_inputs[i])
+      softmax = [[[0.0] * med.num_classes]]
+      softmax[0][0][expected_labels[i]] = 1.0
+      med.extend_event_sequences([partial_melody], softmax)
+      self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+    self.assertListEqual(
+        [expected_inputs[-1:], expected_inputs[-1:]],
+        med.get_inputs_batch(melodies))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testCustomRange"><code class="name flex">
+<span>def <span class="ident">testCustomRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testCustomRange(self):
+  med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+      melody_encoder_decoder.MelodyOneHotEncoding(min_note=24, max_note=36))
+
+  self.assertEqual(med.input_size, 49)
+  self.assertEqual(med.num_classes, 16)
+
+  melody_events = ([24, NO_EVENT, 25, 35, NOTE_OFF] + [NO_EVENT] * 11 +
+                   [24, NOTE_OFF] + [NO_EVENT] * 14 +
+                   [24, NOTE_OFF, 25, 34])
+  melody = melodies_lib.Melody(melody_events)
+
+  melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+  expected_inputs = [
+      # 24, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # 25, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # 35, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+      # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+      # 24, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+      # NOTE_OFF, lookbacks = (25, NO_EVENT)
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+      # 24, lookbacks = (NOTE_OFF, NO_EVENT)
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+      # NOTE_OFF, lookbacks = (NO_EVENT, 25)
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+      # 25, lookbacks = (NO_EVENT, 35)
+      [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+      # 34, lookbacks = (NO_EVENT, NOTE_OFF)
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+  ]
+  expected_labels = [2, 15, 3, 13, 1, 14, 1, 15, 14, 15, 12]
+  melodies = [melody, melody]
+  full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+  for i, melody_index in enumerate(melody_indices):
+    partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+    self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                         expected_inputs[i])
+    self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                         expected_inputs[i])
+    softmax = [[[0.0] * med.num_classes]]
+    softmax[0][0][expected_labels[i]] = 1.0
+    med.extend_event_sequences([partial_melody], softmax)
+    self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+  self.assertListEqual(
+      [expected_inputs[-1:], expected_inputs[-1:]],
+      med.get_inputs_batch(melodies))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testDefaultRange"><code class="name flex">
+<span>def <span class="ident">testDefaultRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDefaultRange(self):
+  med = encoder_decoder.LookbackEventSequenceEncoderDecoder(
+      melody_encoder_decoder.MelodyOneHotEncoding(48, 84))
+  self.assertEqual(med.input_size, 121)
+  self.assertEqual(med.num_classes, 40)
+
+  melody_events = ([48, NO_EVENT, 49, 83, NOTE_OFF] + [NO_EVENT] * 11 +
+                   [48, NOTE_OFF] + [NO_EVENT] * 14 +
+                   [48, NOTE_OFF, 49, 82])
+  melody = melodies_lib.Melody(melody_events)
+
+  melody_indices = [0, 1, 2, 3, 4, 16, 17, 32, 33, 34, 35]
+  expected_inputs = [
+      # 48, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # NO_EVENT, lookbacks = (NO_EVENT, NO_EVENT)
+      [1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # 49, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+      # 83, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+      # NOTE_OFF, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 1.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0],
+      # 48, lookbacks = (NO_EVENT, NO_EVENT)
+      [0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 0.0],
+      # NOTE_OFF, lookbacks = (49, NO_EVENT)
+      [0.0, 1.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, 1.0, 0.0, 0.0],
+      # 48, lookbacks = (NOTE_OFF, NO_EVENT)
+      [0.0, 0.0,
+       1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0],
+      # NOTE_OFF, lookbacks = (NO_EVENT, 49)
+      [0.0, 1.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 0.0],
+      # 49, lookbacks = (NO_EVENT, 83)
+      [0.0, 0.0,
+       0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+       1.0, 1.0, -1.0, -1.0, -1.0, 0.0, 1.0],
+      # 82, lookbacks = (NO_EVENT, NOTE_OFF)
+      [0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+       1.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 1.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0]
+  ]
+  expected_labels = [2, 39, 3, 37, 1, 38, 1, 39, 38, 39, 36]
+  melodies = [melody, melody]
+  full_length_inputs_batch = med.get_inputs_batch(melodies, True)
+
+  for i, melody_index in enumerate(melody_indices):
+    print(i)
+    partial_melody = melodies_lib.Melody(melody_events[:melody_index])
+    self.assertListEqual(full_length_inputs_batch[0][melody_index],
+                         expected_inputs[i])
+    self.assertListEqual(full_length_inputs_batch[1][melody_index],
+                         expected_inputs[i])
+    softmax = [[[0.0] * med.num_classes]]
+    softmax[0][0][expected_labels[i]] = 1.0
+    med.extend_event_sequences([partial_melody], softmax)
+    self.assertEqual(list(partial_melody)[-1], melody_events[melody_index])
+
+  self.assertListEqual(
+      [expected_inputs[-1:], expected_inputs[-1:]],
+      med.get_inputs_batch(melodies))</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest"><code class="flex name class">
+<span>class <span class="ident">MelodyOneHotEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyOneHotEncodingTest(absltest.TestCase):
+
+  def testInit(self):
+    melody_encoder_decoder.MelodyOneHotEncoding(0, 128)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(-1, 12)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(60, 129)
+    with self.assertRaises(ValueError):
+      melody_encoder_decoder.MelodyOneHotEncoding(72, 72)
+
+  def testNumClasses(self):
+    self.assertEqual(
+        14, melody_encoder_decoder.MelodyOneHotEncoding(60, 72).num_classes)
+    self.assertEqual(
+        130, melody_encoder_decoder.MelodyOneHotEncoding(0, 128).num_classes)
+    self.assertEqual(
+        3, melody_encoder_decoder.MelodyOneHotEncoding(60, 61).num_classes)
+
+  def testDefaultEvent(self):
+    self.assertEqual(
+        NO_EVENT,
+        melody_encoder_decoder.MelodyOneHotEncoding(60, 72).default_event)
+
+  def testEncodeEvent(self):
+    enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+    self.assertEqual(2, enc.encode_event(60))
+    self.assertEqual(13, enc.encode_event(71))
+    self.assertEqual(0, enc.encode_event(NO_EVENT))
+    self.assertEqual(1, enc.encode_event(NOTE_OFF))
+    with self.assertRaises(ValueError):
+      enc.encode_event(-3)
+    with self.assertRaises(ValueError):
+      enc.encode_event(59)
+    with self.assertRaises(ValueError):
+      enc.encode_event(72)
+
+  def testDecodeEvent(self):
+    enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+    self.assertEqual(63, enc.decode_event(5))
+    self.assertEqual(60, enc.decode_event(2))
+    self.assertEqual(71, enc.decode_event(13))
+    self.assertEqual(NO_EVENT, enc.decode_event(0))
+    self.assertEqual(NOTE_OFF, enc.decode_event(1))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDecodeEvent"><code class="name flex">
+<span>def <span class="ident">testDecodeEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeEvent(self):
+  enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+  self.assertEqual(63, enc.decode_event(5))
+  self.assertEqual(60, enc.decode_event(2))
+  self.assertEqual(71, enc.decode_event(13))
+  self.assertEqual(NO_EVENT, enc.decode_event(0))
+  self.assertEqual(NOTE_OFF, enc.decode_event(1))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDefaultEvent"><code class="name flex">
+<span>def <span class="ident">testDefaultEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDefaultEvent(self):
+  self.assertEqual(
+      NO_EVENT,
+      melody_encoder_decoder.MelodyOneHotEncoding(60, 72).default_event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testEncodeEvent"><code class="name flex">
+<span>def <span class="ident">testEncodeEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeEvent(self):
+  enc = melody_encoder_decoder.MelodyOneHotEncoding(60, 72)
+  self.assertEqual(2, enc.encode_event(60))
+  self.assertEqual(13, enc.encode_event(71))
+  self.assertEqual(0, enc.encode_event(NO_EVENT))
+  self.assertEqual(1, enc.encode_event(NOTE_OFF))
+  with self.assertRaises(ValueError):
+    enc.encode_event(-3)
+  with self.assertRaises(ValueError):
+    enc.encode_event(59)
+  with self.assertRaises(ValueError):
+    enc.encode_event(72)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testInit"><code class="name flex">
+<span>def <span class="ident">testInit</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInit(self):
+  melody_encoder_decoder.MelodyOneHotEncoding(0, 128)
+  with self.assertRaises(ValueError):
+    melody_encoder_decoder.MelodyOneHotEncoding(-1, 12)
+  with self.assertRaises(ValueError):
+    melody_encoder_decoder.MelodyOneHotEncoding(60, 129)
+  with self.assertRaises(ValueError):
+    melody_encoder_decoder.MelodyOneHotEncoding(72, 72)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testNumClasses"><code class="name flex">
+<span>def <span class="ident">testNumClasses</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumClasses(self):
+  self.assertEqual(
+      14, melody_encoder_decoder.MelodyOneHotEncoding(60, 72).num_classes)
+  self.assertEqual(
+      130, melody_encoder_decoder.MelodyOneHotEncoding(0, 128).num_classes)
+  self.assertEqual(
+      3, melody_encoder_decoder.MelodyOneHotEncoding(60, 61).num_classes)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">MelodyOneHotEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyOneHotEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.min_note = 60
+    self.max_note = 72
+    self.transpose_to_key = 0
+    self.med = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        melody_encoder_decoder.MelodyOneHotEncoding(self.min_note,
+                                                    self.max_note))
+
+  def testInitValues(self):
+    self.assertEqual(self.med.input_size, 14)
+    self.assertEqual(self.med.num_classes, 14)
+    self.assertEqual(self.med.default_event_label, 0)
+
+  def testEncode(self):
+    events = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+    melody = melodies_lib.Melody(events)
+    melody.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    inputs, labels = self.med.encode(melody)
+    expected_inputs = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_labels = [2, 9, 13, 0, 13, 2, 1, 0]
+    self.assertEqual(inputs, expected_inputs)
+    self.assertEqual(labels, expected_labels)
+
+  def testGetInputsBatch(self):
+    events1 = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+    melody1 = melodies_lib.Melody(events1)
+    events2 = [9, 10, 12, 14, 15, 17, 19, 21, 22]
+    melody2 = melodies_lib.Melody(events2)
+    melody1.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    melody2.squash(
+        self.min_note,
+        self.max_note,
+        self.transpose_to_key)
+    melodies = [melody1, melody2]
+    expected_inputs1 = [
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_inputs2 = [
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    expected_full_length_inputs_batch = [expected_inputs1, expected_inputs2]
+    expected_last_event_inputs_batch = [expected_inputs1[-1:],
+                                        expected_inputs2[-1:]]
+    self.assertListEqual(
+        expected_full_length_inputs_batch,
+        self.med.get_inputs_batch(melodies, True))
+    self.assertListEqual(
+        expected_last_event_inputs_batch,
+        self.med.get_inputs_batch(melodies))
+
+  def testExtendMelodies(self):
+    melody1 = melodies_lib.Melody([60])
+    melody2 = melodies_lib.Melody([60])
+    melody3 = melodies_lib.Melody([60])
+    melody4 = melodies_lib.Melody([60])
+    melodies = [melody1, melody2, melody3, melody4]
+    softmax = [[
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ], [
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    ], [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ], [
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ]]
+    self.med.extend_event_sequences(melodies, softmax)
+    self.assertListEqual(list(melody1), [60, 60])
+    self.assertListEqual(list(melody2), [60, 71])
+    self.assertListEqual(list(melody3), [60, NO_EVENT])
+    self.assertListEqual(list(melody4), [60, NOTE_OFF])</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.min_note = 60
+  self.max_note = 72
+  self.transpose_to_key = 0
+  self.med = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+      melody_encoder_decoder.MelodyOneHotEncoding(self.min_note,
+                                                  self.max_note))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testEncode"><code class="name flex">
+<span>def <span class="ident">testEncode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncode(self):
+  events = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+  melody = melodies_lib.Melody(events)
+  melody.squash(
+      self.min_note,
+      self.max_note,
+      self.transpose_to_key)
+  inputs, labels = self.med.encode(melody)
+  expected_inputs = [
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+  expected_labels = [2, 9, 13, 0, 13, 2, 1, 0]
+  self.assertEqual(inputs, expected_inputs)
+  self.assertEqual(labels, expected_labels)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testExtendMelodies"><code class="name flex">
+<span>def <span class="ident">testExtendMelodies</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtendMelodies(self):
+  melody1 = melodies_lib.Melody([60])
+  melody2 = melodies_lib.Melody([60])
+  melody3 = melodies_lib.Melody([60])
+  melody4 = melodies_lib.Melody([60])
+  melodies = [melody1, melody2, melody3, melody4]
+  softmax = [[
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  ], [
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+  ], [
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  ], [
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  ]]
+  self.med.extend_event_sequences(melodies, softmax)
+  self.assertListEqual(list(melody1), [60, 60])
+  self.assertListEqual(list(melody2), [60, 71])
+  self.assertListEqual(list(melody3), [60, NO_EVENT])
+  self.assertListEqual(list(melody4), [60, NOTE_OFF])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testGetInputsBatch"><code class="name flex">
+<span>def <span class="ident">testGetInputsBatch</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testGetInputsBatch(self):
+  events1 = [100, 100, 107, 111, NO_EVENT, 99, 112, NOTE_OFF, NO_EVENT]
+  melody1 = melodies_lib.Melody(events1)
+  events2 = [9, 10, 12, 14, 15, 17, 19, 21, 22]
+  melody2 = melodies_lib.Melody(events2)
+  melody1.squash(
+      self.min_note,
+      self.max_note,
+      self.transpose_to_key)
+  melody2.squash(
+      self.min_note,
+      self.max_note,
+      self.transpose_to_key)
+  melodies = [melody1, melody2]
+  expected_inputs1 = [
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+  expected_inputs2 = [
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+      [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+  expected_full_length_inputs_batch = [expected_inputs1, expected_inputs2]
+  expected_last_event_inputs_batch = [expected_inputs1[-1:],
+                                      expected_inputs2[-1:]]
+  self.assertListEqual(
+      expected_full_length_inputs_batch,
+      self.med.get_inputs_batch(melodies, True))
+  self.assertListEqual(
+      expected_last_event_inputs_batch,
+      self.med.get_inputs_batch(melodies))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testInitValues"><code class="name flex">
+<span>def <span class="ident">testInitValues</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInitValues(self):
+  self.assertEqual(self.med.input_size, 14)
+  self.assertEqual(self.med.num_classes, 14)
+  self.assertEqual(self.med.default_event_label, 0)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest" href="#note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest">KeyMelodyEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testCustomRange" href="#note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testCustomRange">testCustomRange</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testDefaultRange" href="#note_seq.melody_encoder_decoder_test.KeyMelodyEncoderDecoderTest.testDefaultRange">testDefaultRange</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest" href="#note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest">MelodyLookbackEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testCustomRange" href="#note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testCustomRange">testCustomRange</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testDefaultRange" href="#note_seq.melody_encoder_decoder_test.MelodyLookbackEventSequenceEncoderDecoderTest.testDefaultRange">testDefaultRange</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest">MelodyOneHotEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDecodeEvent" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDecodeEvent">testDecodeEvent</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDefaultEvent" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testDefaultEvent">testDefaultEvent</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testEncodeEvent" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testEncodeEvent">testEncodeEvent</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testInit" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testInit">testInit</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testNumClasses" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEncodingTest.testNumClasses">testNumClasses</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest">MelodyOneHotEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.setUp" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testEncode" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testEncode">testEncode</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testExtendMelodies" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testExtendMelodies">testExtendMelodies</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testGetInputsBatch" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testGetInputsBatch">testGetInputsBatch</a></code></li>
+<li><code><a title="note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testInitValues" href="#note_seq.melody_encoder_decoder_test.MelodyOneHotEventSequenceEncoderDecoderTest.testInitValues">testInitValues</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melody_inference.html
+++ b/docs/melody_inference.html
@@ -1,0 +1,716 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melody_inference API documentation</title>
+<meta name="description" content="Infer melody from polyphonic NoteSequence." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melody_inference</code></h1>
+</header>
+<section id="section-intro">
+<p>Infer melody from polyphonic NoteSequence.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Infer melody from polyphonic NoteSequence.&#34;&#34;&#34;
+
+import bisect
+
+from note_seq import constants
+from note_seq import sequences_lib
+import numpy as np
+import scipy.linalg
+
+REST = -1
+MELODY_VELOCITY = 127
+
+# Maximum number of melody frames to infer.
+MAX_NUM_FRAMES = 10000
+
+
+def _melody_transition_distribution(rest_prob, interval_prob_fn):
+  &#34;&#34;&#34;Compute the transition distribution between melody pitches (and rest).
+
+  Args:
+    rest_prob: Probability that a note will be followed by a rest.
+    interval_prob_fn: Function from pitch interval (value between -127 and 127)
+        to weight. Will be normalized so that outgoing probabilities (including
+        rest) from each pitch sum to one.
+
+  Returns:
+    A 257-by-257 melody event transition matrix. Row/column zero represents
+    rest. Rows/columns 1-128 represent MIDI note onsets for all pitches.
+    Rows/columns 129-256 represent MIDI note continuations (i.e. non-onsets) for
+    all pitches.
+  &#34;&#34;&#34;
+  pitches = np.arange(constants.MIN_MIDI_PITCH, constants.MAX_MIDI_PITCH + 1)
+  num_pitches = len(pitches)
+
+  # Evaluate the probability of each possible pitch interval.
+  max_interval = constants.MAX_MIDI_PITCH - constants.MIN_MIDI_PITCH
+  intervals = np.arange(-max_interval, max_interval + 1)
+  interval_probs = np.vectorize(interval_prob_fn)(intervals)
+
+  # Form the note onset transition matrix.
+  interval_probs_mat = scipy.linalg.toeplitz(
+      interval_probs[max_interval::-1],
+      interval_probs[max_interval::])
+  interval_probs_mat /= interval_probs_mat.sum(axis=1)[:, np.newaxis]
+  interval_probs_mat *= 1 - rest_prob
+
+  num_melody_events = 1 + 2 * num_pitches
+  mat = np.zeros([num_melody_events, num_melody_events])
+
+  # Continuing a rest is a non-event.
+  mat[0, 0] = 1
+
+  # All note onsets are equally likely after rest.
+  mat[0, 1:num_pitches+1] = np.ones([1, num_pitches]) / num_pitches
+
+  # Transitioning to rest/onset follows user-specified distribution.
+  mat[1:num_pitches+1, 0] = rest_prob
+  mat[1:num_pitches+1, 1:num_pitches+1] = interval_probs_mat
+
+  # Sustaining a note after onset is a non-event. Transitioning to a different
+  # note (without onset) is forbidden.
+  mat[1:num_pitches+1, num_pitches+1:] = np.eye(num_pitches)
+
+  # Transitioning to rest/onset follows user-specified distribution.
+  mat[num_pitches+1:, 0] = rest_prob
+  mat[num_pitches+1:, 1:num_pitches+1] = interval_probs_mat
+
+  # Sustaining a note is a non-event. Transitioning to a different note (without
+  # onset) is forbidden.
+  mat[num_pitches+1:, num_pitches+1:] = np.eye(num_pitches)
+
+  return mat
+
+
+def sequence_note_frames(sequence):
+  &#34;&#34;&#34;Split a NoteSequence into frame summaries separated by onsets/offsets.
+
+  Args:
+    sequence: The NoteSequence for which to compute frame summaries.
+
+  Returns:
+    pitches: A list of MIDI pitches present in `sequence`, in ascending order.
+    has_onsets: A Boolean matrix with shape `[num_frames, num_pitches]` where
+        entry (i,j) indicates whether pitch j has a note onset in frame i.
+    has_notes: A Boolean matrix with shape `[num_frames, num_pitches]` where
+        entry (i,j) indicates whether pitch j is present in frame i, either as
+        an onset or a sustained note.
+    event_times: A list of length `num_frames - 1` containing the event times
+        separating adjacent frames.
+  &#34;&#34;&#34;
+  notes = [note for note in sequence.notes
+           if not note.is_drum
+           and note.program not in constants.UNPITCHED_PROGRAMS]
+
+  onset_times = [note.start_time for note in notes]
+  offset_times = [note.end_time for note in notes]
+  event_times = set(onset_times + offset_times)
+
+  event_times.discard(0.0)
+  event_times.discard(sequence.total_time)
+
+  event_times = sorted(event_times)
+  num_frames = len(event_times) + 1
+
+  pitches = sorted(set(note.pitch for note in notes))
+  pitch_map = dict((p, i) for i, p in enumerate(pitches))
+  num_pitches = len(pitches)
+
+  has_onsets = np.zeros([num_frames, num_pitches], dtype=bool)
+  has_notes = np.zeros([num_frames, num_pitches], dtype=bool)
+
+  for note in notes:
+    start_frame = bisect.bisect_right(event_times, note.start_time)
+    end_frame = bisect.bisect_left(event_times, note.end_time)
+
+    has_onsets[start_frame, pitch_map[note.pitch]] = True
+    has_notes[start_frame:end_frame+1, pitch_map[note.pitch]] = True
+
+  return pitches, has_onsets, has_notes, event_times
+
+
+def _melody_frame_log_likelihood(pitches, has_onsets, has_notes, durations,
+                                 instantaneous_non_max_pitch_prob,
+                                 instantaneous_non_empty_rest_prob,
+                                 instantaneous_missing_pitch_prob):
+  &#34;&#34;&#34;Compute the log-likelihood of each frame given each melody state.&#34;&#34;&#34;
+  num_frames = len(has_onsets)
+  num_pitches = len(pitches)
+
+  # Whether or not each frame has any notes present at all.
+  any_notes = np.sum(has_notes, axis=1, dtype=bool)
+
+  # Whether or not each note has the maximum pitch in each frame.
+  if num_pitches &gt; 1:
+    has_higher_notes = np.concatenate([
+        np.cumsum(has_notes[:, ::-1], axis=1, dtype=bool)[:, num_pitches-2::-1],
+        np.zeros([num_frames, 1], dtype=bool)
+    ], axis=1)
+  else:
+    has_higher_notes = np.zeros([num_frames, 1], dtype=bool)
+
+  # Initialize the log-likelihood matrix. There are two melody states for each
+  # pitch (onset vs. non-onset) and one rest state.
+  mat = np.zeros([num_frames, 1 + 2 * num_pitches])
+
+  # Log-likelihood of each frame given rest. Depends only on presence of any
+  # notes.
+  mat[:, 0] = (
+      any_notes * instantaneous_non_empty_rest_prob +
+      ~any_notes * (1 - instantaneous_non_empty_rest_prob))
+
+  # Log-likelihood of each frame given onset. Depends on presence of onset and
+  # whether or not it is the maximum pitch. Probability of no observed onset
+  # given melody onset is zero.
+  mat[:, 1:num_pitches+1] = has_onsets * (
+      ~has_higher_notes * (1 - instantaneous_non_max_pitch_prob) +
+      has_higher_notes * instantaneous_non_max_pitch_prob)
+
+  # Log-likelihood of each frame given non-onset. Depends on absence of onset
+  # and whether note is present and the maximum pitch. Probability of observed
+  # onset given melody non-onset is zero; this is to prevent Viterbi from being
+  # &#34;lazy&#34; and always treating repeated notes as sustain.
+  mat[:, num_pitches+1:] = ~has_onsets * (
+      ~has_higher_notes * (1 - instantaneous_non_max_pitch_prob) +
+      has_higher_notes * instantaneous_non_max_pitch_prob) * (
+          has_notes * (1 - instantaneous_missing_pitch_prob) +
+          ~has_notes * instantaneous_missing_pitch_prob)
+
+  # Take the log and scale by duration.
+  mat = durations[:, np.newaxis] * np.log(mat)
+
+  return mat
+
+
+def _melody_viterbi(pitches, melody_frame_loglik, melody_transition_loglik):
+  &#34;&#34;&#34;Use the Viterbi algorithm to infer a sequence of melody events.&#34;&#34;&#34;
+  num_frames, num_melody_events = melody_frame_loglik.shape
+  assert num_melody_events == 2 * len(pitches) + 1
+
+  loglik_matrix = np.zeros([num_frames, num_melody_events])
+  path_matrix = np.zeros([num_frames, num_melody_events], dtype=np.int32)
+
+  # Assume the very first frame follows a rest.
+  loglik_matrix[0, :] = (
+      melody_transition_loglik[0, :] + melody_frame_loglik[0, :])
+
+  for frame in range(1, num_frames):
+    # At each frame, store the log-likelihood of the best sequence ending in
+    # each melody event, along with the index of the parent melody event from
+    # the previous frame.
+    mat = (np.tile(loglik_matrix[frame - 1][:, np.newaxis],
+                   [1, num_melody_events]) +
+           melody_transition_loglik)
+    path_matrix[frame, :] = mat.argmax(axis=0)
+    loglik_matrix[frame, :] = (
+        mat[path_matrix[frame, :], range(num_melody_events)] +
+        melody_frame_loglik[frame])
+
+  # Reconstruct the most likely sequence of melody events.
+  path = [np.argmax(loglik_matrix[-1])]
+  for frame in range(num_frames, 1, -1):
+    path.append(path_matrix[frame - 1, path[-1]])
+
+  # Mapping from melody event index to rest or (pitch, is-onset) tuple.
+  def index_to_event(i):
+    if i == 0:
+      return REST
+    elif i &lt;= len(pitches):
+      # Note onset.
+      return pitches[i - 1], True
+    else:
+      # Note sustain.
+      return pitches[i - len(pitches) - 1], False
+
+  return [index_to_event(index) for index in path[::-1]]
+
+
+class MelodyInferenceError(Exception):  # pylint:disable=g-bad-exception-name
+  pass
+
+
+def infer_melody_for_sequence(sequence,
+                              melody_interval_scale=2.0,
+                              rest_prob=0.1,
+                              instantaneous_non_max_pitch_prob=1e-15,
+                              instantaneous_non_empty_rest_prob=0.0,
+                              instantaneous_missing_pitch_prob=1e-15):
+  &#34;&#34;&#34;Infer melody for a NoteSequence.
+
+  This is a work in progress and should not necessarily be expected to return
+  reasonable results. It operates under two main assumptions:
+
+  1) Melody onsets always coincide with actual note onsets from the polyphonic
+     NoteSequence.
+  2) When multiple notes are active, the melody note tends to be the note with
+     the highest pitch.
+
+  Args:
+    sequence: The NoteSequence for which to infer melody. This NoteSequence will
+        be modified in place, with inferred melody notes added as a new
+        instrument.
+    melody_interval_scale: The scale parameter for the prior distribution over
+        melody intervals.
+    rest_prob: The probability of rest after a melody note.
+    instantaneous_non_max_pitch_prob: The instantaneous probability that the
+        melody note will not have the maximum active pitch.
+    instantaneous_non_empty_rest_prob: The instantaneous probability that at
+        least one note will be active during a melody rest.
+    instantaneous_missing_pitch_prob: The instantaneous probability that the
+        melody note will not be active.
+
+  Returns:
+    The instrument number used for the added melody.
+
+  Raises:
+    MelodyInferenceError: If `sequence` is quantized, or if the number of
+        frames is too large.
+  &#34;&#34;&#34;
+  if sequences_lib.is_quantized_sequence(sequence):
+    raise MelodyInferenceError(
+        &#39;Melody inference on quantized NoteSequence not supported.&#39;)
+
+  pitches, has_onsets, has_notes, event_times = sequence_note_frames(sequence)
+
+  if sequence.notes:
+    melody_instrument = max(note.instrument for note in sequence.notes) + 1
+  else:
+    melody_instrument = 0
+
+  if melody_instrument == 9:
+    # Avoid any confusion around drum channel.
+    melody_instrument = 10
+
+  if not pitches:
+    # No pitches present in sequence.
+    return melody_instrument
+
+  if len(event_times) + 1 &gt; MAX_NUM_FRAMES:
+    raise MelodyInferenceError(
+        &#39;Too many frames for melody inference: %d&#39; % (len(event_times) + 1))
+
+  # Compute frame durations (times between consecutive note events).
+  if event_times:
+    durations = np.array(
+        [event_times[0]] +
+        [t2 - t1 for (t1, t2) in zip(event_times[:-1], event_times[1:])] +
+        [sequence.total_time - event_times[-1]])
+  else:
+    durations = np.array([sequence.total_time])
+
+  # Interval distribution is Cauchy-like.
+  interval_prob_fn = lambda d: 1 / (1 + (d / melody_interval_scale) ** 2)
+  melody_transition_distribution = _melody_transition_distribution(
+      rest_prob=rest_prob, interval_prob_fn=interval_prob_fn)
+
+  # Remove all pitches absent from sequence from transition matrix; for most
+  # sequences this will greatly reduce the state space.
+  num_midi_pitches = constants.MAX_MIDI_PITCH - constants.MIN_MIDI_PITCH + 1
+  pitch_indices = (
+      [0] +
+      [p - constants.MIN_MIDI_PITCH + 1 for p in pitches] +
+      [num_midi_pitches + p - constants.MIN_MIDI_PITCH + 1 for p in pitches]
+  )
+  melody_transition_loglik = np.log(
+      melody_transition_distribution[pitch_indices, :][:, pitch_indices])
+
+  # Compute log-likelihood of each frame under each possibly melody event.
+  melody_frame_loglik = _melody_frame_log_likelihood(
+      pitches, has_onsets, has_notes, durations,
+      instantaneous_non_max_pitch_prob=instantaneous_non_max_pitch_prob,
+      instantaneous_non_empty_rest_prob=instantaneous_non_empty_rest_prob,
+      instantaneous_missing_pitch_prob=instantaneous_missing_pitch_prob)
+
+  # Compute the most likely sequence of melody events using Viterbi.
+  melody_events = _melody_viterbi(
+      pitches, melody_frame_loglik, melody_transition_loglik)
+
+  def add_note(start_time, end_time, pitch):
+    note = sequence.notes.add()
+    note.start_time = start_time
+    note.end_time = end_time
+    note.pitch = pitch
+    note.velocity = MELODY_VELOCITY
+    note.instrument = melody_instrument
+
+  note_pitch = None
+  note_start_time = None
+
+  for event, time in zip(melody_events, [0.0] + event_times):
+    if event == REST:
+      if note_pitch is not None:
+        # A note has just ended.
+        add_note(note_start_time, time, note_pitch)
+        note_pitch = None
+
+    else:
+      pitch, is_onset = event
+      if is_onset:
+        # This is a new note onset.
+        if note_pitch is not None:
+          add_note(note_start_time, time, note_pitch)
+        note_pitch = pitch
+        note_start_time = time
+      else:
+        # This is a continuation of the current note.
+        assert pitch == note_pitch
+
+  if note_pitch is not None:
+    # Add the final note.
+    add_note(note_start_time, sequence.total_time, note_pitch)
+
+  return melody_instrument</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.melody_inference.infer_melody_for_sequence"><code class="name flex">
+<span>def <span class="ident">infer_melody_for_sequence</span></span>(<span>sequence, melody_interval_scale=2.0, rest_prob=0.1, instantaneous_non_max_pitch_prob=1e-15, instantaneous_non_empty_rest_prob=0.0, instantaneous_missing_pitch_prob=1e-15)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Infer melody for a NoteSequence.</p>
+<p>This is a work in progress and should not necessarily be expected to return
+reasonable results. It operates under two main assumptions:</p>
+<p>1) Melody onsets always coincide with actual note onsets from the polyphonic
+NoteSequence.
+2) When multiple notes are active, the melody note tends to be the note with
+the highest pitch.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to infer melody. This NoteSequence will
+be modified in place, with inferred melody notes added as a new
+instrument.</dd>
+<dt><strong><code>melody_interval_scale</code></strong></dt>
+<dd>The scale parameter for the prior distribution over
+melody intervals.</dd>
+<dt><strong><code>rest_prob</code></strong></dt>
+<dd>The probability of rest after a melody note.</dd>
+<dt><strong><code>instantaneous_non_max_pitch_prob</code></strong></dt>
+<dd>The instantaneous probability that the
+melody note will not have the maximum active pitch.</dd>
+<dt><strong><code>instantaneous_non_empty_rest_prob</code></strong></dt>
+<dd>The instantaneous probability that at
+least one note will be active during a melody rest.</dd>
+<dt><strong><code>instantaneous_missing_pitch_prob</code></strong></dt>
+<dd>The instantaneous probability that the
+melody note will not be active.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The instrument number used for the added melody.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.melody_inference.MelodyInferenceError" href="#note_seq.melody_inference.MelodyInferenceError">MelodyInferenceError</a></code></dt>
+<dd>If <code>sequence</code> is quantized, or if the number of
+frames is too large.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def infer_melody_for_sequence(sequence,
+                              melody_interval_scale=2.0,
+                              rest_prob=0.1,
+                              instantaneous_non_max_pitch_prob=1e-15,
+                              instantaneous_non_empty_rest_prob=0.0,
+                              instantaneous_missing_pitch_prob=1e-15):
+  &#34;&#34;&#34;Infer melody for a NoteSequence.
+
+  This is a work in progress and should not necessarily be expected to return
+  reasonable results. It operates under two main assumptions:
+
+  1) Melody onsets always coincide with actual note onsets from the polyphonic
+     NoteSequence.
+  2) When multiple notes are active, the melody note tends to be the note with
+     the highest pitch.
+
+  Args:
+    sequence: The NoteSequence for which to infer melody. This NoteSequence will
+        be modified in place, with inferred melody notes added as a new
+        instrument.
+    melody_interval_scale: The scale parameter for the prior distribution over
+        melody intervals.
+    rest_prob: The probability of rest after a melody note.
+    instantaneous_non_max_pitch_prob: The instantaneous probability that the
+        melody note will not have the maximum active pitch.
+    instantaneous_non_empty_rest_prob: The instantaneous probability that at
+        least one note will be active during a melody rest.
+    instantaneous_missing_pitch_prob: The instantaneous probability that the
+        melody note will not be active.
+
+  Returns:
+    The instrument number used for the added melody.
+
+  Raises:
+    MelodyInferenceError: If `sequence` is quantized, or if the number of
+        frames is too large.
+  &#34;&#34;&#34;
+  if sequences_lib.is_quantized_sequence(sequence):
+    raise MelodyInferenceError(
+        &#39;Melody inference on quantized NoteSequence not supported.&#39;)
+
+  pitches, has_onsets, has_notes, event_times = sequence_note_frames(sequence)
+
+  if sequence.notes:
+    melody_instrument = max(note.instrument for note in sequence.notes) + 1
+  else:
+    melody_instrument = 0
+
+  if melody_instrument == 9:
+    # Avoid any confusion around drum channel.
+    melody_instrument = 10
+
+  if not pitches:
+    # No pitches present in sequence.
+    return melody_instrument
+
+  if len(event_times) + 1 &gt; MAX_NUM_FRAMES:
+    raise MelodyInferenceError(
+        &#39;Too many frames for melody inference: %d&#39; % (len(event_times) + 1))
+
+  # Compute frame durations (times between consecutive note events).
+  if event_times:
+    durations = np.array(
+        [event_times[0]] +
+        [t2 - t1 for (t1, t2) in zip(event_times[:-1], event_times[1:])] +
+        [sequence.total_time - event_times[-1]])
+  else:
+    durations = np.array([sequence.total_time])
+
+  # Interval distribution is Cauchy-like.
+  interval_prob_fn = lambda d: 1 / (1 + (d / melody_interval_scale) ** 2)
+  melody_transition_distribution = _melody_transition_distribution(
+      rest_prob=rest_prob, interval_prob_fn=interval_prob_fn)
+
+  # Remove all pitches absent from sequence from transition matrix; for most
+  # sequences this will greatly reduce the state space.
+  num_midi_pitches = constants.MAX_MIDI_PITCH - constants.MIN_MIDI_PITCH + 1
+  pitch_indices = (
+      [0] +
+      [p - constants.MIN_MIDI_PITCH + 1 for p in pitches] +
+      [num_midi_pitches + p - constants.MIN_MIDI_PITCH + 1 for p in pitches]
+  )
+  melody_transition_loglik = np.log(
+      melody_transition_distribution[pitch_indices, :][:, pitch_indices])
+
+  # Compute log-likelihood of each frame under each possibly melody event.
+  melody_frame_loglik = _melody_frame_log_likelihood(
+      pitches, has_onsets, has_notes, durations,
+      instantaneous_non_max_pitch_prob=instantaneous_non_max_pitch_prob,
+      instantaneous_non_empty_rest_prob=instantaneous_non_empty_rest_prob,
+      instantaneous_missing_pitch_prob=instantaneous_missing_pitch_prob)
+
+  # Compute the most likely sequence of melody events using Viterbi.
+  melody_events = _melody_viterbi(
+      pitches, melody_frame_loglik, melody_transition_loglik)
+
+  def add_note(start_time, end_time, pitch):
+    note = sequence.notes.add()
+    note.start_time = start_time
+    note.end_time = end_time
+    note.pitch = pitch
+    note.velocity = MELODY_VELOCITY
+    note.instrument = melody_instrument
+
+  note_pitch = None
+  note_start_time = None
+
+  for event, time in zip(melody_events, [0.0] + event_times):
+    if event == REST:
+      if note_pitch is not None:
+        # A note has just ended.
+        add_note(note_start_time, time, note_pitch)
+        note_pitch = None
+
+    else:
+      pitch, is_onset = event
+      if is_onset:
+        # This is a new note onset.
+        if note_pitch is not None:
+          add_note(note_start_time, time, note_pitch)
+        note_pitch = pitch
+        note_start_time = time
+      else:
+        # This is a continuation of the current note.
+        assert pitch == note_pitch
+
+  if note_pitch is not None:
+    # Add the final note.
+    add_note(note_start_time, sequence.total_time, note_pitch)
+
+  return melody_instrument</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_inference.sequence_note_frames"><code class="name flex">
+<span>def <span class="ident">sequence_note_frames</span></span>(<span>sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Split a NoteSequence into frame summaries separated by onsets/offsets.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to compute frame summaries.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>pitches</code></dt>
+<dd>A list of MIDI pitches present in <code>sequence</code>, in ascending order.</dd>
+<dt><code>has_onsets</code></dt>
+<dd>A Boolean matrix with shape <code>[num_frames, num_pitches]</code> where
+entry (i,j) indicates whether pitch j has a note onset in frame i.</dd>
+<dt><code>has_notes</code></dt>
+<dd>A Boolean matrix with shape <code>[num_frames, num_pitches]</code> where
+entry (i,j) indicates whether pitch j is present in frame i, either as
+an onset or a sustained note.</dd>
+<dt><code>event_times</code></dt>
+<dd>A list of length <code>num_frames - 1</code> containing the event times
+separating adjacent frames.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_note_frames(sequence):
+  &#34;&#34;&#34;Split a NoteSequence into frame summaries separated by onsets/offsets.
+
+  Args:
+    sequence: The NoteSequence for which to compute frame summaries.
+
+  Returns:
+    pitches: A list of MIDI pitches present in `sequence`, in ascending order.
+    has_onsets: A Boolean matrix with shape `[num_frames, num_pitches]` where
+        entry (i,j) indicates whether pitch j has a note onset in frame i.
+    has_notes: A Boolean matrix with shape `[num_frames, num_pitches]` where
+        entry (i,j) indicates whether pitch j is present in frame i, either as
+        an onset or a sustained note.
+    event_times: A list of length `num_frames - 1` containing the event times
+        separating adjacent frames.
+  &#34;&#34;&#34;
+  notes = [note for note in sequence.notes
+           if not note.is_drum
+           and note.program not in constants.UNPITCHED_PROGRAMS]
+
+  onset_times = [note.start_time for note in notes]
+  offset_times = [note.end_time for note in notes]
+  event_times = set(onset_times + offset_times)
+
+  event_times.discard(0.0)
+  event_times.discard(sequence.total_time)
+
+  event_times = sorted(event_times)
+  num_frames = len(event_times) + 1
+
+  pitches = sorted(set(note.pitch for note in notes))
+  pitch_map = dict((p, i) for i, p in enumerate(pitches))
+  num_pitches = len(pitches)
+
+  has_onsets = np.zeros([num_frames, num_pitches], dtype=bool)
+  has_notes = np.zeros([num_frames, num_pitches], dtype=bool)
+
+  for note in notes:
+    start_frame = bisect.bisect_right(event_times, note.start_time)
+    end_frame = bisect.bisect_left(event_times, note.end_time)
+
+    has_onsets[start_frame, pitch_map[note.pitch]] = True
+    has_notes[start_frame:end_frame+1, pitch_map[note.pitch]] = True
+
+  return pitches, has_onsets, has_notes, event_times</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melody_inference.MelodyInferenceError"><code class="flex name class">
+<span>class <span class="ident">MelodyInferenceError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyInferenceError(Exception):  # pylint:disable=g-bad-exception-name
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.melody_inference.infer_melody_for_sequence" href="#note_seq.melody_inference.infer_melody_for_sequence">infer_melody_for_sequence</a></code></li>
+<li><code><a title="note_seq.melody_inference.sequence_note_frames" href="#note_seq.melody_inference.sequence_note_frames">sequence_note_frames</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melody_inference.MelodyInferenceError" href="#note_seq.melody_inference.MelodyInferenceError">MelodyInferenceError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/melody_inference_test.html
+++ b/docs/melody_inference_test.html
@@ -1,0 +1,436 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.melody_inference_test API documentation</title>
+<meta name="description" content="Tests for melody inference." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.melody_inference_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for melody inference.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for melody inference.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import melody_inference
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+
+class MelodyInferenceTest(absltest.TestCase):
+
+  def testSequenceNoteFrames(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.5, 2.0), (62, 100, 1.0, 1.25)])
+
+    pitches, has_onsets, has_notes, event_times = (
+        melody_inference.sequence_note_frames(sequence))
+
+    expected_pitches = [60, 62]
+    expected_has_onsets = [[0, 0], [1, 0], [0, 1], [0, 0]]
+    expected_has_notes = [[0, 0], [1, 0], [1, 1], [1, 0]]
+    expected_event_times = [0.5, 1.0, 1.25]
+
+    self.assertEqual(expected_pitches, pitches)
+    self.assertEqual(expected_has_onsets, has_onsets.tolist())
+    self.assertEqual(expected_has_notes, has_notes.tolist())
+    self.assertEqual(expected_event_times, event_times)
+
+  def testMelodyInferenceEmptySequence(self):
+    sequence = music_pb2.NoteSequence()
+    melody_inference.infer_melody_for_sequence(sequence)
+    expected_sequence = music_pb2.NoteSequence()
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferenceSingleNote(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(60, 100, 0.5, 1.0)])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(60, 100, 0.5, 1.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1, [(60, 127, 0.5, 1.0)])
+
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferenceMonophonic(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1,
+        [(60, 127, 0.5, 1.0), (62, 127, 1.0, 2.0), (64, 127, 2.0, 4.0)])
+
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferencePolyphonic(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [
+            (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+            (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+            (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+            (72, 100, 3.0, 4.0)
+        ])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [
+            (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+            (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+            (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+            (72, 100, 3.0, 4.0)
+        ])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1, [
+            (67, 127, 0.0, 1.0), (69, 127, 1.0, 2.0),
+            (71, 127, 2.0, 3.0), (72, 127, 3.0, 4.0)
+        ])
+
+    self.assertEqual(expected_sequence, sequence)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest"><code class="flex name class">
+<span>class <span class="ident">MelodyInferenceTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MelodyInferenceTest(absltest.TestCase):
+
+  def testSequenceNoteFrames(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.5, 2.0), (62, 100, 1.0, 1.25)])
+
+    pitches, has_onsets, has_notes, event_times = (
+        melody_inference.sequence_note_frames(sequence))
+
+    expected_pitches = [60, 62]
+    expected_has_onsets = [[0, 0], [1, 0], [0, 1], [0, 0]]
+    expected_has_notes = [[0, 0], [1, 0], [1, 1], [1, 0]]
+    expected_event_times = [0.5, 1.0, 1.25]
+
+    self.assertEqual(expected_pitches, pitches)
+    self.assertEqual(expected_has_onsets, has_onsets.tolist())
+    self.assertEqual(expected_has_notes, has_notes.tolist())
+    self.assertEqual(expected_event_times, event_times)
+
+  def testMelodyInferenceEmptySequence(self):
+    sequence = music_pb2.NoteSequence()
+    melody_inference.infer_melody_for_sequence(sequence)
+    expected_sequence = music_pb2.NoteSequence()
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferenceSingleNote(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(60, 100, 0.5, 1.0)])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(60, 100, 0.5, 1.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1, [(60, 127, 0.5, 1.0)])
+
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferenceMonophonic(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1,
+        [(60, 127, 0.5, 1.0), (62, 127, 1.0, 2.0), (64, 127, 2.0, 4.0)])
+
+    self.assertEqual(expected_sequence, sequence)
+
+  def testMelodyInferencePolyphonic(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [
+            (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+            (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+            (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+            (72, 100, 3.0, 4.0)
+        ])
+
+    melody_inference.infer_melody_for_sequence(sequence)
+
+    expected_sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [
+            (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+            (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+            (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+            (72, 100, 3.0, 4.0)
+        ])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 1, [
+            (67, 127, 0.0, 1.0), (69, 127, 1.0, 2.0),
+            (71, 127, 2.0, 3.0), (72, 127, 3.0, 4.0)
+        ])
+
+    self.assertEqual(expected_sequence, sequence)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceEmptySequence"><code class="name flex">
+<span>def <span class="ident">testMelodyInferenceEmptySequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMelodyInferenceEmptySequence(self):
+  sequence = music_pb2.NoteSequence()
+  melody_inference.infer_melody_for_sequence(sequence)
+  expected_sequence = music_pb2.NoteSequence()
+  self.assertEqual(expected_sequence, sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceMonophonic"><code class="name flex">
+<span>def <span class="ident">testMelodyInferenceMonophonic</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMelodyInferenceMonophonic(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+
+  melody_inference.infer_melody_for_sequence(sequence)
+
+  expected_sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.5, 1.0), (62, 100, 1.0, 2.0), (64, 100, 2.0, 4.0)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 1,
+      [(60, 127, 0.5, 1.0), (62, 127, 1.0, 2.0), (64, 127, 2.0, 4.0)])
+
+  self.assertEqual(expected_sequence, sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferencePolyphonic"><code class="name flex">
+<span>def <span class="ident">testMelodyInferencePolyphonic</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMelodyInferencePolyphonic(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [
+          (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+          (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+          (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+          (72, 100, 3.0, 4.0)
+      ])
+
+  melody_inference.infer_melody_for_sequence(sequence)
+
+  expected_sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [
+          (36, 100, 0.0, 4.0), (64, 100, 0.0, 1.0), (67, 100, 0.0, 1.0),
+          (65, 100, 1.0, 2.0), (69, 100, 1.0, 2.0),
+          (67, 100, 2.0, 4.0), (71, 100, 2.0, 3.0),
+          (72, 100, 3.0, 4.0)
+      ])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 1, [
+          (67, 127, 0.0, 1.0), (69, 127, 1.0, 2.0),
+          (71, 127, 2.0, 3.0), (72, 127, 3.0, 4.0)
+      ])
+
+  self.assertEqual(expected_sequence, sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceSingleNote"><code class="name flex">
+<span>def <span class="ident">testMelodyInferenceSingleNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMelodyInferenceSingleNote(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(60, 100, 0.5, 1.0)])
+
+  melody_inference.infer_melody_for_sequence(sequence)
+
+  expected_sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [(60, 100, 0.5, 1.0)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 1, [(60, 127, 0.5, 1.0)])
+
+  self.assertEqual(expected_sequence, sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.melody_inference_test.MelodyInferenceTest.testSequenceNoteFrames"><code class="name flex">
+<span>def <span class="ident">testSequenceNoteFrames</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceNoteFrames(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.5, 2.0), (62, 100, 1.0, 1.25)])
+
+  pitches, has_onsets, has_notes, event_times = (
+      melody_inference.sequence_note_frames(sequence))
+
+  expected_pitches = [60, 62]
+  expected_has_onsets = [[0, 0], [1, 0], [0, 1], [0, 0]]
+  expected_has_notes = [[0, 0], [1, 0], [1, 1], [1, 0]]
+  expected_event_times = [0.5, 1.0, 1.25]
+
+  self.assertEqual(expected_pitches, pitches)
+  self.assertEqual(expected_has_onsets, has_onsets.tolist())
+  self.assertEqual(expected_has_notes, has_notes.tolist())
+  self.assertEqual(expected_event_times, event_times)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.melody_inference_test.MelodyInferenceTest" href="#note_seq.melody_inference_test.MelodyInferenceTest">MelodyInferenceTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceEmptySequence" href="#note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceEmptySequence">testMelodyInferenceEmptySequence</a></code></li>
+<li><code><a title="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceMonophonic" href="#note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceMonophonic">testMelodyInferenceMonophonic</a></code></li>
+<li><code><a title="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferencePolyphonic" href="#note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferencePolyphonic">testMelodyInferencePolyphonic</a></code></li>
+<li><code><a title="note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceSingleNote" href="#note_seq.melody_inference_test.MelodyInferenceTest.testMelodyInferenceSingleNote">testMelodyInferenceSingleNote</a></code></li>
+<li><code><a title="note_seq.melody_inference_test.MelodyInferenceTest.testSequenceNoteFrames" href="#note_seq.melody_inference_test.MelodyInferenceTest.testSequenceNoteFrames">testSequenceNoteFrames</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/midi_io.html
+++ b/docs/midi_io.html
@@ -1,0 +1,916 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.midi_io API documentation</title>
+<meta name="description" content="MIDI ops …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.midi_io</code></h1>
+</header>
+<section id="section-intro">
+<p>MIDI ops.</p>
+<p>Input and output wrappers for converting between MIDI and other formats.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;MIDI ops.
+
+Input and output wrappers for converting between MIDI and other formats.
+&#34;&#34;&#34;
+
+import collections
+import io
+import sys
+
+from note_seq import constants
+from note_seq.protobuf import music_pb2
+import pretty_midi
+
+
+# Allow pretty_midi to read MIDI files with absurdly high tick rates.
+# Useful for reading the MAPS dataset.
+# https://github.com/craffel/pretty-midi/issues/112
+pretty_midi.pretty_midi.MAX_TICK = 1e10
+
+# The offset used to change the mode of a key from major to minor when
+# generating a PrettyMIDI KeySignature.
+_PRETTY_MIDI_MAJOR_TO_MINOR_OFFSET = 12
+
+
+class MIDIConversionError(Exception):
+  pass
+
+
+def midi_to_note_sequence(midi_data):
+  &#34;&#34;&#34;Convert MIDI file contents to a NoteSequence.
+
+  Converts a MIDI file encoded as a string into a NoteSequence. Decoding errors
+  are very common when working with large sets of MIDI files, so be sure to
+  handle MIDIConversionError exceptions.
+
+  Args:
+    midi_data: A string containing the contents of a MIDI file or populated
+        pretty_midi.PrettyMIDI object.
+
+  Returns:
+    A NoteSequence.
+
+  Raises:
+    MIDIConversionError: An improper MIDI mode was supplied.
+  &#34;&#34;&#34;
+  # In practice many MIDI files cannot be decoded with pretty_midi. Catch all
+  # errors here and try to log a meaningful message. So many different
+  # exceptions are raised in pretty_midi.PrettyMidi that it is cumbersome to
+  # catch them all only for the purpose of error logging.
+  # pylint: disable=bare-except
+  if isinstance(midi_data, pretty_midi.PrettyMIDI):
+    midi = midi_data
+  else:
+    try:
+      midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_data))
+    except:
+      raise MIDIConversionError(&#39;Midi decoding error %s: %s&#39; %
+                                (sys.exc_info()[0], sys.exc_info()[1]))
+  # pylint: enable=bare-except
+
+  sequence = music_pb2.NoteSequence()
+
+  # Populate header.
+  sequence.ticks_per_quarter = midi.resolution
+  sequence.source_info.parser = music_pb2.NoteSequence.SourceInfo.PRETTY_MIDI
+  sequence.source_info.encoding_type = (
+      music_pb2.NoteSequence.SourceInfo.MIDI)
+
+  # Populate time signatures.
+  for midi_time in midi.time_signature_changes:
+    time_signature = sequence.time_signatures.add()
+    time_signature.time = midi_time.time
+    time_signature.numerator = midi_time.numerator
+    try:
+      # Denominator can be too large for int32.
+      time_signature.denominator = midi_time.denominator
+    except ValueError:
+      raise MIDIConversionError(&#39;Invalid time signature denominator %d&#39; %
+                                midi_time.denominator)
+
+  # Populate key signatures.
+  for midi_key in midi.key_signature_changes:
+    key_signature = sequence.key_signatures.add()
+    key_signature.time = midi_key.time
+    key_signature.key = midi_key.key_number % 12
+    midi_mode = midi_key.key_number // 12
+    if midi_mode == 0:
+      key_signature.mode = key_signature.MAJOR
+    elif midi_mode == 1:
+      key_signature.mode = key_signature.MINOR
+    else:
+      raise MIDIConversionError(&#39;Invalid midi_mode %i&#39; % midi_mode)
+
+  # Populate tempo changes.
+  tempo_times, tempo_qpms = midi.get_tempo_changes()
+  for time_in_seconds, tempo_in_qpm in zip(tempo_times, tempo_qpms):
+    tempo = sequence.tempos.add()
+    tempo.time = time_in_seconds
+    tempo.qpm = tempo_in_qpm
+
+  # Populate notes by gathering them all from the midi&#39;s instruments.
+  # Also set the sequence.total_time as the max end time in the notes.
+  midi_notes = []
+  midi_pitch_bends = []
+  midi_control_changes = []
+  for num_instrument, midi_instrument in enumerate(midi.instruments):
+    # Populate instrument name from the midi&#39;s instruments
+    if midi_instrument.name:
+      instrument_info = sequence.instrument_infos.add()
+      instrument_info.name = midi_instrument.name
+      instrument_info.instrument = num_instrument
+    for midi_note in midi_instrument.notes:
+      if not sequence.total_time or midi_note.end &gt; sequence.total_time:
+        sequence.total_time = midi_note.end
+      midi_notes.append((midi_instrument.program, num_instrument,
+                         midi_instrument.is_drum, midi_note))
+    for midi_pitch_bend in midi_instrument.pitch_bends:
+      midi_pitch_bends.append(
+          (midi_instrument.program, num_instrument,
+           midi_instrument.is_drum, midi_pitch_bend))
+    for midi_control_change in midi_instrument.control_changes:
+      midi_control_changes.append(
+          (midi_instrument.program, num_instrument,
+           midi_instrument.is_drum, midi_control_change))
+
+  for program, instrument, is_drum, midi_note in midi_notes:
+    note = sequence.notes.add()
+    note.instrument = instrument
+    note.program = program
+    note.start_time = midi_note.start
+    note.end_time = midi_note.end
+    note.pitch = midi_note.pitch
+    note.velocity = midi_note.velocity
+    note.is_drum = is_drum
+
+  for program, instrument, is_drum, midi_pitch_bend in midi_pitch_bends:
+    pitch_bend = sequence.pitch_bends.add()
+    pitch_bend.instrument = instrument
+    pitch_bend.program = program
+    pitch_bend.time = midi_pitch_bend.time
+    pitch_bend.bend = midi_pitch_bend.pitch
+    pitch_bend.is_drum = is_drum
+
+  for program, instrument, is_drum, midi_control_change in midi_control_changes:
+    control_change = sequence.control_changes.add()
+    control_change.instrument = instrument
+    control_change.program = program
+    control_change.time = midi_control_change.time
+    control_change.control_number = midi_control_change.number
+    control_change.control_value = midi_control_change.value
+    control_change.is_drum = is_drum
+
+  # TODO(douglaseck): Estimate note type (e.g. quarter note) and populate
+  # note.numerator and note.denominator.
+
+  return sequence
+
+
+def midi_file_to_note_sequence(midi_file):
+  &#34;&#34;&#34;Converts MIDI file to a NoteSequence.
+
+  Args:
+    midi_file: A string path to a MIDI file.
+
+  Returns:
+    A NoteSequence.
+
+  Raises:
+    MIDIConversionError: Invalid midi_file.
+  &#34;&#34;&#34;
+  with open(midi_file, &#39;rb&#39;) as f:
+    midi_as_string = f.read()
+    return midi_to_note_sequence(midi_as_string)
+
+
+def note_sequence_to_midi_file(sequence, output_file,
+                               drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Convert NoteSequence to a MIDI file on disk.
+
+  Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+  relative values (MIDI ticks). When the NoteSequence is translated back to
+  MIDI the absolute time is retained. The tempo map is also recreated.
+
+  Args:
+    sequence: A NoteSequence.
+    output_file: String path to MIDI file that will be written.
+    drop_events_n_seconds_after_last_note: Events (e.g., time signature changes)
+        that occur this many seconds after the last note will be dropped. If
+        None, then no events will be dropped.
+  &#34;&#34;&#34;
+  pretty_midi_object = note_sequence_to_pretty_midi(
+      sequence, drop_events_n_seconds_after_last_note)
+  pretty_midi_object.write(open(output_file, &#39;wb&#39;))
+
+
+def note_sequence_to_pretty_midi(
+    sequence, drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Convert NoteSequence to a PrettyMIDI.
+
+  Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+  relative values (MIDI ticks). When the NoteSequence is translated back to
+  PrettyMIDI the absolute time is retained. The tempo map is also recreated.
+
+  Args:
+    sequence: A NoteSequence.
+    drop_events_n_seconds_after_last_note: Events (e.g., time signature changes)
+        that occur this many seconds after the last note will be dropped. If
+        None, then no events will be dropped.
+
+  Returns:
+    A pretty_midi.PrettyMIDI object or None if sequence could not be decoded.
+  &#34;&#34;&#34;
+  ticks_per_quarter = sequence.ticks_per_quarter or constants.STANDARD_PPQ
+
+  max_event_time = None
+  if drop_events_n_seconds_after_last_note is not None:
+    max_event_time = (max([n.end_time for n in sequence.notes] or [0]) +
+                      drop_events_n_seconds_after_last_note)
+
+  # Try to find a tempo at time zero. The list is not guaranteed to be in order.
+  initial_seq_tempo = None
+  for seq_tempo in sequence.tempos:
+    if seq_tempo.time == 0:
+      initial_seq_tempo = seq_tempo
+      break
+
+  kwargs = {}
+  if initial_seq_tempo:
+    kwargs[&#39;initial_tempo&#39;] = initial_seq_tempo.qpm
+  else:
+    kwargs[&#39;initial_tempo&#39;] = constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  pm = pretty_midi.PrettyMIDI(resolution=ticks_per_quarter, **kwargs)
+
+  # Create an empty instrument to contain time and key signatures.
+  instrument = pretty_midi.Instrument(0)
+  pm.instruments.append(instrument)
+
+  # Populate time signatures.
+  for seq_ts in sequence.time_signatures:
+    if max_event_time and seq_ts.time &gt; max_event_time:
+      continue
+    time_signature = pretty_midi.containers.TimeSignature(
+        seq_ts.numerator, seq_ts.denominator, seq_ts.time)
+    pm.time_signature_changes.append(time_signature)
+
+  # Populate key signatures.
+  for seq_key in sequence.key_signatures:
+    if max_event_time and seq_key.time &gt; max_event_time:
+      continue
+    key_number = seq_key.key
+    if seq_key.mode == seq_key.MINOR:
+      key_number += _PRETTY_MIDI_MAJOR_TO_MINOR_OFFSET
+    key_signature = pretty_midi.containers.KeySignature(
+        key_number, seq_key.time)
+    pm.key_signature_changes.append(key_signature)
+
+  # Populate tempos.
+  # TODO(douglaseck): Update this code if pretty_midi adds the ability to
+  # write tempo.
+  for seq_tempo in sequence.tempos:
+    # Skip if this tempo was added in the PrettyMIDI constructor.
+    if seq_tempo == initial_seq_tempo:
+      continue
+    if max_event_time and seq_tempo.time &gt; max_event_time:
+      continue
+    tick_scale = 60.0 / (pm.resolution * seq_tempo.qpm)
+    tick = pm.time_to_tick(seq_tempo.time)
+    # pylint: disable=protected-access
+    pm._tick_scales.append((tick, tick_scale))
+    pm._update_tick_to_time(0)
+    # pylint: enable=protected-access
+
+  # Populate instrument names by first creating an instrument map between
+  # instrument index and name.
+  # Then, going over this map in the instrument event for loop
+  inst_infos = {}
+  for inst_info in sequence.instrument_infos:
+    inst_infos[inst_info.instrument] = inst_info.name
+
+  # Populate instrument events by first gathering notes and other event types
+  # in lists then write them sorted to the PrettyMidi object.
+  instrument_events = collections.defaultdict(
+      lambda: collections.defaultdict(list))
+  for seq_note in sequence.notes:
+    instrument_events[(seq_note.instrument, seq_note.program,
+                       seq_note.is_drum)][&#39;notes&#39;].append(
+                           pretty_midi.Note(
+                               seq_note.velocity, seq_note.pitch,
+                               seq_note.start_time, seq_note.end_time))
+  for seq_bend in sequence.pitch_bends:
+    if max_event_time and seq_bend.time &gt; max_event_time:
+      continue
+    instrument_events[(seq_bend.instrument, seq_bend.program,
+                       seq_bend.is_drum)][&#39;bends&#39;].append(
+                           pretty_midi.PitchBend(seq_bend.bend, seq_bend.time))
+  for seq_cc in sequence.control_changes:
+    if max_event_time and seq_cc.time &gt; max_event_time:
+      continue
+    instrument_events[(seq_cc.instrument, seq_cc.program,
+                       seq_cc.is_drum)][&#39;controls&#39;].append(
+                           pretty_midi.ControlChange(
+                               seq_cc.control_number,
+                               seq_cc.control_value, seq_cc.time))
+
+  for (instr_id, prog_id, is_drum) in sorted(instrument_events.keys()):
+    # For instr_id 0 append to the instrument created above.
+    if instr_id &gt; 0:
+      instrument = pretty_midi.Instrument(prog_id, is_drum)
+      pm.instruments.append(instrument)
+    else:
+      instrument.is_drum = is_drum
+    # propagate instrument name to the midi file
+    instrument.program = prog_id
+    if instr_id in inst_infos:
+      instrument.name = inst_infos[instr_id]
+    instrument.notes = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;notes&#39;]
+    instrument.pitch_bends = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;bends&#39;]
+    instrument.control_changes = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;controls&#39;]
+
+  return pm
+
+
+def midi_to_sequence_proto(midi_data):
+  &#34;&#34;&#34;Renamed to midi_to_note_sequence.&#34;&#34;&#34;
+  return midi_to_note_sequence(midi_data)
+
+
+def sequence_proto_to_pretty_midi(sequence,
+                                  drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Renamed to note_sequence_to_pretty_midi.&#34;&#34;&#34;
+  return note_sequence_to_pretty_midi(sequence,
+                                      drop_events_n_seconds_after_last_note)
+
+
+def midi_file_to_sequence_proto(midi_file):
+  &#34;&#34;&#34;Renamed to midi_file_to_note_sequence.&#34;&#34;&#34;
+  return midi_file_to_note_sequence(midi_file)
+
+
+def sequence_proto_to_midi_file(sequence, output_file,
+                                drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Renamed to note_sequence_to_midi_file.&#34;&#34;&#34;
+  return note_sequence_to_midi_file(sequence, output_file,
+                                    drop_events_n_seconds_after_last_note)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.midi_io.midi_file_to_note_sequence"><code class="name flex">
+<span>def <span class="ident">midi_file_to_note_sequence</span></span>(<span>midi_file)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts MIDI file to a NoteSequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>midi_file</code></strong></dt>
+<dd>A string path to a MIDI file.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.midi_io.MIDIConversionError" href="#note_seq.midi_io.MIDIConversionError">MIDIConversionError</a></code></dt>
+<dd>Invalid midi_file.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_file_to_note_sequence(midi_file):
+  &#34;&#34;&#34;Converts MIDI file to a NoteSequence.
+
+  Args:
+    midi_file: A string path to a MIDI file.
+
+  Returns:
+    A NoteSequence.
+
+  Raises:
+    MIDIConversionError: Invalid midi_file.
+  &#34;&#34;&#34;
+  with open(midi_file, &#39;rb&#39;) as f:
+    midi_as_string = f.read()
+    return midi_to_note_sequence(midi_as_string)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.midi_file_to_sequence_proto"><code class="name flex">
+<span>def <span class="ident">midi_file_to_sequence_proto</span></span>(<span>midi_file)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Renamed to midi_file_to_note_sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_file_to_sequence_proto(midi_file):
+  &#34;&#34;&#34;Renamed to midi_file_to_note_sequence.&#34;&#34;&#34;
+  return midi_file_to_note_sequence(midi_file)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.midi_to_note_sequence"><code class="name flex">
+<span>def <span class="ident">midi_to_note_sequence</span></span>(<span>midi_data)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert MIDI file contents to a NoteSequence.</p>
+<p>Converts a MIDI file encoded as a string into a NoteSequence. Decoding errors
+are very common when working with large sets of MIDI files, so be sure to
+handle MIDIConversionError exceptions.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>midi_data</code></strong></dt>
+<dd>A string containing the contents of a MIDI file or populated
+pretty_midi.PrettyMIDI object.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.midi_io.MIDIConversionError" href="#note_seq.midi_io.MIDIConversionError">MIDIConversionError</a></code></dt>
+<dd>An improper MIDI mode was supplied.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_to_note_sequence(midi_data):
+  &#34;&#34;&#34;Convert MIDI file contents to a NoteSequence.
+
+  Converts a MIDI file encoded as a string into a NoteSequence. Decoding errors
+  are very common when working with large sets of MIDI files, so be sure to
+  handle MIDIConversionError exceptions.
+
+  Args:
+    midi_data: A string containing the contents of a MIDI file or populated
+        pretty_midi.PrettyMIDI object.
+
+  Returns:
+    A NoteSequence.
+
+  Raises:
+    MIDIConversionError: An improper MIDI mode was supplied.
+  &#34;&#34;&#34;
+  # In practice many MIDI files cannot be decoded with pretty_midi. Catch all
+  # errors here and try to log a meaningful message. So many different
+  # exceptions are raised in pretty_midi.PrettyMidi that it is cumbersome to
+  # catch them all only for the purpose of error logging.
+  # pylint: disable=bare-except
+  if isinstance(midi_data, pretty_midi.PrettyMIDI):
+    midi = midi_data
+  else:
+    try:
+      midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_data))
+    except:
+      raise MIDIConversionError(&#39;Midi decoding error %s: %s&#39; %
+                                (sys.exc_info()[0], sys.exc_info()[1]))
+  # pylint: enable=bare-except
+
+  sequence = music_pb2.NoteSequence()
+
+  # Populate header.
+  sequence.ticks_per_quarter = midi.resolution
+  sequence.source_info.parser = music_pb2.NoteSequence.SourceInfo.PRETTY_MIDI
+  sequence.source_info.encoding_type = (
+      music_pb2.NoteSequence.SourceInfo.MIDI)
+
+  # Populate time signatures.
+  for midi_time in midi.time_signature_changes:
+    time_signature = sequence.time_signatures.add()
+    time_signature.time = midi_time.time
+    time_signature.numerator = midi_time.numerator
+    try:
+      # Denominator can be too large for int32.
+      time_signature.denominator = midi_time.denominator
+    except ValueError:
+      raise MIDIConversionError(&#39;Invalid time signature denominator %d&#39; %
+                                midi_time.denominator)
+
+  # Populate key signatures.
+  for midi_key in midi.key_signature_changes:
+    key_signature = sequence.key_signatures.add()
+    key_signature.time = midi_key.time
+    key_signature.key = midi_key.key_number % 12
+    midi_mode = midi_key.key_number // 12
+    if midi_mode == 0:
+      key_signature.mode = key_signature.MAJOR
+    elif midi_mode == 1:
+      key_signature.mode = key_signature.MINOR
+    else:
+      raise MIDIConversionError(&#39;Invalid midi_mode %i&#39; % midi_mode)
+
+  # Populate tempo changes.
+  tempo_times, tempo_qpms = midi.get_tempo_changes()
+  for time_in_seconds, tempo_in_qpm in zip(tempo_times, tempo_qpms):
+    tempo = sequence.tempos.add()
+    tempo.time = time_in_seconds
+    tempo.qpm = tempo_in_qpm
+
+  # Populate notes by gathering them all from the midi&#39;s instruments.
+  # Also set the sequence.total_time as the max end time in the notes.
+  midi_notes = []
+  midi_pitch_bends = []
+  midi_control_changes = []
+  for num_instrument, midi_instrument in enumerate(midi.instruments):
+    # Populate instrument name from the midi&#39;s instruments
+    if midi_instrument.name:
+      instrument_info = sequence.instrument_infos.add()
+      instrument_info.name = midi_instrument.name
+      instrument_info.instrument = num_instrument
+    for midi_note in midi_instrument.notes:
+      if not sequence.total_time or midi_note.end &gt; sequence.total_time:
+        sequence.total_time = midi_note.end
+      midi_notes.append((midi_instrument.program, num_instrument,
+                         midi_instrument.is_drum, midi_note))
+    for midi_pitch_bend in midi_instrument.pitch_bends:
+      midi_pitch_bends.append(
+          (midi_instrument.program, num_instrument,
+           midi_instrument.is_drum, midi_pitch_bend))
+    for midi_control_change in midi_instrument.control_changes:
+      midi_control_changes.append(
+          (midi_instrument.program, num_instrument,
+           midi_instrument.is_drum, midi_control_change))
+
+  for program, instrument, is_drum, midi_note in midi_notes:
+    note = sequence.notes.add()
+    note.instrument = instrument
+    note.program = program
+    note.start_time = midi_note.start
+    note.end_time = midi_note.end
+    note.pitch = midi_note.pitch
+    note.velocity = midi_note.velocity
+    note.is_drum = is_drum
+
+  for program, instrument, is_drum, midi_pitch_bend in midi_pitch_bends:
+    pitch_bend = sequence.pitch_bends.add()
+    pitch_bend.instrument = instrument
+    pitch_bend.program = program
+    pitch_bend.time = midi_pitch_bend.time
+    pitch_bend.bend = midi_pitch_bend.pitch
+    pitch_bend.is_drum = is_drum
+
+  for program, instrument, is_drum, midi_control_change in midi_control_changes:
+    control_change = sequence.control_changes.add()
+    control_change.instrument = instrument
+    control_change.program = program
+    control_change.time = midi_control_change.time
+    control_change.control_number = midi_control_change.number
+    control_change.control_value = midi_control_change.value
+    control_change.is_drum = is_drum
+
+  # TODO(douglaseck): Estimate note type (e.g. quarter note) and populate
+  # note.numerator and note.denominator.
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.midi_to_sequence_proto"><code class="name flex">
+<span>def <span class="ident">midi_to_sequence_proto</span></span>(<span>midi_data)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Renamed to midi_to_note_sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def midi_to_sequence_proto(midi_data):
+  &#34;&#34;&#34;Renamed to midi_to_note_sequence.&#34;&#34;&#34;
+  return midi_to_note_sequence(midi_data)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.note_sequence_to_midi_file"><code class="name flex">
+<span>def <span class="ident">note_sequence_to_midi_file</span></span>(<span>sequence, output_file, drop_events_n_seconds_after_last_note=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert NoteSequence to a MIDI file on disk.</p>
+<p>Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+relative values (MIDI ticks). When the NoteSequence is translated back to
+MIDI the absolute time is retained. The tempo map is also recreated.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A NoteSequence.</dd>
+<dt><strong><code>output_file</code></strong></dt>
+<dd>String path to MIDI file that will be written.</dd>
+<dt><strong><code>drop_events_n_seconds_after_last_note</code></strong></dt>
+<dd>Events (e.g., time signature changes)
+that occur this many seconds after the last note will be dropped. If
+None, then no events will be dropped.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def note_sequence_to_midi_file(sequence, output_file,
+                               drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Convert NoteSequence to a MIDI file on disk.
+
+  Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+  relative values (MIDI ticks). When the NoteSequence is translated back to
+  MIDI the absolute time is retained. The tempo map is also recreated.
+
+  Args:
+    sequence: A NoteSequence.
+    output_file: String path to MIDI file that will be written.
+    drop_events_n_seconds_after_last_note: Events (e.g., time signature changes)
+        that occur this many seconds after the last note will be dropped. If
+        None, then no events will be dropped.
+  &#34;&#34;&#34;
+  pretty_midi_object = note_sequence_to_pretty_midi(
+      sequence, drop_events_n_seconds_after_last_note)
+  pretty_midi_object.write(open(output_file, &#39;wb&#39;))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.note_sequence_to_pretty_midi"><code class="name flex">
+<span>def <span class="ident">note_sequence_to_pretty_midi</span></span>(<span>sequence, drop_events_n_seconds_after_last_note=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert NoteSequence to a PrettyMIDI.</p>
+<p>Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+relative values (MIDI ticks). When the NoteSequence is translated back to
+PrettyMIDI the absolute time is retained. The tempo map is also recreated.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A NoteSequence.</dd>
+<dt><strong><code>drop_events_n_seconds_after_last_note</code></strong></dt>
+<dd>Events (e.g., time signature changes)
+that occur this many seconds after the last note will be dropped. If
+None, then no events will be dropped.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A pretty_midi.PrettyMIDI object or None if sequence could not be decoded.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def note_sequence_to_pretty_midi(
+    sequence, drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Convert NoteSequence to a PrettyMIDI.
+
+  Time is stored in the NoteSequence in absolute values (seconds) as opposed to
+  relative values (MIDI ticks). When the NoteSequence is translated back to
+  PrettyMIDI the absolute time is retained. The tempo map is also recreated.
+
+  Args:
+    sequence: A NoteSequence.
+    drop_events_n_seconds_after_last_note: Events (e.g., time signature changes)
+        that occur this many seconds after the last note will be dropped. If
+        None, then no events will be dropped.
+
+  Returns:
+    A pretty_midi.PrettyMIDI object or None if sequence could not be decoded.
+  &#34;&#34;&#34;
+  ticks_per_quarter = sequence.ticks_per_quarter or constants.STANDARD_PPQ
+
+  max_event_time = None
+  if drop_events_n_seconds_after_last_note is not None:
+    max_event_time = (max([n.end_time for n in sequence.notes] or [0]) +
+                      drop_events_n_seconds_after_last_note)
+
+  # Try to find a tempo at time zero. The list is not guaranteed to be in order.
+  initial_seq_tempo = None
+  for seq_tempo in sequence.tempos:
+    if seq_tempo.time == 0:
+      initial_seq_tempo = seq_tempo
+      break
+
+  kwargs = {}
+  if initial_seq_tempo:
+    kwargs[&#39;initial_tempo&#39;] = initial_seq_tempo.qpm
+  else:
+    kwargs[&#39;initial_tempo&#39;] = constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  pm = pretty_midi.PrettyMIDI(resolution=ticks_per_quarter, **kwargs)
+
+  # Create an empty instrument to contain time and key signatures.
+  instrument = pretty_midi.Instrument(0)
+  pm.instruments.append(instrument)
+
+  # Populate time signatures.
+  for seq_ts in sequence.time_signatures:
+    if max_event_time and seq_ts.time &gt; max_event_time:
+      continue
+    time_signature = pretty_midi.containers.TimeSignature(
+        seq_ts.numerator, seq_ts.denominator, seq_ts.time)
+    pm.time_signature_changes.append(time_signature)
+
+  # Populate key signatures.
+  for seq_key in sequence.key_signatures:
+    if max_event_time and seq_key.time &gt; max_event_time:
+      continue
+    key_number = seq_key.key
+    if seq_key.mode == seq_key.MINOR:
+      key_number += _PRETTY_MIDI_MAJOR_TO_MINOR_OFFSET
+    key_signature = pretty_midi.containers.KeySignature(
+        key_number, seq_key.time)
+    pm.key_signature_changes.append(key_signature)
+
+  # Populate tempos.
+  # TODO(douglaseck): Update this code if pretty_midi adds the ability to
+  # write tempo.
+  for seq_tempo in sequence.tempos:
+    # Skip if this tempo was added in the PrettyMIDI constructor.
+    if seq_tempo == initial_seq_tempo:
+      continue
+    if max_event_time and seq_tempo.time &gt; max_event_time:
+      continue
+    tick_scale = 60.0 / (pm.resolution * seq_tempo.qpm)
+    tick = pm.time_to_tick(seq_tempo.time)
+    # pylint: disable=protected-access
+    pm._tick_scales.append((tick, tick_scale))
+    pm._update_tick_to_time(0)
+    # pylint: enable=protected-access
+
+  # Populate instrument names by first creating an instrument map between
+  # instrument index and name.
+  # Then, going over this map in the instrument event for loop
+  inst_infos = {}
+  for inst_info in sequence.instrument_infos:
+    inst_infos[inst_info.instrument] = inst_info.name
+
+  # Populate instrument events by first gathering notes and other event types
+  # in lists then write them sorted to the PrettyMidi object.
+  instrument_events = collections.defaultdict(
+      lambda: collections.defaultdict(list))
+  for seq_note in sequence.notes:
+    instrument_events[(seq_note.instrument, seq_note.program,
+                       seq_note.is_drum)][&#39;notes&#39;].append(
+                           pretty_midi.Note(
+                               seq_note.velocity, seq_note.pitch,
+                               seq_note.start_time, seq_note.end_time))
+  for seq_bend in sequence.pitch_bends:
+    if max_event_time and seq_bend.time &gt; max_event_time:
+      continue
+    instrument_events[(seq_bend.instrument, seq_bend.program,
+                       seq_bend.is_drum)][&#39;bends&#39;].append(
+                           pretty_midi.PitchBend(seq_bend.bend, seq_bend.time))
+  for seq_cc in sequence.control_changes:
+    if max_event_time and seq_cc.time &gt; max_event_time:
+      continue
+    instrument_events[(seq_cc.instrument, seq_cc.program,
+                       seq_cc.is_drum)][&#39;controls&#39;].append(
+                           pretty_midi.ControlChange(
+                               seq_cc.control_number,
+                               seq_cc.control_value, seq_cc.time))
+
+  for (instr_id, prog_id, is_drum) in sorted(instrument_events.keys()):
+    # For instr_id 0 append to the instrument created above.
+    if instr_id &gt; 0:
+      instrument = pretty_midi.Instrument(prog_id, is_drum)
+      pm.instruments.append(instrument)
+    else:
+      instrument.is_drum = is_drum
+    # propagate instrument name to the midi file
+    instrument.program = prog_id
+    if instr_id in inst_infos:
+      instrument.name = inst_infos[instr_id]
+    instrument.notes = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;notes&#39;]
+    instrument.pitch_bends = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;bends&#39;]
+    instrument.control_changes = instrument_events[
+        (instr_id, prog_id, is_drum)][&#39;controls&#39;]
+
+  return pm</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.sequence_proto_to_midi_file"><code class="name flex">
+<span>def <span class="ident">sequence_proto_to_midi_file</span></span>(<span>sequence, output_file, drop_events_n_seconds_after_last_note=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Renamed to note_sequence_to_midi_file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_proto_to_midi_file(sequence, output_file,
+                                drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Renamed to note_sequence_to_midi_file.&#34;&#34;&#34;
+  return note_sequence_to_midi_file(sequence, output_file,
+                                    drop_events_n_seconds_after_last_note)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io.sequence_proto_to_pretty_midi"><code class="name flex">
+<span>def <span class="ident">sequence_proto_to_pretty_midi</span></span>(<span>sequence, drop_events_n_seconds_after_last_note=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Renamed to note_sequence_to_pretty_midi.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_proto_to_pretty_midi(sequence,
+                                  drop_events_n_seconds_after_last_note=None):
+  &#34;&#34;&#34;Renamed to note_sequence_to_pretty_midi.&#34;&#34;&#34;
+  return note_sequence_to_pretty_midi(sequence,
+                                      drop_events_n_seconds_after_last_note)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.midi_io.MIDIConversionError"><code class="flex name class">
+<span>class <span class="ident">MIDIConversionError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MIDIConversionError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.midi_io.midi_file_to_note_sequence" href="#note_seq.midi_io.midi_file_to_note_sequence">midi_file_to_note_sequence</a></code></li>
+<li><code><a title="note_seq.midi_io.midi_file_to_sequence_proto" href="#note_seq.midi_io.midi_file_to_sequence_proto">midi_file_to_sequence_proto</a></code></li>
+<li><code><a title="note_seq.midi_io.midi_to_note_sequence" href="#note_seq.midi_io.midi_to_note_sequence">midi_to_note_sequence</a></code></li>
+<li><code><a title="note_seq.midi_io.midi_to_sequence_proto" href="#note_seq.midi_io.midi_to_sequence_proto">midi_to_sequence_proto</a></code></li>
+<li><code><a title="note_seq.midi_io.note_sequence_to_midi_file" href="#note_seq.midi_io.note_sequence_to_midi_file">note_sequence_to_midi_file</a></code></li>
+<li><code><a title="note_seq.midi_io.note_sequence_to_pretty_midi" href="#note_seq.midi_io.note_sequence_to_pretty_midi">note_sequence_to_pretty_midi</a></code></li>
+<li><code><a title="note_seq.midi_io.sequence_proto_to_midi_file" href="#note_seq.midi_io.sequence_proto_to_midi_file">sequence_proto_to_midi_file</a></code></li>
+<li><code><a title="note_seq.midi_io.sequence_proto_to_pretty_midi" href="#note_seq.midi_io.sequence_proto_to_pretty_midi">sequence_proto_to_pretty_midi</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.midi_io.MIDIConversionError" href="#note_seq.midi_io.MIDIConversionError">MIDIConversionError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/midi_io_test.html
+++ b/docs/midi_io_test.html
@@ -1,0 +1,1325 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.midi_io_test API documentation</title>
+<meta name="description" content="Test to ensure correct midi input and output." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.midi_io_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Test to ensure correct midi input and output.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Test to ensure correct midi input and output.&#34;&#34;&#34;
+import collections
+import os.path
+import tempfile
+
+from absl.testing import absltest
+import mido
+from note_seq import constants
+from note_seq import midi_io
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+import pretty_midi
+
+# self.midi_simple_filename contains a c-major scale of 8 quarter notes each
+# with a sustain of .95 of the entire note. Here are the first two notes dumped
+# using mididump.py:
+#   midi.NoteOnEvent(tick=0, channel=0, data=[60, 100]),
+#   midi.NoteOnEvent(tick=209, channel=0, data=[60, 0]),
+#   midi.NoteOnEvent(tick=11, channel=0, data=[62, 100]),
+#   midi.NoteOnEvent(tick=209, channel=0, data=[62, 0]),
+_SIMPLE_MIDI_FILE_VELO = 100
+_SIMPLE_MIDI_FILE_NUM_NOTES = 8
+_SIMPLE_MIDI_FILE_SUSTAIN = .95
+
+# self.midi_complex_filename contains many instruments including percussion as
+# well as control change and pitch bend events.
+
+# self.midi_is_drum_filename contains 41 tracks, two of which are on channel 9.
+
+# self.midi_event_order_filename contains notes ordered
+# non-monotonically by pitch.  Here are relevent events as printed by
+# mididump.py:
+#   midi.NoteOnEvent(tick=0, channel=0, data=[1, 100]),
+#   midi.NoteOnEvent(tick=0, channel=0, data=[3, 100]),
+#   midi.NoteOnEvent(tick=0, channel=0, data=[2, 100]),
+#   midi.NoteOnEvent(tick=4400, channel=0, data=[3, 0]),
+#   midi.NoteOnEvent(tick=0, channel=0, data=[1, 0]),
+#   midi.NoteOnEvent(tick=0, channel=0, data=[2, 0]),
+
+
+class MidiIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.midi_simple_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example.mid&#39;)
+    self.midi_complex_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_complex.mid&#39;)
+    self.midi_is_drum_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_is_drum.mid&#39;)
+    self.midi_event_order_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_event_order.mid&#39;)
+
+  def CheckPrettyMidiAndSequence(self, midi, sequence_proto):
+    &#34;&#34;&#34;Compares PrettyMIDI object against a sequence proto.
+
+    Args:
+      midi: A pretty_midi.PrettyMIDI object.
+      sequence_proto: A NoteSequence proto.
+    &#34;&#34;&#34;
+    # Test time signature changes.
+    self.assertEqual(len(midi.time_signature_changes),
+                     len(sequence_proto.time_signatures))
+    for midi_time, sequence_time in zip(midi.time_signature_changes,
+                                        sequence_proto.time_signatures):
+      self.assertEqual(midi_time.numerator, sequence_time.numerator)
+      self.assertEqual(midi_time.denominator, sequence_time.denominator)
+      self.assertAlmostEqual(midi_time.time, sequence_time.time)
+
+    # Test key signature changes.
+    self.assertEqual(len(midi.key_signature_changes),
+                     len(sequence_proto.key_signatures))
+    for midi_key, sequence_key in zip(midi.key_signature_changes,
+                                      sequence_proto.key_signatures):
+      self.assertEqual(midi_key.key_number % 12, sequence_key.key)
+      self.assertEqual(midi_key.key_number // 12, sequence_key.mode)
+      self.assertAlmostEqual(midi_key.time, sequence_key.time)
+
+    # Test tempos.
+    midi_times, midi_qpms = midi.get_tempo_changes()
+    self.assertEqual(len(midi_times),
+                     len(sequence_proto.tempos))
+    self.assertEqual(len(midi_qpms),
+                     len(sequence_proto.tempos))
+    for midi_time, midi_qpm, sequence_tempo in zip(
+        midi_times, midi_qpms, sequence_proto.tempos):
+      self.assertAlmostEqual(midi_qpm, sequence_tempo.qpm)
+      self.assertAlmostEqual(midi_time, sequence_tempo.time)
+
+    # Test instruments.
+    seq_instruments = collections.defaultdict(
+        lambda: collections.defaultdict(list))
+    for seq_note in sequence_proto.notes:
+      seq_instruments[
+          (seq_note.instrument, seq_note.program, seq_note.is_drum)][
+              &#39;notes&#39;].append(seq_note)
+    for seq_bend in sequence_proto.pitch_bends:
+      seq_instruments[
+          (seq_bend.instrument, seq_bend.program, seq_bend.is_drum)][
+              &#39;bends&#39;].append(seq_bend)
+    for seq_control in sequence_proto.control_changes:
+      seq_instruments[
+          (seq_control.instrument, seq_control.program, seq_control.is_drum)][
+              &#39;controls&#39;].append(seq_control)
+
+    sorted_seq_instrument_keys = sorted(seq_instruments.keys())
+
+    if seq_instruments:
+      self.assertEqual(len(midi.instruments), len(seq_instruments))
+    else:
+      self.assertLen(midi.instruments, 1)
+      self.assertEmpty(midi.instruments[0].notes)
+      self.assertEmpty(midi.instruments[0].pitch_bends)
+
+    for midi_instrument, seq_instrument_key in zip(
+        midi.instruments, sorted_seq_instrument_keys):
+
+      seq_instrument_notes = seq_instruments[seq_instrument_key][&#39;notes&#39;]
+
+      self.assertEqual(len(midi_instrument.notes), len(seq_instrument_notes))
+      for midi_note, sequence_note in zip(midi_instrument.notes,
+                                          seq_instrument_notes):
+        self.assertEqual(midi_note.pitch, sequence_note.pitch)
+        self.assertEqual(midi_note.velocity, sequence_note.velocity)
+        self.assertAlmostEqual(midi_note.start, sequence_note.start_time)
+        self.assertAlmostEqual(midi_note.end, sequence_note.end_time)
+
+      seq_instrument_pitch_bends = seq_instruments[seq_instrument_key][&#39;bends&#39;]
+      self.assertEqual(len(midi_instrument.pitch_bends),
+                       len(seq_instrument_pitch_bends))
+      for midi_pitch_bend, sequence_pitch_bend in zip(
+          midi_instrument.pitch_bends,
+          seq_instrument_pitch_bends):
+        self.assertEqual(midi_pitch_bend.pitch, sequence_pitch_bend.bend)
+        self.assertAlmostEqual(midi_pitch_bend.time, sequence_pitch_bend.time)
+
+  def CheckMidiToSequence(self, filename):
+    &#34;&#34;&#34;Test the translation from PrettyMIDI to Sequence proto.&#34;&#34;&#34;
+    source_midi = pretty_midi.PrettyMIDI(filename)
+    sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    self.CheckPrettyMidiAndSequence(source_midi, sequence_proto)
+
+  def CheckSequenceToPrettyMidi(self, filename):
+    &#34;&#34;&#34;Test the translation from Sequence proto to PrettyMIDI.&#34;&#34;&#34;
+    source_midi = pretty_midi.PrettyMIDI(filename)
+    sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(sequence_proto)
+    self.CheckPrettyMidiAndSequence(translated_midi, sequence_proto)
+
+  def CheckReadWriteMidi(self, filename):
+    &#34;&#34;&#34;Test writing to a MIDI file and comparing it to the original Sequence.&#34;&#34;&#34;
+
+    # TODO(deck): The input MIDI file is opened in pretty-midi and
+    # re-written to a temp file, sanitizing the MIDI data (reordering
+    # note ons, etc). Issue 85 in the pretty-midi GitHub
+    # (http://github.com/craffel/pretty-midi/issues/85) requests that
+    # this sanitization be available outside of the context of a file
+    # write. If that is implemented, this rewrite code should be
+    # modified or deleted.
+
+    # When writing to the temp file, use the file object itself instead of
+    # file.name to avoid the permission error on Windows.
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as rewrite_file:
+      original_midi = pretty_midi.PrettyMIDI(filename)
+      original_midi.write(rewrite_file)  # Use file object
+      # Back the file position to top to reload the rewrite_file
+      rewrite_file.seek(0)
+      source_midi = pretty_midi.PrettyMIDI(rewrite_file)  # Use file object
+      sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+
+    # Translate the NoteSequence to MIDI and write to a file.
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as temp_file:
+      midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+      # Read it back in and compare to source.
+      created_midi = pretty_midi.PrettyMIDI(temp_file)  # Use file object
+
+    self.CheckPrettyMidiAndSequence(created_midi, sequence_proto)
+
+  def testSimplePrettyMidiToSequence(self):
+    self.CheckMidiToSequence(self.midi_simple_filename)
+
+  def testSimpleSequenceToPrettyMidi(self):
+    self.CheckSequenceToPrettyMidi(self.midi_simple_filename)
+
+  def testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    stripped_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    del stripped_sequence_proto.tempos[:]
+    stripped_sequence_proto.ClearField(&#39;ticks_per_quarter&#39;)
+
+    expected_sequence_proto = music_pb2.NoteSequence()
+    expected_sequence_proto.CopyFrom(stripped_sequence_proto)
+    expected_sequence_proto.tempos.add(
+        qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+    expected_sequence_proto.ticks_per_quarter = constants.STANDARD_PPQ
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        stripped_sequence_proto)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, expected_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_MultipleTempos(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    del multi_tempo_sequence_proto.tempos[:]
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+
+    # Translating to MIDI adds an implicit DEFAULT_QUARTERS_PER_MINUTE tempo
+    # at time 0, so recreate the list with that in place.
+    del multi_tempo_sequence_proto.tempos[:]
+    multi_tempo_sequence_proto.tempos.add(
+        time=0.0, qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    # Add a final tempo long after the last note.
+    multi_tempo_sequence_proto.tempos.add(time=600.0, qpm=120)
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+    # Translate dropping anything after the last note.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=0)
+    # The added tempo should have been dropped.
+    del multi_tempo_sequence_proto.tempos[-1]
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+    # Add a final tempo 15 seconds after the last note.
+    last_note_time = max([n.end_time for n in multi_tempo_sequence_proto.notes])
+    multi_tempo_sequence_proto.tempos.add(time=last_note_time + 15, qpm=120)
+    # Translate dropping anything 30 seconds after the last note, which should
+    # preserve the added tempo.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=30)
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testEmptySequenceToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.assertLen(translated_midi.instruments, 1)
+    self.assertEmpty(translated_midi.instruments[0].notes)
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    self.assertLen(translated_midi.instruments, 1)
+    self.assertEmpty(translated_midi.instruments[0].notes)
+
+  def testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+    source_sequence.tempos.add(time=0, qpm=120)
+    source_sequence.tempos.add(time=10, qpm=160)
+    source_sequence.tempos.add(time=40, qpm=240)
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    del source_sequence.tempos[-1]
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+  def testSimpleReadWriteMidi(self):
+    self.CheckReadWriteMidi(self.midi_simple_filename)
+
+  def testComplexPrettyMidiToSequence(self):
+    self.CheckMidiToSequence(self.midi_complex_filename)
+
+  def testComplexSequenceToPrettyMidi(self):
+    self.CheckSequenceToPrettyMidi(self.midi_complex_filename)
+
+  def testIsDrumDetection(self):
+    &#34;&#34;&#34;Verify that is_drum instruments are properly tracked.
+
+    self.midi_is_drum_filename is a MIDI file containing two tracks
+    set to channel 9 (is_drum == True). Each contains one NoteOn. This
+    test is designed to catch a bug where the second track would lose
+    is_drum, remapping the drum track to an instrument track.
+    &#34;&#34;&#34;
+    sequence_proto = midi_io.midi_file_to_sequence_proto(
+        self.midi_is_drum_filename)
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiDrumTest&#39;) as temp_file:
+      midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+      midi_data1 = mido.MidiFile(filename=self.midi_is_drum_filename)
+      # Use the file object when writing to the tempfile
+      # to avoid permission error.
+      midi_data2 = mido.MidiFile(file=temp_file)
+
+    # Count number of channel 9 Note Ons.
+    channel_counts = [0, 0]
+    for index, midi_data in enumerate([midi_data1, midi_data2]):
+      for event in midi_data:
+        if (event.type == &#39;note_on&#39; and
+            event.velocity &gt; 0 and event.channel == 9):
+          channel_counts[index] += 1
+    self.assertEqual(channel_counts, [2, 2])
+
+  def testInstrumentInfo_NoteSequenceToPrettyMidi(self):
+    source_sequence = music_pb2.NoteSequence()
+    source_sequence.notes.add(
+        pitch=60, start_time=0.0, end_time=0.5, velocity=80, instrument=0)
+    source_sequence.notes.add(
+        pitch=60, start_time=0.5, end_time=1.0, velocity=80, instrument=1)
+    instrument_info1 = source_sequence.instrument_infos.add()
+    instrument_info1.name = &#39;inst_0&#39;
+    instrument_info1.instrument = 0
+    instrument_info2 = source_sequence.instrument_infos.add()
+    instrument_info2.name = &#39;inst_1&#39;
+    instrument_info2.instrument = 1
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(source_sequence)
+    translated_sequence = midi_io.midi_to_note_sequence(translated_midi)
+
+    self.assertEqual(
+        len(source_sequence.instrument_infos),
+        len(translated_sequence.instrument_infos))
+    self.assertEqual(source_sequence.instrument_infos[0].name,
+                     translated_sequence.instrument_infos[0].name)
+    self.assertEqual(source_sequence.instrument_infos[1].name,
+                     translated_sequence.instrument_infos[1].name)
+
+  def testComplexReadWriteMidi(self):
+    self.CheckReadWriteMidi(self.midi_complex_filename)
+
+  def testEventOrdering(self):
+    self.CheckReadWriteMidi(self.midi_event_order_filename)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.midi_io_test.MidiIoTest"><code class="flex name class">
+<span>class <span class="ident">MidiIoTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MidiIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.midi_simple_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example.mid&#39;)
+    self.midi_complex_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_complex.mid&#39;)
+    self.midi_is_drum_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_is_drum.mid&#39;)
+    self.midi_event_order_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;example_event_order.mid&#39;)
+
+  def CheckPrettyMidiAndSequence(self, midi, sequence_proto):
+    &#34;&#34;&#34;Compares PrettyMIDI object against a sequence proto.
+
+    Args:
+      midi: A pretty_midi.PrettyMIDI object.
+      sequence_proto: A NoteSequence proto.
+    &#34;&#34;&#34;
+    # Test time signature changes.
+    self.assertEqual(len(midi.time_signature_changes),
+                     len(sequence_proto.time_signatures))
+    for midi_time, sequence_time in zip(midi.time_signature_changes,
+                                        sequence_proto.time_signatures):
+      self.assertEqual(midi_time.numerator, sequence_time.numerator)
+      self.assertEqual(midi_time.denominator, sequence_time.denominator)
+      self.assertAlmostEqual(midi_time.time, sequence_time.time)
+
+    # Test key signature changes.
+    self.assertEqual(len(midi.key_signature_changes),
+                     len(sequence_proto.key_signatures))
+    for midi_key, sequence_key in zip(midi.key_signature_changes,
+                                      sequence_proto.key_signatures):
+      self.assertEqual(midi_key.key_number % 12, sequence_key.key)
+      self.assertEqual(midi_key.key_number // 12, sequence_key.mode)
+      self.assertAlmostEqual(midi_key.time, sequence_key.time)
+
+    # Test tempos.
+    midi_times, midi_qpms = midi.get_tempo_changes()
+    self.assertEqual(len(midi_times),
+                     len(sequence_proto.tempos))
+    self.assertEqual(len(midi_qpms),
+                     len(sequence_proto.tempos))
+    for midi_time, midi_qpm, sequence_tempo in zip(
+        midi_times, midi_qpms, sequence_proto.tempos):
+      self.assertAlmostEqual(midi_qpm, sequence_tempo.qpm)
+      self.assertAlmostEqual(midi_time, sequence_tempo.time)
+
+    # Test instruments.
+    seq_instruments = collections.defaultdict(
+        lambda: collections.defaultdict(list))
+    for seq_note in sequence_proto.notes:
+      seq_instruments[
+          (seq_note.instrument, seq_note.program, seq_note.is_drum)][
+              &#39;notes&#39;].append(seq_note)
+    for seq_bend in sequence_proto.pitch_bends:
+      seq_instruments[
+          (seq_bend.instrument, seq_bend.program, seq_bend.is_drum)][
+              &#39;bends&#39;].append(seq_bend)
+    for seq_control in sequence_proto.control_changes:
+      seq_instruments[
+          (seq_control.instrument, seq_control.program, seq_control.is_drum)][
+              &#39;controls&#39;].append(seq_control)
+
+    sorted_seq_instrument_keys = sorted(seq_instruments.keys())
+
+    if seq_instruments:
+      self.assertEqual(len(midi.instruments), len(seq_instruments))
+    else:
+      self.assertLen(midi.instruments, 1)
+      self.assertEmpty(midi.instruments[0].notes)
+      self.assertEmpty(midi.instruments[0].pitch_bends)
+
+    for midi_instrument, seq_instrument_key in zip(
+        midi.instruments, sorted_seq_instrument_keys):
+
+      seq_instrument_notes = seq_instruments[seq_instrument_key][&#39;notes&#39;]
+
+      self.assertEqual(len(midi_instrument.notes), len(seq_instrument_notes))
+      for midi_note, sequence_note in zip(midi_instrument.notes,
+                                          seq_instrument_notes):
+        self.assertEqual(midi_note.pitch, sequence_note.pitch)
+        self.assertEqual(midi_note.velocity, sequence_note.velocity)
+        self.assertAlmostEqual(midi_note.start, sequence_note.start_time)
+        self.assertAlmostEqual(midi_note.end, sequence_note.end_time)
+
+      seq_instrument_pitch_bends = seq_instruments[seq_instrument_key][&#39;bends&#39;]
+      self.assertEqual(len(midi_instrument.pitch_bends),
+                       len(seq_instrument_pitch_bends))
+      for midi_pitch_bend, sequence_pitch_bend in zip(
+          midi_instrument.pitch_bends,
+          seq_instrument_pitch_bends):
+        self.assertEqual(midi_pitch_bend.pitch, sequence_pitch_bend.bend)
+        self.assertAlmostEqual(midi_pitch_bend.time, sequence_pitch_bend.time)
+
+  def CheckMidiToSequence(self, filename):
+    &#34;&#34;&#34;Test the translation from PrettyMIDI to Sequence proto.&#34;&#34;&#34;
+    source_midi = pretty_midi.PrettyMIDI(filename)
+    sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    self.CheckPrettyMidiAndSequence(source_midi, sequence_proto)
+
+  def CheckSequenceToPrettyMidi(self, filename):
+    &#34;&#34;&#34;Test the translation from Sequence proto to PrettyMIDI.&#34;&#34;&#34;
+    source_midi = pretty_midi.PrettyMIDI(filename)
+    sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(sequence_proto)
+    self.CheckPrettyMidiAndSequence(translated_midi, sequence_proto)
+
+  def CheckReadWriteMidi(self, filename):
+    &#34;&#34;&#34;Test writing to a MIDI file and comparing it to the original Sequence.&#34;&#34;&#34;
+
+    # TODO(deck): The input MIDI file is opened in pretty-midi and
+    # re-written to a temp file, sanitizing the MIDI data (reordering
+    # note ons, etc). Issue 85 in the pretty-midi GitHub
+    # (http://github.com/craffel/pretty-midi/issues/85) requests that
+    # this sanitization be available outside of the context of a file
+    # write. If that is implemented, this rewrite code should be
+    # modified or deleted.
+
+    # When writing to the temp file, use the file object itself instead of
+    # file.name to avoid the permission error on Windows.
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as rewrite_file:
+      original_midi = pretty_midi.PrettyMIDI(filename)
+      original_midi.write(rewrite_file)  # Use file object
+      # Back the file position to top to reload the rewrite_file
+      rewrite_file.seek(0)
+      source_midi = pretty_midi.PrettyMIDI(rewrite_file)  # Use file object
+      sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+
+    # Translate the NoteSequence to MIDI and write to a file.
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as temp_file:
+      midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+      # Read it back in and compare to source.
+      created_midi = pretty_midi.PrettyMIDI(temp_file)  # Use file object
+
+    self.CheckPrettyMidiAndSequence(created_midi, sequence_proto)
+
+  def testSimplePrettyMidiToSequence(self):
+    self.CheckMidiToSequence(self.midi_simple_filename)
+
+  def testSimpleSequenceToPrettyMidi(self):
+    self.CheckSequenceToPrettyMidi(self.midi_simple_filename)
+
+  def testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    stripped_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    del stripped_sequence_proto.tempos[:]
+    stripped_sequence_proto.ClearField(&#39;ticks_per_quarter&#39;)
+
+    expected_sequence_proto = music_pb2.NoteSequence()
+    expected_sequence_proto.CopyFrom(stripped_sequence_proto)
+    expected_sequence_proto.tempos.add(
+        qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+    expected_sequence_proto.ticks_per_quarter = constants.STANDARD_PPQ
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        stripped_sequence_proto)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, expected_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_MultipleTempos(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    del multi_tempo_sequence_proto.tempos[:]
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+
+    # Translating to MIDI adds an implicit DEFAULT_QUARTERS_PER_MINUTE tempo
+    # at time 0, so recreate the list with that in place.
+    del multi_tempo_sequence_proto.tempos[:]
+    multi_tempo_sequence_proto.tempos.add(
+        time=0.0, qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+    multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+    multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote(self):
+    source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+    multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+    # Add a final tempo long after the last note.
+    multi_tempo_sequence_proto.tempos.add(time=600.0, qpm=120)
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto)
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+    # Translate dropping anything after the last note.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=0)
+    # The added tempo should have been dropped.
+    del multi_tempo_sequence_proto.tempos[-1]
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+    # Add a final tempo 15 seconds after the last note.
+    last_note_time = max([n.end_time for n in multi_tempo_sequence_proto.notes])
+    multi_tempo_sequence_proto.tempos.add(time=last_note_time + 15, qpm=120)
+    # Translate dropping anything 30 seconds after the last note, which should
+    # preserve the added tempo.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=30)
+    self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  def testEmptySequenceToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.assertLen(translated_midi.instruments, 1)
+    self.assertEmpty(translated_midi.instruments[0].notes)
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    self.assertLen(translated_midi.instruments, 1)
+    self.assertEmpty(translated_midi.instruments[0].notes)
+
+  def testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+    source_sequence.tempos.add(time=0, qpm=120)
+    source_sequence.tempos.add(time=10, qpm=160)
+    source_sequence.tempos.add(time=40, qpm=240)
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    del source_sequence.tempos[-1]
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+  def testSimpleReadWriteMidi(self):
+    self.CheckReadWriteMidi(self.midi_simple_filename)
+
+  def testComplexPrettyMidiToSequence(self):
+    self.CheckMidiToSequence(self.midi_complex_filename)
+
+  def testComplexSequenceToPrettyMidi(self):
+    self.CheckSequenceToPrettyMidi(self.midi_complex_filename)
+
+  def testIsDrumDetection(self):
+    &#34;&#34;&#34;Verify that is_drum instruments are properly tracked.
+
+    self.midi_is_drum_filename is a MIDI file containing two tracks
+    set to channel 9 (is_drum == True). Each contains one NoteOn. This
+    test is designed to catch a bug where the second track would lose
+    is_drum, remapping the drum track to an instrument track.
+    &#34;&#34;&#34;
+    sequence_proto = midi_io.midi_file_to_sequence_proto(
+        self.midi_is_drum_filename)
+    with tempfile.NamedTemporaryFile(prefix=&#39;MidiDrumTest&#39;) as temp_file:
+      midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+      midi_data1 = mido.MidiFile(filename=self.midi_is_drum_filename)
+      # Use the file object when writing to the tempfile
+      # to avoid permission error.
+      midi_data2 = mido.MidiFile(file=temp_file)
+
+    # Count number of channel 9 Note Ons.
+    channel_counts = [0, 0]
+    for index, midi_data in enumerate([midi_data1, midi_data2]):
+      for event in midi_data:
+        if (event.type == &#39;note_on&#39; and
+            event.velocity &gt; 0 and event.channel == 9):
+          channel_counts[index] += 1
+    self.assertEqual(channel_counts, [2, 2])
+
+  def testInstrumentInfo_NoteSequenceToPrettyMidi(self):
+    source_sequence = music_pb2.NoteSequence()
+    source_sequence.notes.add(
+        pitch=60, start_time=0.0, end_time=0.5, velocity=80, instrument=0)
+    source_sequence.notes.add(
+        pitch=60, start_time=0.5, end_time=1.0, velocity=80, instrument=1)
+    instrument_info1 = source_sequence.instrument_infos.add()
+    instrument_info1.name = &#39;inst_0&#39;
+    instrument_info1.instrument = 0
+    instrument_info2 = source_sequence.instrument_infos.add()
+    instrument_info2.name = &#39;inst_1&#39;
+    instrument_info2.instrument = 1
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(source_sequence)
+    translated_sequence = midi_io.midi_to_note_sequence(translated_midi)
+
+    self.assertEqual(
+        len(source_sequence.instrument_infos),
+        len(translated_sequence.instrument_infos))
+    self.assertEqual(source_sequence.instrument_infos[0].name,
+                     translated_sequence.instrument_infos[0].name)
+    self.assertEqual(source_sequence.instrument_infos[1].name,
+                     translated_sequence.instrument_infos[1].name)
+
+  def testComplexReadWriteMidi(self):
+    self.CheckReadWriteMidi(self.midi_complex_filename)
+
+  def testEventOrdering(self):
+    self.CheckReadWriteMidi(self.midi_event_order_filename)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.midi_io_test.MidiIoTest.CheckMidiToSequence"><code class="name flex">
+<span>def <span class="ident">CheckMidiToSequence</span></span>(<span>self, filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from PrettyMIDI to Sequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CheckMidiToSequence(self, filename):
+  &#34;&#34;&#34;Test the translation from PrettyMIDI to Sequence proto.&#34;&#34;&#34;
+  source_midi = pretty_midi.PrettyMIDI(filename)
+  sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  self.CheckPrettyMidiAndSequence(source_midi, sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.CheckPrettyMidiAndSequence"><code class="name flex">
+<span>def <span class="ident">CheckPrettyMidiAndSequence</span></span>(<span>self, midi, sequence_proto)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compares PrettyMIDI object against a sequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>midi</code></strong></dt>
+<dd>A pretty_midi.PrettyMIDI object.</dd>
+<dt><strong><code>sequence_proto</code></strong></dt>
+<dd>A NoteSequence proto.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CheckPrettyMidiAndSequence(self, midi, sequence_proto):
+  &#34;&#34;&#34;Compares PrettyMIDI object against a sequence proto.
+
+  Args:
+    midi: A pretty_midi.PrettyMIDI object.
+    sequence_proto: A NoteSequence proto.
+  &#34;&#34;&#34;
+  # Test time signature changes.
+  self.assertEqual(len(midi.time_signature_changes),
+                   len(sequence_proto.time_signatures))
+  for midi_time, sequence_time in zip(midi.time_signature_changes,
+                                      sequence_proto.time_signatures):
+    self.assertEqual(midi_time.numerator, sequence_time.numerator)
+    self.assertEqual(midi_time.denominator, sequence_time.denominator)
+    self.assertAlmostEqual(midi_time.time, sequence_time.time)
+
+  # Test key signature changes.
+  self.assertEqual(len(midi.key_signature_changes),
+                   len(sequence_proto.key_signatures))
+  for midi_key, sequence_key in zip(midi.key_signature_changes,
+                                    sequence_proto.key_signatures):
+    self.assertEqual(midi_key.key_number % 12, sequence_key.key)
+    self.assertEqual(midi_key.key_number // 12, sequence_key.mode)
+    self.assertAlmostEqual(midi_key.time, sequence_key.time)
+
+  # Test tempos.
+  midi_times, midi_qpms = midi.get_tempo_changes()
+  self.assertEqual(len(midi_times),
+                   len(sequence_proto.tempos))
+  self.assertEqual(len(midi_qpms),
+                   len(sequence_proto.tempos))
+  for midi_time, midi_qpm, sequence_tempo in zip(
+      midi_times, midi_qpms, sequence_proto.tempos):
+    self.assertAlmostEqual(midi_qpm, sequence_tempo.qpm)
+    self.assertAlmostEqual(midi_time, sequence_tempo.time)
+
+  # Test instruments.
+  seq_instruments = collections.defaultdict(
+      lambda: collections.defaultdict(list))
+  for seq_note in sequence_proto.notes:
+    seq_instruments[
+        (seq_note.instrument, seq_note.program, seq_note.is_drum)][
+            &#39;notes&#39;].append(seq_note)
+  for seq_bend in sequence_proto.pitch_bends:
+    seq_instruments[
+        (seq_bend.instrument, seq_bend.program, seq_bend.is_drum)][
+            &#39;bends&#39;].append(seq_bend)
+  for seq_control in sequence_proto.control_changes:
+    seq_instruments[
+        (seq_control.instrument, seq_control.program, seq_control.is_drum)][
+            &#39;controls&#39;].append(seq_control)
+
+  sorted_seq_instrument_keys = sorted(seq_instruments.keys())
+
+  if seq_instruments:
+    self.assertEqual(len(midi.instruments), len(seq_instruments))
+  else:
+    self.assertLen(midi.instruments, 1)
+    self.assertEmpty(midi.instruments[0].notes)
+    self.assertEmpty(midi.instruments[0].pitch_bends)
+
+  for midi_instrument, seq_instrument_key in zip(
+      midi.instruments, sorted_seq_instrument_keys):
+
+    seq_instrument_notes = seq_instruments[seq_instrument_key][&#39;notes&#39;]
+
+    self.assertEqual(len(midi_instrument.notes), len(seq_instrument_notes))
+    for midi_note, sequence_note in zip(midi_instrument.notes,
+                                        seq_instrument_notes):
+      self.assertEqual(midi_note.pitch, sequence_note.pitch)
+      self.assertEqual(midi_note.velocity, sequence_note.velocity)
+      self.assertAlmostEqual(midi_note.start, sequence_note.start_time)
+      self.assertAlmostEqual(midi_note.end, sequence_note.end_time)
+
+    seq_instrument_pitch_bends = seq_instruments[seq_instrument_key][&#39;bends&#39;]
+    self.assertEqual(len(midi_instrument.pitch_bends),
+                     len(seq_instrument_pitch_bends))
+    for midi_pitch_bend, sequence_pitch_bend in zip(
+        midi_instrument.pitch_bends,
+        seq_instrument_pitch_bends):
+      self.assertEqual(midi_pitch_bend.pitch, sequence_pitch_bend.bend)
+      self.assertAlmostEqual(midi_pitch_bend.time, sequence_pitch_bend.time)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.CheckReadWriteMidi"><code class="name flex">
+<span>def <span class="ident">CheckReadWriteMidi</span></span>(<span>self, filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test writing to a MIDI file and comparing it to the original Sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CheckReadWriteMidi(self, filename):
+  &#34;&#34;&#34;Test writing to a MIDI file and comparing it to the original Sequence.&#34;&#34;&#34;
+
+  # TODO(deck): The input MIDI file is opened in pretty-midi and
+  # re-written to a temp file, sanitizing the MIDI data (reordering
+  # note ons, etc). Issue 85 in the pretty-midi GitHub
+  # (http://github.com/craffel/pretty-midi/issues/85) requests that
+  # this sanitization be available outside of the context of a file
+  # write. If that is implemented, this rewrite code should be
+  # modified or deleted.
+
+  # When writing to the temp file, use the file object itself instead of
+  # file.name to avoid the permission error on Windows.
+  with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as rewrite_file:
+    original_midi = pretty_midi.PrettyMIDI(filename)
+    original_midi.write(rewrite_file)  # Use file object
+    # Back the file position to top to reload the rewrite_file
+    rewrite_file.seek(0)
+    source_midi = pretty_midi.PrettyMIDI(rewrite_file)  # Use file object
+    sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+
+  # Translate the NoteSequence to MIDI and write to a file.
+  with tempfile.NamedTemporaryFile(prefix=&#39;MidiIoTest&#39;) as temp_file:
+    midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+    # Read it back in and compare to source.
+    created_midi = pretty_midi.PrettyMIDI(temp_file)  # Use file object
+
+  self.CheckPrettyMidiAndSequence(created_midi, sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.CheckSequenceToPrettyMidi"><code class="name flex">
+<span>def <span class="ident">CheckSequenceToPrettyMidi</span></span>(<span>self, filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from Sequence proto to PrettyMIDI.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def CheckSequenceToPrettyMidi(self, filename):
+  &#34;&#34;&#34;Test the translation from Sequence proto to PrettyMIDI.&#34;&#34;&#34;
+  source_midi = pretty_midi.PrettyMIDI(filename)
+  sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(sequence_proto)
+  self.CheckPrettyMidiAndSequence(translated_midi, sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.midi_simple_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example.mid&#39;)
+  self.midi_complex_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example_complex.mid&#39;)
+  self.midi_is_drum_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example_is_drum.mid&#39;)
+  self.midi_event_order_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;example_event_order.mid&#39;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testComplexPrettyMidiToSequence"><code class="name flex">
+<span>def <span class="ident">testComplexPrettyMidiToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testComplexPrettyMidiToSequence(self):
+  self.CheckMidiToSequence(self.midi_complex_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testComplexReadWriteMidi"><code class="name flex">
+<span>def <span class="ident">testComplexReadWriteMidi</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testComplexReadWriteMidi(self):
+  self.CheckReadWriteMidi(self.midi_complex_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testComplexSequenceToPrettyMidi"><code class="name flex">
+<span>def <span class="ident">testComplexSequenceToPrettyMidi</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testComplexSequenceToPrettyMidi(self):
+  self.CheckSequenceToPrettyMidi(self.midi_complex_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testEmptySequenceToPrettyMidi_DropEventsAfterLastNote"><code class="name flex">
+<span>def <span class="ident">testEmptySequenceToPrettyMidi_DropEventsAfterLastNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmptySequenceToPrettyMidi_DropEventsAfterLastNote(self):
+  source_sequence = music_pb2.NoteSequence()
+
+  # Translate without dropping.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      source_sequence)
+  self.assertLen(translated_midi.instruments, 1)
+  self.assertEmpty(translated_midi.instruments[0].notes)
+
+  # Translate dropping anything after 30 seconds.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      source_sequence, drop_events_n_seconds_after_last_note=30)
+  self.assertLen(translated_midi.instruments, 1)
+  self.assertEmpty(translated_midi.instruments[0].notes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testEventOrdering"><code class="name flex">
+<span>def <span class="ident">testEventOrdering</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventOrdering(self):
+  self.CheckReadWriteMidi(self.midi_event_order_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testInstrumentInfo_NoteSequenceToPrettyMidi"><code class="name flex">
+<span>def <span class="ident">testInstrumentInfo_NoteSequenceToPrettyMidi</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInstrumentInfo_NoteSequenceToPrettyMidi(self):
+  source_sequence = music_pb2.NoteSequence()
+  source_sequence.notes.add(
+      pitch=60, start_time=0.0, end_time=0.5, velocity=80, instrument=0)
+  source_sequence.notes.add(
+      pitch=60, start_time=0.5, end_time=1.0, velocity=80, instrument=1)
+  instrument_info1 = source_sequence.instrument_infos.add()
+  instrument_info1.name = &#39;inst_0&#39;
+  instrument_info1.instrument = 0
+  instrument_info2 = source_sequence.instrument_infos.add()
+  instrument_info2.name = &#39;inst_1&#39;
+  instrument_info2.instrument = 1
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(source_sequence)
+  translated_sequence = midi_io.midi_to_note_sequence(translated_midi)
+
+  self.assertEqual(
+      len(source_sequence.instrument_infos),
+      len(translated_sequence.instrument_infos))
+  self.assertEqual(source_sequence.instrument_infos[0].name,
+                   translated_sequence.instrument_infos[0].name)
+  self.assertEqual(source_sequence.instrument_infos[1].name,
+                   translated_sequence.instrument_infos[1].name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testIsDrumDetection"><code class="name flex">
+<span>def <span class="ident">testIsDrumDetection</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify that is_drum instruments are properly tracked.</p>
+<p>self.midi_is_drum_filename is a MIDI file containing two tracks
+set to channel 9 (is_drum == True). Each contains one NoteOn. This
+test is designed to catch a bug where the second track would lose
+is_drum, remapping the drum track to an instrument track.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testIsDrumDetection(self):
+  &#34;&#34;&#34;Verify that is_drum instruments are properly tracked.
+
+  self.midi_is_drum_filename is a MIDI file containing two tracks
+  set to channel 9 (is_drum == True). Each contains one NoteOn. This
+  test is designed to catch a bug where the second track would lose
+  is_drum, remapping the drum track to an instrument track.
+  &#34;&#34;&#34;
+  sequence_proto = midi_io.midi_file_to_sequence_proto(
+      self.midi_is_drum_filename)
+  with tempfile.NamedTemporaryFile(prefix=&#39;MidiDrumTest&#39;) as temp_file:
+    midi_io.sequence_proto_to_midi_file(sequence_proto, temp_file.name)
+    midi_data1 = mido.MidiFile(filename=self.midi_is_drum_filename)
+    # Use the file object when writing to the tempfile
+    # to avoid permission error.
+    midi_data2 = mido.MidiFile(file=temp_file)
+
+  # Count number of channel 9 Note Ons.
+  channel_counts = [0, 0]
+  for index, midi_data in enumerate([midi_data1, midi_data2]):
+    for event in midi_data:
+      if (event.type == &#39;note_on&#39; and
+          event.velocity &gt; 0 and event.channel == 9):
+        channel_counts[index] += 1
+  self.assertEqual(channel_counts, [2, 2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote"><code class="name flex">
+<span>def <span class="ident">testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote(self):
+  source_sequence = music_pb2.NoteSequence()
+  source_sequence.tempos.add(time=0, qpm=120)
+  source_sequence.tempos.add(time=10, qpm=160)
+  source_sequence.tempos.add(time=40, qpm=240)
+
+  # Translate without dropping.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      source_sequence)
+  self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+  # Translate dropping anything after 30 seconds.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      source_sequence, drop_events_n_seconds_after_last_note=30)
+  del source_sequence.tempos[-1]
+  self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimplePrettyMidiToSequence"><code class="name flex">
+<span>def <span class="ident">testSimplePrettyMidiToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimplePrettyMidiToSequence(self):
+  self.CheckMidiToSequence(self.midi_simple_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleReadWriteMidi"><code class="name flex">
+<span>def <span class="ident">testSimpleReadWriteMidi</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleReadWriteMidi(self):
+  self.CheckReadWriteMidi(self.midi_simple_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi"><code class="name flex">
+<span>def <span class="ident">testSimpleSequenceToPrettyMidi</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleSequenceToPrettyMidi(self):
+  self.CheckSequenceToPrettyMidi(self.midi_simple_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo"><code class="name flex">
+<span>def <span class="ident">testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo(self):
+  source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+  stripped_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  del stripped_sequence_proto.tempos[:]
+  stripped_sequence_proto.ClearField(&#39;ticks_per_quarter&#39;)
+
+  expected_sequence_proto = music_pb2.NoteSequence()
+  expected_sequence_proto.CopyFrom(stripped_sequence_proto)
+  expected_sequence_proto.tempos.add(
+      qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+  expected_sequence_proto.ticks_per_quarter = constants.STANDARD_PPQ
+
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      stripped_sequence_proto)
+
+  self.CheckPrettyMidiAndSequence(translated_midi, expected_sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote"><code class="name flex">
+<span>def <span class="ident">testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote(self):
+  source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+  multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  # Add a final tempo long after the last note.
+  multi_tempo_sequence_proto.tempos.add(time=600.0, qpm=120)
+
+  # Translate without dropping.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      multi_tempo_sequence_proto)
+  self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  # Translate dropping anything after the last note.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=0)
+  # The added tempo should have been dropped.
+  del multi_tempo_sequence_proto.tempos[-1]
+  self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
+
+  # Add a final tempo 15 seconds after the last note.
+  last_note_time = max([n.end_time for n in multi_tempo_sequence_proto.notes])
+  multi_tempo_sequence_proto.tempos.add(time=last_note_time + 15, qpm=120)
+  # Translate dropping anything 30 seconds after the last note, which should
+  # preserve the added tempo.
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=30)
+  self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero"><code class="name flex">
+<span>def <span class="ident">testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero(self):
+  source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+  multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  del multi_tempo_sequence_proto.tempos[:]
+  multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+  multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      multi_tempo_sequence_proto)
+
+  # Translating to MIDI adds an implicit DEFAULT_QUARTERS_PER_MINUTE tempo
+  # at time 0, so recreate the list with that in place.
+  del multi_tempo_sequence_proto.tempos[:]
+  multi_tempo_sequence_proto.tempos.add(
+      time=0.0, qpm=constants.DEFAULT_QUARTERS_PER_MINUTE)
+  multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+  multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+  self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_MultipleTempos"><code class="name flex">
+<span>def <span class="ident">testSimpleSequenceToPrettyMidi_MultipleTempos</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSimpleSequenceToPrettyMidi_MultipleTempos(self):
+  source_midi = pretty_midi.PrettyMIDI(self.midi_simple_filename)
+  multi_tempo_sequence_proto = midi_io.midi_to_sequence_proto(source_midi)
+  multi_tempo_sequence_proto.tempos.add(time=1.0, qpm=60)
+  multi_tempo_sequence_proto.tempos.add(time=2.0, qpm=120)
+
+  translated_midi = midi_io.sequence_proto_to_pretty_midi(
+      multi_tempo_sequence_proto)
+
+  self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.midi_io_test.MidiIoTest" href="#note_seq.midi_io_test.MidiIoTest">MidiIoTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.CheckMidiToSequence" href="#note_seq.midi_io_test.MidiIoTest.CheckMidiToSequence">CheckMidiToSequence</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.CheckPrettyMidiAndSequence" href="#note_seq.midi_io_test.MidiIoTest.CheckPrettyMidiAndSequence">CheckPrettyMidiAndSequence</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.CheckReadWriteMidi" href="#note_seq.midi_io_test.MidiIoTest.CheckReadWriteMidi">CheckReadWriteMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.CheckSequenceToPrettyMidi" href="#note_seq.midi_io_test.MidiIoTest.CheckSequenceToPrettyMidi">CheckSequenceToPrettyMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.setUp" href="#note_seq.midi_io_test.MidiIoTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testComplexPrettyMidiToSequence" href="#note_seq.midi_io_test.MidiIoTest.testComplexPrettyMidiToSequence">testComplexPrettyMidiToSequence</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testComplexReadWriteMidi" href="#note_seq.midi_io_test.MidiIoTest.testComplexReadWriteMidi">testComplexReadWriteMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testComplexSequenceToPrettyMidi" href="#note_seq.midi_io_test.MidiIoTest.testComplexSequenceToPrettyMidi">testComplexSequenceToPrettyMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testEmptySequenceToPrettyMidi_DropEventsAfterLastNote" href="#note_seq.midi_io_test.MidiIoTest.testEmptySequenceToPrettyMidi_DropEventsAfterLastNote">testEmptySequenceToPrettyMidi_DropEventsAfterLastNote</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testEventOrdering" href="#note_seq.midi_io_test.MidiIoTest.testEventOrdering">testEventOrdering</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testInstrumentInfo_NoteSequenceToPrettyMidi" href="#note_seq.midi_io_test.MidiIoTest.testInstrumentInfo_NoteSequenceToPrettyMidi">testInstrumentInfo_NoteSequenceToPrettyMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testIsDrumDetection" href="#note_seq.midi_io_test.MidiIoTest.testIsDrumDetection">testIsDrumDetection</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote" href="#note_seq.midi_io_test.MidiIoTest.testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote">testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimplePrettyMidiToSequence" href="#note_seq.midi_io_test.MidiIoTest.testSimplePrettyMidiToSequence">testSimplePrettyMidiToSequence</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleReadWriteMidi" href="#note_seq.midi_io_test.MidiIoTest.testSimpleReadWriteMidi">testSimpleReadWriteMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi" href="#note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi">testSimpleSequenceToPrettyMidi</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo" href="#note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo">testSimpleSequenceToPrettyMidi_DefaultTicksAndTempo</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote" href="#note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote">testSimpleSequenceToPrettyMidi_DropEventsAfterLastNote</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero" href="#note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero">testSimpleSequenceToPrettyMidi_FirstTempoNotAtZero</a></code></li>
+<li><code><a title="note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_MultipleTempos" href="#note_seq.midi_io_test.MidiIoTest.testSimpleSequenceToPrettyMidi_MultipleTempos">testSimpleSequenceToPrettyMidi_MultipleTempos</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/midi_synth.html
+++ b/docs/midi_synth.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.midi_synth API documentation</title>
+<meta name="description" content="MIDI audio synthesis." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.midi_synth</code></h1>
+</header>
+<section id="section-intro">
+<p>MIDI audio synthesis.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;MIDI audio synthesis.&#34;&#34;&#34;
+
+from note_seq import midi_io
+import numpy as np
+
+
+def synthesize(sequence, sample_rate, wave=np.sin):
+  &#34;&#34;&#34;Synthesizes audio from a music_pb2.NoteSequence using a waveform.
+
+  This uses the pretty_midi `synthesize` method. Sound quality will be lower
+  than using `fluidsynth` with a good SoundFont.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize.
+    sample_rate: An integer audio sampling rate in Hz.
+    wave: Function that returns a periodic waveform.
+
+  Returns:
+    A 1-D numpy float array containing the synthesized waveform.
+  &#34;&#34;&#34;
+  midi = midi_io.note_sequence_to_pretty_midi(sequence)
+  return midi.synthesize(fs=sample_rate, wave=wave)
+
+
+def fluidsynth(sequence, sample_rate, sf2_path=None):
+  &#34;&#34;&#34;Synthesizes audio from a music_pb2.NoteSequence using FluidSynth.
+
+  This uses the pretty_midi `fluidsynth` method. In order to use this synth,
+  you must have FluidSynth and pyFluidSynth installed.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize.
+    sample_rate: An integer audio sampling rate in Hz.
+    sf2_path: A string path to a SoundFont. If None, uses the TimGM6mb.sf2 file
+        included with pretty_midi.
+
+  Returns:
+    A 1-D numpy float array containing the synthesized waveform.
+  &#34;&#34;&#34;
+  midi = midi_io.note_sequence_to_pretty_midi(sequence)
+  return midi.fluidsynth(fs=sample_rate, sf2_path=sf2_path)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.midi_synth.fluidsynth"><code class="name flex">
+<span>def <span class="ident">fluidsynth</span></span>(<span>sequence, sample_rate, sf2_path=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Synthesizes audio from a music_pb2.NoteSequence using FluidSynth.</p>
+<p>This uses the pretty_midi <code><a title="note_seq.midi_synth.fluidsynth" href="#note_seq.midi_synth.fluidsynth">fluidsynth()</a></code> method. In order to use this synth,
+you must have FluidSynth and pyFluidSynth installed.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence to synthesize.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>An integer audio sampling rate in Hz.</dd>
+<dt><strong><code>sf2_path</code></strong></dt>
+<dd>A string path to a SoundFont. If None, uses the TimGM6mb.sf2 file
+included with pretty_midi.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A 1-D numpy float array containing the synthesized waveform.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def fluidsynth(sequence, sample_rate, sf2_path=None):
+  &#34;&#34;&#34;Synthesizes audio from a music_pb2.NoteSequence using FluidSynth.
+
+  This uses the pretty_midi `fluidsynth` method. In order to use this synth,
+  you must have FluidSynth and pyFluidSynth installed.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize.
+    sample_rate: An integer audio sampling rate in Hz.
+    sf2_path: A string path to a SoundFont. If None, uses the TimGM6mb.sf2 file
+        included with pretty_midi.
+
+  Returns:
+    A 1-D numpy float array containing the synthesized waveform.
+  &#34;&#34;&#34;
+  midi = midi_io.note_sequence_to_pretty_midi(sequence)
+  return midi.fluidsynth(fs=sample_rate, sf2_path=sf2_path)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.midi_synth.synthesize"><code class="name flex">
+<span>def <span class="ident">synthesize</span></span>(<span>sequence, sample_rate, wave=&lt;ufunc &#x27;sin&#x27;&gt;)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Synthesizes audio from a music_pb2.NoteSequence using a waveform.</p>
+<p>This uses the pretty_midi <code><a title="note_seq.midi_synth.synthesize" href="#note_seq.midi_synth.synthesize">synthesize()</a></code> method. Sound quality will be lower
+than using <code><a title="note_seq.midi_synth.fluidsynth" href="#note_seq.midi_synth.fluidsynth">fluidsynth()</a></code> with a good SoundFont.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence to synthesize.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>An integer audio sampling rate in Hz.</dd>
+<dt><strong><code>wave</code></strong></dt>
+<dd>Function that returns a periodic waveform.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A 1-D numpy float array containing the synthesized waveform.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def synthesize(sequence, sample_rate, wave=np.sin):
+  &#34;&#34;&#34;Synthesizes audio from a music_pb2.NoteSequence using a waveform.
+
+  This uses the pretty_midi `synthesize` method. Sound quality will be lower
+  than using `fluidsynth` with a good SoundFont.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize.
+    sample_rate: An integer audio sampling rate in Hz.
+    wave: Function that returns a periodic waveform.
+
+  Returns:
+    A 1-D numpy float array containing the synthesized waveform.
+  &#34;&#34;&#34;
+  midi = midi_io.note_sequence_to_pretty_midi(sequence)
+  return midi.synthesize(fs=sample_rate, wave=wave)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.midi_synth.fluidsynth" href="#note_seq.midi_synth.fluidsynth">fluidsynth</a></code></li>
+<li><code><a title="note_seq.midi_synth.synthesize" href="#note_seq.midi_synth.synthesize">synthesize</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/musicnet_io.html
+++ b/docs/musicnet_io.html
@@ -1,0 +1,305 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.musicnet_io API documentation</title>
+<meta name="description" content="Import NoteSequences from MusicNet." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.musicnet_io</code></h1>
+</header>
+<section id="section-intro">
+<p>Import NoteSequences from MusicNet.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Import NoteSequences from MusicNet.&#34;&#34;&#34;
+
+import io
+
+from note_seq.protobuf import music_pb2
+import numpy as np
+
+
+MUSICNET_SAMPLE_RATE = 44100
+MUSICNET_NOTE_VELOCITY = 100
+
+
+def note_interval_tree_to_sequence_proto(note_interval_tree, sample_rate):
+  &#34;&#34;&#34;Convert MusicNet note interval tree to a NoteSequence proto.
+
+  Args:
+    note_interval_tree: An intervaltree.IntervalTree containing note intervals
+        and data as found in the MusicNet archive. The interval begin and end
+        values are audio sample numbers.
+    sample_rate: The sample rate for which the note intervals are defined.
+
+  Returns:
+    A NoteSequence proto containing the notes in the interval tree.
+  &#34;&#34;&#34;
+  sequence = music_pb2.NoteSequence()
+
+  # Sort note intervals by onset time.
+  note_intervals = sorted(note_interval_tree,
+                          key=lambda note_interval: note_interval.begin)
+
+  # MusicNet represents &#34;instruments&#34; as MIDI program numbers. Here we map each
+  # program to a separate MIDI instrument.
+  instruments = {}
+
+  for note_interval in note_intervals:
+    note_data = note_interval.data
+
+    note = sequence.notes.add()
+    note.pitch = note_data[1]
+    note.velocity = MUSICNET_NOTE_VELOCITY
+    note.start_time = float(note_interval.begin) / sample_rate
+    note.end_time = float(note_interval.end) / sample_rate
+    # MusicNet &#34;instrument&#34; numbers use 1-based indexing, so we subtract 1 here.
+    note.program = note_data[0] - 1
+    note.is_drum = False
+
+    if note.program not in instruments:
+      instruments[note.program] = len(instruments)
+    note.instrument = instruments[note.program]
+
+    if note.end_time &gt; sequence.total_time:
+      sequence.total_time = note.end_time
+
+  return sequence
+
+
+def musicnet_iterator(musicnet_file):
+  &#34;&#34;&#34;An iterator over the MusicNet archive that yields audio and NoteSequences.
+
+  The MusicNet archive (in .npz format) can be downloaded from:
+  https://homes.cs.washington.edu/~thickstn/media/musicnet.npz
+
+  Args:
+    musicnet_file: The path to the MusicNet NumPy archive (.npz) containing
+        audio and transcriptions for 330 classical recordings.
+
+  Yields:
+    Tuples where the first element is a NumPy array of sampled audio (at 44.1
+    kHz) and the second element is a NoteSequence proto containing the
+    transcription.
+  &#34;&#34;&#34;
+  with open(musicnet_file, &#39;rb&#39;) as f:
+    # Unfortunately the gfile seek function breaks the reading of NumPy
+    # archives, so we read the archive first then load as BytesIO.
+    musicnet_bytes = f.read()
+    musicnet_bytesio = io.BytesIO(musicnet_bytes)
+    # allow_pickle is required because the npz files contain intervaltrees.
+    musicnet = np.load(musicnet_bytesio, encoding=&#39;latin1&#39;, allow_pickle=True)
+
+  for file_id in musicnet.files:
+    audio, note_interval_tree = musicnet[file_id]
+    sequence = note_interval_tree_to_sequence_proto(
+        note_interval_tree, MUSICNET_SAMPLE_RATE)
+
+    sequence.filename = file_id
+    sequence.collection_name = &#39;MusicNet&#39;
+    sequence.id = &#39;/id/musicnet/%s&#39; % file_id
+
+    sequence.source_info.source_type = (
+        music_pb2.NoteSequence.SourceInfo.PERFORMANCE_BASED)
+    sequence.source_info.encoding_type = (
+        music_pb2.NoteSequence.SourceInfo.MUSICNET)
+    sequence.source_info.parser = (
+        music_pb2.NoteSequence.SourceInfo.MAGENTA_MUSICNET)
+
+    yield audio, sequence</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.musicnet_io.musicnet_iterator"><code class="name flex">
+<span>def <span class="ident">musicnet_iterator</span></span>(<span>musicnet_file)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An iterator over the MusicNet archive that yields audio and NoteSequences.</p>
+<p>The MusicNet archive (in .npz format) can be downloaded from:
+<a href="https://homes.cs.washington.edu/~thickstn/media/musicnet.npz">https://homes.cs.washington.edu/~thickstn/media/musicnet.npz</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>musicnet_file</code></strong></dt>
+<dd>The path to the MusicNet NumPy archive (.npz) containing
+audio and transcriptions for 330 classical recordings.</dd>
+</dl>
+<h2 id="yields">Yields</h2>
+<p>Tuples where the first element is a NumPy array of sampled audio (at 44.1
+kHz) and the second element is a NoteSequence proto containing the
+transcription.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def musicnet_iterator(musicnet_file):
+  &#34;&#34;&#34;An iterator over the MusicNet archive that yields audio and NoteSequences.
+
+  The MusicNet archive (in .npz format) can be downloaded from:
+  https://homes.cs.washington.edu/~thickstn/media/musicnet.npz
+
+  Args:
+    musicnet_file: The path to the MusicNet NumPy archive (.npz) containing
+        audio and transcriptions for 330 classical recordings.
+
+  Yields:
+    Tuples where the first element is a NumPy array of sampled audio (at 44.1
+    kHz) and the second element is a NoteSequence proto containing the
+    transcription.
+  &#34;&#34;&#34;
+  with open(musicnet_file, &#39;rb&#39;) as f:
+    # Unfortunately the gfile seek function breaks the reading of NumPy
+    # archives, so we read the archive first then load as BytesIO.
+    musicnet_bytes = f.read()
+    musicnet_bytesio = io.BytesIO(musicnet_bytes)
+    # allow_pickle is required because the npz files contain intervaltrees.
+    musicnet = np.load(musicnet_bytesio, encoding=&#39;latin1&#39;, allow_pickle=True)
+
+  for file_id in musicnet.files:
+    audio, note_interval_tree = musicnet[file_id]
+    sequence = note_interval_tree_to_sequence_proto(
+        note_interval_tree, MUSICNET_SAMPLE_RATE)
+
+    sequence.filename = file_id
+    sequence.collection_name = &#39;MusicNet&#39;
+    sequence.id = &#39;/id/musicnet/%s&#39; % file_id
+
+    sequence.source_info.source_type = (
+        music_pb2.NoteSequence.SourceInfo.PERFORMANCE_BASED)
+    sequence.source_info.encoding_type = (
+        music_pb2.NoteSequence.SourceInfo.MUSICNET)
+    sequence.source_info.parser = (
+        music_pb2.NoteSequence.SourceInfo.MAGENTA_MUSICNET)
+
+    yield audio, sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicnet_io.note_interval_tree_to_sequence_proto"><code class="name flex">
+<span>def <span class="ident">note_interval_tree_to_sequence_proto</span></span>(<span>note_interval_tree, sample_rate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert MusicNet note interval tree to a NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_interval_tree</code></strong></dt>
+<dd>An intervaltree.IntervalTree containing note intervals
+and data as found in the MusicNet archive. The interval begin and end
+values are audio sample numbers.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate for which the note intervals are defined.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto containing the notes in the interval tree.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def note_interval_tree_to_sequence_proto(note_interval_tree, sample_rate):
+  &#34;&#34;&#34;Convert MusicNet note interval tree to a NoteSequence proto.
+
+  Args:
+    note_interval_tree: An intervaltree.IntervalTree containing note intervals
+        and data as found in the MusicNet archive. The interval begin and end
+        values are audio sample numbers.
+    sample_rate: The sample rate for which the note intervals are defined.
+
+  Returns:
+    A NoteSequence proto containing the notes in the interval tree.
+  &#34;&#34;&#34;
+  sequence = music_pb2.NoteSequence()
+
+  # Sort note intervals by onset time.
+  note_intervals = sorted(note_interval_tree,
+                          key=lambda note_interval: note_interval.begin)
+
+  # MusicNet represents &#34;instruments&#34; as MIDI program numbers. Here we map each
+  # program to a separate MIDI instrument.
+  instruments = {}
+
+  for note_interval in note_intervals:
+    note_data = note_interval.data
+
+    note = sequence.notes.add()
+    note.pitch = note_data[1]
+    note.velocity = MUSICNET_NOTE_VELOCITY
+    note.start_time = float(note_interval.begin) / sample_rate
+    note.end_time = float(note_interval.end) / sample_rate
+    # MusicNet &#34;instrument&#34; numbers use 1-based indexing, so we subtract 1 here.
+    note.program = note_data[0] - 1
+    note.is_drum = False
+
+    if note.program not in instruments:
+      instruments[note.program] = len(instruments)
+    note.instrument = instruments[note.program]
+
+    if note.end_time &gt; sequence.total_time:
+      sequence.total_time = note.end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.musicnet_io.musicnet_iterator" href="#note_seq.musicnet_io.musicnet_iterator">musicnet_iterator</a></code></li>
+<li><code><a title="note_seq.musicnet_io.note_interval_tree_to_sequence_proto" href="#note_seq.musicnet_io.note_interval_tree_to_sequence_proto">note_interval_tree_to_sequence_proto</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/musicnet_io_test.html
+++ b/docs/musicnet_io_test.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.musicnet_io_test API documentation</title>
+<meta name="description" content="Tests for MusicNet data parsing." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.musicnet_io_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for MusicNet data parsing.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for MusicNet data parsing.&#34;&#34;&#34;
+
+import os
+
+from absl.testing import absltest
+from note_seq import musicnet_io
+from note_seq import testing_lib
+import numpy as np
+
+
+class MusicNetIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    # This example archive contains a single file consisting of just a major
+    # chord.
+    self.musicnet_example_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;musicnet_example.npz&#39;)
+
+  def testNoteIntervalTreeToSequenceProto(self):
+    # allow_pickle is required because the npz files contain intervaltrees.
+    example = np.load(
+        self.musicnet_example_filename, encoding=&#39;latin1&#39;, allow_pickle=True)
+    note_interval_tree = example[&#39;test&#39;][1]
+    sequence = musicnet_io.note_interval_tree_to_sequence_proto(
+        note_interval_tree, 44100)
+    self.assertLen(sequence.notes, 3)
+    self.assertEqual(72, min(note.pitch for note in sequence.notes))
+    self.assertEqual(79, max(note.pitch for note in sequence.notes))
+    self.assertTrue(all(note.instrument == 0 for note in sequence.notes))
+    self.assertTrue(all(note.program == 41 for note in sequence.notes))
+    self.assertEqual(0.5, sequence.total_time)
+
+  def testMusicNetIterator(self):
+    iterator = musicnet_io.musicnet_iterator(self.musicnet_example_filename)
+    pairs = list(iterator)
+    audio, sequence = pairs[0]
+    self.assertLen(pairs, 1)
+    self.assertEqual(&#39;test&#39;, sequence.filename)
+    self.assertEqual(&#39;MusicNet&#39;, sequence.collection_name)
+    self.assertEqual(&#39;/id/musicnet/test&#39;, sequence.id)
+    self.assertLen(sequence.notes, 3)
+    self.assertLen(audio, 66150)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.musicnet_io_test.MusicNetIoTest"><code class="flex name class">
+<span>class <span class="ident">MusicNetIoTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicNetIoTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    # This example archive contains a single file consisting of just a major
+    # chord.
+    self.musicnet_example_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;musicnet_example.npz&#39;)
+
+  def testNoteIntervalTreeToSequenceProto(self):
+    # allow_pickle is required because the npz files contain intervaltrees.
+    example = np.load(
+        self.musicnet_example_filename, encoding=&#39;latin1&#39;, allow_pickle=True)
+    note_interval_tree = example[&#39;test&#39;][1]
+    sequence = musicnet_io.note_interval_tree_to_sequence_proto(
+        note_interval_tree, 44100)
+    self.assertLen(sequence.notes, 3)
+    self.assertEqual(72, min(note.pitch for note in sequence.notes))
+    self.assertEqual(79, max(note.pitch for note in sequence.notes))
+    self.assertTrue(all(note.instrument == 0 for note in sequence.notes))
+    self.assertTrue(all(note.program == 41 for note in sequence.notes))
+    self.assertEqual(0.5, sequence.total_time)
+
+  def testMusicNetIterator(self):
+    iterator = musicnet_io.musicnet_iterator(self.musicnet_example_filename)
+    pairs = list(iterator)
+    audio, sequence = pairs[0]
+    self.assertLen(pairs, 1)
+    self.assertEqual(&#39;test&#39;, sequence.filename)
+    self.assertEqual(&#39;MusicNet&#39;, sequence.collection_name)
+    self.assertEqual(&#39;/id/musicnet/test&#39;, sequence.id)
+    self.assertLen(sequence.notes, 3)
+    self.assertLen(audio, 66150)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.musicnet_io_test.MusicNetIoTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  # This example archive contains a single file consisting of just a major
+  # chord.
+  self.musicnet_example_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;musicnet_example.npz&#39;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicnet_io_test.MusicNetIoTest.testMusicNetIterator"><code class="name flex">
+<span>def <span class="ident">testMusicNetIterator</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMusicNetIterator(self):
+  iterator = musicnet_io.musicnet_iterator(self.musicnet_example_filename)
+  pairs = list(iterator)
+  audio, sequence = pairs[0]
+  self.assertLen(pairs, 1)
+  self.assertEqual(&#39;test&#39;, sequence.filename)
+  self.assertEqual(&#39;MusicNet&#39;, sequence.collection_name)
+  self.assertEqual(&#39;/id/musicnet/test&#39;, sequence.id)
+  self.assertLen(sequence.notes, 3)
+  self.assertLen(audio, 66150)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicnet_io_test.MusicNetIoTest.testNoteIntervalTreeToSequenceProto"><code class="name flex">
+<span>def <span class="ident">testNoteIntervalTreeToSequenceProto</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNoteIntervalTreeToSequenceProto(self):
+  # allow_pickle is required because the npz files contain intervaltrees.
+  example = np.load(
+      self.musicnet_example_filename, encoding=&#39;latin1&#39;, allow_pickle=True)
+  note_interval_tree = example[&#39;test&#39;][1]
+  sequence = musicnet_io.note_interval_tree_to_sequence_proto(
+      note_interval_tree, 44100)
+  self.assertLen(sequence.notes, 3)
+  self.assertEqual(72, min(note.pitch for note in sequence.notes))
+  self.assertEqual(79, max(note.pitch for note in sequence.notes))
+  self.assertTrue(all(note.instrument == 0 for note in sequence.notes))
+  self.assertTrue(all(note.program == 41 for note in sequence.notes))
+  self.assertEqual(0.5, sequence.total_time)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.musicnet_io_test.MusicNetIoTest" href="#note_seq.musicnet_io_test.MusicNetIoTest">MusicNetIoTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicnet_io_test.MusicNetIoTest.setUp" href="#note_seq.musicnet_io_test.MusicNetIoTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.musicnet_io_test.MusicNetIoTest.testMusicNetIterator" href="#note_seq.musicnet_io_test.MusicNetIoTest.testMusicNetIterator">testMusicNetIterator</a></code></li>
+<li><code><a title="note_seq.musicnet_io_test.MusicNetIoTest.testNoteIntervalTreeToSequenceProto" href="#note_seq.musicnet_io_test.MusicNetIoTest.testNoteIntervalTreeToSequenceProto">testNoteIntervalTreeToSequenceProto</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/musicxml_parser.html
+++ b/docs/musicxml_parser.html
@@ -1,0 +1,3463 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.musicxml_parser API documentation</title>
+<meta name="description" content="MusicXML parser …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.musicxml_parser</code></h1>
+</header>
+<section id="section-intro">
+<p>MusicXML parser.</p>
+<p>Simple MusicXML parser used to convert MusicXML into NoteSequence.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;MusicXML parser.
+
+Simple MusicXML parser used to convert MusicXML into NoteSequence.
+&#34;&#34;&#34;
+
+import fractions
+import xml.etree.ElementTree as ET
+import zipfile
+
+from note_seq import constants
+
+Fraction = fractions.Fraction
+
+DEFAULT_MIDI_PROGRAM = 0    # Default MIDI Program (0 = grand piano)
+DEFAULT_MIDI_CHANNEL = 0    # Default MIDI Channel (0 = first channel)
+MUSICXML_MIME_TYPE = &#39;application/vnd.recordare.musicxml+xml&#39;
+
+
+class MusicXMLParseError(Exception):
+  &#34;&#34;&#34;Exception thrown when the MusicXML contents cannot be parsed.&#34;&#34;&#34;
+  pass
+
+
+class PitchStepParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a pitch step cannot be parsed.
+
+  Will happen if pitch step is not one of A, B, C, D, E, F, or G
+  &#34;&#34;&#34;
+  pass
+
+
+class ChordSymbolParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a chord symbol cannot be parsed.&#34;&#34;&#34;
+  pass
+
+
+class MultipleTimeSignatureError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when multiple time signatures found in a measure.&#34;&#34;&#34;
+  pass
+
+
+class AlternatingTimeSignatureError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when an alternating time signature is encountered.&#34;&#34;&#34;
+  pass
+
+
+class TimeSignatureParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when the time signature could not be parsed.&#34;&#34;&#34;
+  pass
+
+
+class UnpitchedNoteError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when an unpitched note is encountered.
+
+  We do not currently support parsing files with unpitched notes (e.g.,
+  percussion scores).
+
+  http://www.musicxml.com/tutorial/percussion/unpitched-notes/
+  &#34;&#34;&#34;
+  pass
+
+
+class KeyParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a key signature cannot be parsed.&#34;&#34;&#34;
+  pass
+
+
+class InvalidNoteDurationTypeError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a note&#39;s duration type is invalid.&#34;&#34;&#34;
+  pass
+
+
+class MusicXMLParserState(object):
+  &#34;&#34;&#34;Maintains internal state of the MusicXML parser.&#34;&#34;&#34;
+
+  def __init__(self):
+    # Default to one division per measure
+    # From the MusicXML documentation: &#34;The divisions element indicates
+    # how many divisions per quarter note are used to indicate a note&#39;s
+    # duration. For example, if duration = 1 and divisions = 2,
+    # this is an eighth note duration.&#34;
+    self.divisions = 1
+
+    # Default to a tempo of 120 quarter notes per minute
+    # MusicXML calls this tempo, but Magenta calls this qpm
+    # Therefore, the variable is called qpm, but reads the
+    # MusicXML tempo attribute
+    # (120 qpm is the default tempo according to the
+    # Standard MIDI Files 1.0 Specification)
+    self.qpm = 120
+
+    # Duration of a single quarter note in seconds
+    self.seconds_per_quarter = 0.5
+
+    # Running total of time for the current event in seconds.
+    # Resets to 0 on every part. Affected by &lt;forward&gt; and &lt;backup&gt; elements
+    self.time_position = 0
+
+    # Default to a MIDI velocity of 64 (mf)
+    self.velocity = 64
+
+    # Default MIDI program (0 = grand piano)
+    self.midi_program = DEFAULT_MIDI_PROGRAM
+
+    # Current MIDI channel (usually equal to the part number)
+    self.midi_channel = DEFAULT_MIDI_CHANNEL
+
+    # Keep track of previous note to get chord timing correct
+    # This variable stores an instance of the Note class (defined below)
+    self.previous_note = None
+
+    # Keep track of current transposition level in +/- semitones.
+    self.transpose = 0
+
+    # Keep track of current time signature. Does not support polymeter.
+    self.time_signature = None
+
+
+class MusicXMLDocument(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML Document.
+
+  Represents the top level object which holds the MusicXML document
+  Responsible for loading the .xml or .mxl file using the _get_score method
+  If the file is .mxl, this class uncompresses it
+
+  After the file is loaded, this class then parses the document into memory
+  using the parse method.
+  &#34;&#34;&#34;
+
+  def __init__(self, filename):
+    self._score = self._get_score(filename)
+    self.parts = []
+    # ScoreParts indexed by id.
+    self._score_parts = {}
+    self.midi_resolution = constants.STANDARD_PPQ
+    self._state = MusicXMLParserState()
+    # Total time in seconds
+    self.total_time_secs = 0
+    self._parse()
+
+  @staticmethod
+  def _get_score(filename):
+    &#34;&#34;&#34;Given a MusicXML file, return the score as an xml.etree.ElementTree.
+
+    Given a MusicXML file, return the score as an xml.etree.ElementTree
+    If the file is compress (ends in .mxl), uncompress it first
+
+    Args:
+        filename: The path of a MusicXML file
+
+    Returns:
+      The score as an xml.etree.ElementTree.
+
+    Raises:
+      MusicXMLParseError: if the file cannot be parsed.
+    &#34;&#34;&#34;
+    score = None
+    if filename.endswith(&#39;.mxl&#39;):
+      # Compressed MXL file. Uncompress in memory.
+      try:
+        mxlzip = zipfile.ZipFile(filename)
+      except zipfile.BadZipfile as exception:
+        raise MusicXMLParseError(exception)
+
+      # A compressed MXL file may contain multiple files, but only one
+      # MusicXML file. Read the META-INF/container.xml file inside of the
+      # MXL file to locate the MusicXML file within the MXL file
+      # http://www.musicxml.com/tutorial/compressed-mxl-files/zip-archive-structure/
+
+      # Raise a MusicXMLParseError if multiple MusicXML files found
+
+      infolist = mxlzip.infolist()
+      # In py3, instead of returning raw bytes, ZipFile.infolist() tries to
+      # guess the filenames&#39; encoding based on file headers, and decodes using
+      # this encoding in order to return a list of strings. If the utf-8
+      # header is missing, it decodes using the DOS code page 437 encoding
+      # which is almost definitely wrong. Here we need to explicitly check
+      # for when this has occurred and change the encoding to utf-8.
+      # https://stackoverflow.com/questions/37723505/namelist-from-zipfile-returns-strings-with-an-invalid-encoding
+      zip_filename_utf8_flag = 0x800
+      for info in infolist:
+        if info.flag_bits &amp; zip_filename_utf8_flag == 0:
+          filename_bytes = info.filename.encode(&#39;437&#39;)
+          filename = filename_bytes.decode(&#39;utf-8&#39;, &#39;replace&#39;)
+          info.filename = filename
+
+      container_file = [x for x in infolist
+                        if x.filename == &#39;META-INF/container.xml&#39;]
+      compressed_file_name = &#39;&#39;
+
+      if container_file:
+        try:
+          container = ET.fromstring(mxlzip.read(container_file[0]))
+          for rootfile_tag in container.findall(&#39;./rootfiles/rootfile&#39;):
+            if &#39;media-type&#39; in rootfile_tag.attrib:
+              if rootfile_tag.attrib[&#39;media-type&#39;] == MUSICXML_MIME_TYPE:
+                if not compressed_file_name:
+                  compressed_file_name = rootfile_tag.attrib[&#39;full-path&#39;]
+                else:
+                  raise MusicXMLParseError(
+                      &#39;Multiple MusicXML files found in compressed archive&#39;)
+            else:
+              # No media-type attribute, so assume this is the MusicXML file
+              if not compressed_file_name:
+                compressed_file_name = rootfile_tag.attrib[&#39;full-path&#39;]
+              else:
+                raise MusicXMLParseError(
+                    &#39;Multiple MusicXML files found in compressed archive&#39;)
+        except ET.ParseError as exception:
+          raise MusicXMLParseError(exception)
+
+      if not compressed_file_name:
+        raise MusicXMLParseError(
+            &#39;Unable to locate main .xml file in compressed archive.&#39;)
+      try:
+        compressed_file_info = [x for x in infolist
+                                if x.filename == compressed_file_name][0]
+      except IndexError:
+        raise MusicXMLParseError(
+            &#39;Score file %s not found in zip archive&#39; % compressed_file_name)
+      score_string = mxlzip.read(compressed_file_info)
+      try:
+        score = ET.fromstring(score_string)
+      except ET.ParseError as exception:
+        raise MusicXMLParseError(exception)
+    else:
+      # Uncompressed XML file.
+      try:
+        tree = ET.parse(filename)
+        score = tree.getroot()
+      except ET.ParseError as exception:
+        raise MusicXMLParseError(exception)
+
+    return score
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the uncompressed MusicXML document.&#34;&#34;&#34;
+    # Parse part-list
+    xml_part_list = self._score.find(&#39;part-list&#39;)
+    if xml_part_list is not None:
+      for element in xml_part_list:
+        if element.tag == &#39;score-part&#39;:
+          score_part = ScorePart(element)
+          self._score_parts[score_part.id] = score_part
+
+    # Parse parts
+    for score_part_index, child in enumerate(self._score.findall(&#39;part&#39;)):
+      part = Part(child, self._score_parts, self._state)
+      self.parts.append(part)
+      score_part_index += 1
+      if self._state.time_position &gt; self.total_time_secs:
+        self.total_time_secs = self._state.time_position
+
+  def get_chord_symbols(self):
+    &#34;&#34;&#34;Return a list of all the chord symbols used in this score.&#34;&#34;&#34;
+    chord_symbols = []
+    for part in self.parts:
+      for measure in part.measures:
+        for chord_symbol in measure.chord_symbols:
+          if chord_symbol not in chord_symbols:
+            # Prevent duplicate chord symbols
+            chord_symbols.append(chord_symbol)
+    return chord_symbols
+
+  def get_time_signatures(self):
+    &#34;&#34;&#34;Return a list of all the time signatures used in this score.
+
+    Does not support polymeter (i.e. assumes all parts have the same
+    time signature, such as Part 1 having a time signature of 6/8
+    while Part 2 has a simultaneous time signature of 2/4).
+
+    Ignores duplicate time signatures to prevent Magenta duplicate
+    time signature error. This happens when multiple parts have the
+    same time signature is used in multiple parts at the same time.
+
+    Example: If Part 1 has a time siganture of 4/4 and Part 2 also
+    has a time signature of 4/4, then only instance of 4/4 is sent
+    to Magenta.
+
+    Returns:
+      A list of all TimeSignature objects used in this score.
+    &#34;&#34;&#34;
+    time_signatures = []
+    for part in self.parts:
+      for measure in part.measures:
+        if measure.time_signature is not None:
+          if measure.time_signature not in time_signatures:
+            # Prevent duplicate time signatures
+            time_signatures.append(measure.time_signature)
+
+    return time_signatures
+
+  def get_key_signatures(self):
+    &#34;&#34;&#34;Return a list of all the key signatures used in this score.
+
+    Support different key signatures in different parts (score in
+    written pitch).
+
+    Ignores duplicate key signatures to prevent Magenta duplicate key
+    signature error. This happens when multiple parts have the same
+    key signature at the same time.
+
+    Example: If the score is in written pitch and the
+    flute is written in the key of Bb major, the trombone will also be
+    written in the key of Bb major. However, the clarinet and trumpet
+    will be written in the key of C major because they are Bb transposing
+    instruments.
+
+    If no key signatures are found, create a default key signature of
+    C major.
+
+    Returns:
+      A list of all KeySignature objects used in this score.
+    &#34;&#34;&#34;
+    key_signatures = []
+    for part in self.parts:
+      for measure in part.measures:
+        if measure.key_signature is not None:
+          if measure.key_signature not in key_signatures:
+            # Prevent duplicate key signatures
+            key_signatures.append(measure.key_signature)
+
+    if not key_signatures:
+      # If there are no key signatures, add C major at the beginning
+      key_signature = KeySignature(self._state)
+      key_signature.time_position = 0
+      key_signatures.append(key_signature)
+
+    return key_signatures
+
+  def get_tempos(self):
+    &#34;&#34;&#34;Return a list of all tempos in this score.
+
+    If no tempos are found, create a default tempo of 120 qpm.
+
+    Returns:
+      A list of all Tempo objects used in this score.
+    &#34;&#34;&#34;
+    tempos = []
+
+    if self.parts:
+      part = self.parts[0]  # Use only first part
+      for measure in part.measures:
+        for tempo in measure.tempos:
+          tempos.append(tempo)
+
+    # If no tempos, add a default of 120 at beginning
+    if not tempos:
+      tempo = Tempo(self._state)
+      tempo.qpm = self._state.qpm
+      tempo.time_position = 0
+      tempos.append(tempo)
+
+    return tempos
+
+
+class ScorePart(object):
+  &#34;&#34;&#34;&#34;Internal representation of a MusicXML &lt;score-part&gt;.
+
+  A &lt;score-part&gt; element contains MIDI program and channel info
+  for the &lt;part&gt; elements in the MusicXML document.
+
+  If no MIDI info is found for the part, use the default MIDI channel (0)
+  and default to the Grand Piano program (MIDI Program #1).
+  &#34;&#34;&#34;
+
+  def __init__(self, xml_score_part=None):
+    self.id = &#39;&#39;
+    self.part_name = &#39;&#39;
+    self.midi_channel = DEFAULT_MIDI_CHANNEL
+    self.midi_program = DEFAULT_MIDI_PROGRAM
+    if xml_score_part is not None:
+      self._parse(xml_score_part)
+
+  def _parse(self, xml_score_part):
+    &#34;&#34;&#34;Parse the &lt;score-part&gt; element to an in-memory representation.&#34;&#34;&#34;
+    self.id = xml_score_part.attrib[&#39;id&#39;]
+
+    if xml_score_part.find(&#39;part-name&#39;) is not None:
+      self.part_name = xml_score_part.find(&#39;part-name&#39;).text or &#39;&#39;
+
+    xml_midi_instrument = xml_score_part.find(&#39;midi-instrument&#39;)
+    if (xml_midi_instrument is not None and
+        xml_midi_instrument.find(&#39;midi-channel&#39;) is not None and
+        xml_midi_instrument.find(&#39;midi-program&#39;) is not None):
+      self.midi_channel = int(xml_midi_instrument.find(&#39;midi-channel&#39;).text)
+      self.midi_program = int(xml_midi_instrument.find(&#39;midi-program&#39;).text)
+    else:
+      # If no MIDI info, use the default MIDI channel.
+      self.midi_channel = DEFAULT_MIDI_CHANNEL
+      # Use the default MIDI program
+      self.midi_program = DEFAULT_MIDI_PROGRAM
+
+  def __str__(self):
+    score_str = &#39;ScorePart: &#39; + self.part_name
+    score_str += &#39;, Channel: &#39; + str(self.midi_channel)
+    score_str += &#39;, Program: &#39; + str(self.midi_program)
+    return score_str
+
+
+class Part(object):
+  &#34;&#34;&#34;Internal represention of a MusicXML &lt;part&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_part, score_parts, state):
+    self.id = &#39;&#39;
+    self.score_part = None
+    self.measures = []
+    self._state = state
+    self._parse(xml_part, score_parts)
+
+  def _parse(self, xml_part, score_parts):
+    &#34;&#34;&#34;Parse the &lt;part&gt; element.&#34;&#34;&#34;
+    if &#39;id&#39; in xml_part.attrib:
+      self.id = xml_part.attrib[&#39;id&#39;]
+    if self.id in score_parts:
+      self.score_part = score_parts[self.id]
+    else:
+      # If this part references a score-part id that was not found in the file,
+      # construct a default score-part.
+      self.score_part = ScorePart()
+
+    # Reset the time position when parsing each part
+    self._state.time_position = 0
+    self._state.midi_channel = self.score_part.midi_channel
+    self._state.midi_program = self.score_part.midi_program
+    self._state.transpose = 0
+
+    xml_measures = xml_part.findall(&#39;measure&#39;)
+    for measure in xml_measures:
+      # Issue #674: Repair measures that do not contain notes
+      # by inserting a whole measure rest
+      self._repair_empty_measure(measure)
+      parsed_measure = Measure(measure, self._state)
+      self.measures.append(parsed_measure)
+
+  def _repair_empty_measure(self, measure):
+    &#34;&#34;&#34;Repair a measure if it is empty by inserting a whole measure rest.
+
+    If a &lt;measure&gt; only consists of a &lt;forward&gt; element that advances
+    the time cursor, remove the &lt;forward&gt; element and replace
+    with a whole measure rest of the same duration.
+
+    Args:
+      measure: The measure to repair.
+    &#34;&#34;&#34;
+    # Issue #674 - If the &lt;forward&gt; element is in a measure without
+    # any &lt;note&gt; elements, treat it as if it were a whole measure
+    # rest by inserting a rest of that duration
+    forward_count = len(measure.findall(&#39;forward&#39;))
+    note_count = len(measure.findall(&#39;note&#39;))
+    if note_count == 0 and forward_count == 1:
+      # Get the duration of the &lt;forward&gt; element
+      xml_forward = measure.find(&#39;forward&#39;)
+      xml_duration = xml_forward.find(&#39;duration&#39;)
+      forward_duration = int(xml_duration.text)
+
+      # Delete the &lt;forward&gt; element
+      measure.remove(xml_forward)
+
+      # Insert the new note
+      new_note = &#39;&lt;note&gt;&#39;
+      new_note += &#39;&lt;rest /&gt;&lt;duration&gt;&#39; + str(forward_duration) + &#39;&lt;/duration&gt;&#39;
+      new_note += &#39;&lt;voice&gt;1&lt;/voice&gt;&lt;type&gt;whole&lt;/type&gt;&lt;staff&gt;1&lt;/staff&gt;&#39;
+      new_note += &#39;&lt;/note&gt;&#39;
+      new_note_xml = ET.fromstring(new_note)
+      measure.append(new_note_xml)
+
+  def __str__(self):
+    part_str = &#39;Part: &#39; + self.score_part.part_name
+    return part_str
+
+
+class Measure(object):
+  &#34;&#34;&#34;Internal represention of the MusicXML &lt;measure&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_measure, state):
+    self.xml_measure = xml_measure
+    self.notes = []
+    self.chord_symbols = []
+    self.tempos = []
+    self.time_signature = None
+    self.key_signature = None
+    # Cumulative duration in MusicXML duration.
+    # Used for time signature calculations
+    self.duration = 0
+    self.state = state
+    # Record the starting time of this measure so that time signatures
+    # can be inserted at the beginning of the measure
+    self.start_time_position = self.state.time_position
+    self._parse()
+    # Update the time signature if a partial or pickup measure
+    self._fix_time_signature()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the &lt;measure&gt; element.&#34;&#34;&#34;
+
+    for child in self.xml_measure:
+      if child.tag == &#39;attributes&#39;:
+        self._parse_attributes(child)
+      elif child.tag == &#39;backup&#39;:
+        self._parse_backup(child)
+      elif child.tag == &#39;direction&#39;:
+        self._parse_direction(child)
+      elif child.tag == &#39;forward&#39;:
+        self._parse_forward(child)
+      elif child.tag == &#39;note&#39;:
+        note = Note(child, self.state)
+        self.notes.append(note)
+        # Keep track of current note as previous note for chord timings
+        self.state.previous_note = note
+
+        # Sum up the MusicXML durations in voice 1 of this measure
+        if note.voice == 1 and not note.is_in_chord:
+          self.duration += note.note_duration.duration
+      elif child.tag == &#39;harmony&#39;:
+        chord_symbol = ChordSymbol(child, self.state)
+        self.chord_symbols.append(chord_symbol)
+
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_attributes(self, xml_attributes):
+    &#34;&#34;&#34;Parse the MusicXML &lt;attributes&gt; element.&#34;&#34;&#34;
+
+    for child in xml_attributes:
+      if child.tag == &#39;divisions&#39;:
+        self.state.divisions = int(child.text)
+      elif child.tag == &#39;key&#39;:
+        self.key_signature = KeySignature(self.state, child)
+      elif child.tag == &#39;time&#39;:
+        if self.time_signature is None:
+          self.time_signature = TimeSignature(self.state, child)
+          self.state.time_signature = self.time_signature
+        else:
+          raise MultipleTimeSignatureError(&#39;Multiple time signatures&#39;)
+      elif child.tag == &#39;transpose&#39;:
+        transpose = int(child.find(&#39;chromatic&#39;).text)
+        self.state.transpose = transpose
+        if self.key_signature is not None:
+          # Transposition is chromatic. Every half step up is 5 steps backward
+          # on the circle of fifths, which has 12 positions.
+          key_transpose = (transpose * -5) % 12
+          new_key = self.key_signature.key + key_transpose
+          # If the new key has &gt;6 sharps, translate to flats.
+          # TODO(fjord): Could be more smart about when to use sharps vs. flats
+          # when there are enharmonic equivalents.
+          if new_key &gt; 6:
+            new_key %= -6
+          self.key_signature.key = new_key
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_backup(self, xml_backup):
+    &#34;&#34;&#34;Parse the MusicXML &lt;backup&gt; element.
+
+    This moves the global time position backwards.
+
+    Args:
+      xml_backup: XML element with tag type &#39;backup&#39;.
+    &#34;&#34;&#34;
+
+    xml_duration = xml_backup.find(&#39;duration&#39;)
+    backup_duration = int(xml_duration.text)
+    midi_ticks = backup_duration * (constants.STANDARD_PPQ
+                                    / self.state.divisions)
+    seconds = ((midi_ticks / constants.STANDARD_PPQ)
+               * self.state.seconds_per_quarter)
+    self.state.time_position -= seconds
+
+  def _parse_direction(self, xml_direction):
+    &#34;&#34;&#34;Parse the MusicXML &lt;direction&gt; element.&#34;&#34;&#34;
+
+    for child in xml_direction:
+      if child.tag == &#39;sound&#39;:
+        if child.get(&#39;tempo&#39;) is not None:
+          tempo = Tempo(self.state, child)
+          self.tempos.append(tempo)
+          self.state.qpm = tempo.qpm
+          self.state.seconds_per_quarter = 60 / self.state.qpm
+          if child.get(&#39;dynamics&#39;) is not None:
+            self.state.velocity = int(child.get(&#39;dynamics&#39;))
+
+  def _parse_forward(self, xml_forward):
+    &#34;&#34;&#34;Parse the MusicXML &lt;forward&gt; element.
+
+    This moves the global time position forward.
+
+    Args:
+      xml_forward: XML element with tag type &#39;forward&#39;.
+    &#34;&#34;&#34;
+
+    xml_duration = xml_forward.find(&#39;duration&#39;)
+    forward_duration = int(xml_duration.text)
+    midi_ticks = forward_duration * (constants.STANDARD_PPQ
+                                     / self.state.divisions)
+    seconds = ((midi_ticks / constants.STANDARD_PPQ)
+               * self.state.seconds_per_quarter)
+    self.state.time_position += seconds
+
+  def _fix_time_signature(self):
+    &#34;&#34;&#34;Correct the time signature for incomplete measures.
+
+    If the measure is incomplete or a pickup, insert an appropriate
+    time signature into this Measure.
+    &#34;&#34;&#34;
+    # Compute the fractional time signature (duration / divisions)
+    # Multiply divisions by 4 because division is always parts per quarter note
+    numerator = self.duration
+    denominator = self.state.divisions * 4
+    fractional_time_signature = Fraction(numerator, denominator)
+
+    if self.state.time_signature is None and self.time_signature is None:
+      # No global time signature yet and no measure time signature defined
+      # in this measure (no time signature or senza misura).
+      # Insert the fractional time signature as the time signature
+      # for this measure
+      self.time_signature = TimeSignature(self.state)
+      self.time_signature.numerator = fractional_time_signature.numerator
+      self.time_signature.denominator = fractional_time_signature.denominator
+      self.state.time_signature = self.time_signature
+    else:
+      fractional_state_time_signature = Fraction(
+          self.state.time_signature.numerator,
+          self.state.time_signature.denominator)
+
+      # Check for pickup measure. Reset time signature to smaller numerator
+      pickup_measure = False
+      if numerator &lt; self.state.time_signature.numerator:
+        pickup_measure = True
+
+      # Get the current time signature denominator
+      global_time_signature_denominator = self.state.time_signature.denominator
+
+      # If the fractional time signature = 1 (e.g. 4/4),
+      # make the numerator the same as the global denominator
+      if fractional_time_signature == 1 and not pickup_measure:
+        new_time_signature = TimeSignature(self.state)
+        new_time_signature.numerator = global_time_signature_denominator
+        new_time_signature.denominator = global_time_signature_denominator
+      else:
+        # Otherwise, set the time signature to the fractional time signature
+        # Issue #674 - Use the original numerator and denominator
+        # instead of the fractional one
+        new_time_signature = TimeSignature(self.state)
+        new_time_signature.numerator = numerator
+        new_time_signature.denominator = denominator
+
+        new_time_sig_fraction = Fraction(numerator, denominator)
+
+        if new_time_sig_fraction == fractional_time_signature:
+          new_time_signature.numerator = fractional_time_signature.numerator
+          new_time_signature.denominator = fractional_time_signature.denominator
+
+      # Insert a new time signature only if it does not equal the global
+      # time signature.
+      if (pickup_measure or
+          (self.time_signature is None
+           and (fractional_time_signature != fractional_state_time_signature))):
+        new_time_signature.time_position = self.start_time_position
+        self.time_signature = new_time_signature
+        self.state.time_signature = new_time_signature
+
+
+class Note(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML &lt;note&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_note, state):
+    self.xml_note = xml_note
+    self.voice = 1
+    self.is_rest = False
+    self.is_in_chord = False
+    self.is_grace_note = False
+    self.pitch = None               # Tuple (Pitch Name, MIDI number)
+    self.note_duration = NoteDuration(state)
+    self.state = state
+    self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;note&gt; element.&#34;&#34;&#34;
+
+    self.midi_channel = self.state.midi_channel
+    self.midi_program = self.state.midi_program
+    self.velocity = self.state.velocity
+
+    for child in self.xml_note:
+      if child.tag == &#39;chord&#39;:
+        self.is_in_chord = True
+      elif child.tag == &#39;duration&#39;:
+        self.note_duration.parse_duration(self.is_in_chord, self.is_grace_note,
+                                          child.text)
+      elif child.tag == &#39;pitch&#39;:
+        self._parse_pitch(child)
+      elif child.tag == &#39;rest&#39;:
+        self.is_rest = True
+      elif child.tag == &#39;voice&#39;:
+        self.voice = int(child.text)
+      elif child.tag == &#39;dot&#39;:
+        self.note_duration.dots += 1
+      elif child.tag == &#39;type&#39;:
+        self.note_duration.type = child.text
+      elif child.tag == &#39;time-modification&#39;:
+        # A time-modification element represents a tuplet_ratio
+        self._parse_tuplet(child)
+      elif child.tag == &#39;unpitched&#39;:
+        raise UnpitchedNoteError(&#39;Unpitched notes are not supported&#39;)
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_pitch(self, xml_pitch):
+    &#34;&#34;&#34;Parse the MusicXML &lt;pitch&gt; element.&#34;&#34;&#34;
+    step = xml_pitch.find(&#39;step&#39;).text
+    alter_text = &#39;&#39;
+    alter = 0.0
+    if xml_pitch.find(&#39;alter&#39;) is not None:
+      alter_text = xml_pitch.find(&#39;alter&#39;).text
+    octave = xml_pitch.find(&#39;octave&#39;).text
+
+    # Parse alter string to a float (floats represent microtonal alterations)
+    if alter_text:
+      alter = float(alter_text)
+
+    # Check if this is a semitone alter (i.e. an integer) or microtonal (float)
+    alter_semitones = int(alter)  # Number of semitones
+    is_microtonal_alter = (alter != alter_semitones)
+
+    # Visual pitch representation
+    alter_string = &#39;&#39;
+    if alter_semitones == -2:
+      alter_string = &#39;bb&#39;
+    elif alter_semitones == -1:
+      alter_string = &#39;b&#39;
+    elif alter_semitones == 1:
+      alter_string = &#39;#&#39;
+    elif alter_semitones == 2:
+      alter_string = &#39;x&#39;
+
+    if is_microtonal_alter:
+      alter_string += &#39; (+microtones) &#39;
+
+    # N.B. - pitch_string does not account for transposition
+    pitch_string = step + alter_string + octave
+
+    # Compute MIDI pitch number (C4 = 60, C1 = 24, C0 = 12)
+    midi_pitch = self.pitch_to_midi_pitch(step, alter, octave)
+    # Transpose MIDI pitch
+    midi_pitch += self.state.transpose
+    self.pitch = (pitch_string, midi_pitch)
+
+  def _parse_tuplet(self, xml_time_modification):
+    &#34;&#34;&#34;Parses a tuplet ratio.
+
+    Represented in MusicXML by the &lt;time-modification&gt; element.
+
+    Args:
+      xml_time_modification: An xml time-modification element.
+    &#34;&#34;&#34;
+    numerator = int(xml_time_modification.find(&#39;actual-notes&#39;).text)
+    denominator = int(xml_time_modification.find(&#39;normal-notes&#39;).text)
+    self.note_duration.tuplet_ratio = Fraction(numerator, denominator)
+
+  @staticmethod
+  def pitch_to_midi_pitch(step, alter, octave):
+    &#34;&#34;&#34;Convert MusicXML pitch representation to MIDI pitch number.&#34;&#34;&#34;
+    pitch_class = 0
+    if step == &#39;C&#39;:
+      pitch_class = 0
+    elif step == &#39;D&#39;:
+      pitch_class = 2
+    elif step == &#39;E&#39;:
+      pitch_class = 4
+    elif step == &#39;F&#39;:
+      pitch_class = 5
+    elif step == &#39;G&#39;:
+      pitch_class = 7
+    elif step == &#39;A&#39;:
+      pitch_class = 9
+    elif step == &#39;B&#39;:
+      pitch_class = 11
+    else:
+      # Raise exception for unknown step (ex: &#39;Q&#39;)
+      raise PitchStepParseError(&#39;Unable to parse pitch step &#39; + step)
+
+    pitch_class = (pitch_class + int(alter)) % 12
+    midi_pitch = (12 + pitch_class) + (int(octave) * 12)
+    return midi_pitch
+
+  def __str__(self):
+    note_string = &#39;{duration: &#39; + str(self.note_duration.duration)
+    note_string += &#39;, midi_ticks: &#39; + str(self.note_duration.midi_ticks)
+    note_string += &#39;, seconds: &#39; + str(self.note_duration.seconds)
+    if self.is_rest:
+      note_string += &#39;, rest: &#39; + str(self.is_rest)
+    else:
+      note_string += &#39;, pitch: &#39; + self.pitch[0]
+      note_string += &#39;, MIDI pitch: &#39; + str(self.pitch[1])
+
+    note_string += &#39;, voice: &#39; + str(self.voice)
+    note_string += &#39;, velocity: &#39; + str(self.velocity) + &#39;} &#39;
+    note_string += &#39;(@time: &#39; + str(self.note_duration.time_position) + &#39;)&#39;
+    return note_string
+
+
+class NoteDuration(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML note&#39;s duration properties.&#34;&#34;&#34;
+
+  TYPE_RATIO_MAP = {&#39;maxima&#39;: Fraction(8, 1), &#39;long&#39;: Fraction(4, 1),
+                    &#39;breve&#39;: Fraction(2, 1), &#39;whole&#39;: Fraction(1, 1),
+                    &#39;half&#39;: Fraction(1, 2), &#39;quarter&#39;: Fraction(1, 4),
+                    &#39;eighth&#39;: Fraction(1, 8), &#39;16th&#39;: Fraction(1, 16),
+                    &#39;32nd&#39;: Fraction(1, 32), &#39;64th&#39;: Fraction(1, 64),
+                    &#39;128th&#39;: Fraction(1, 128), &#39;256th&#39;: Fraction(1, 256),
+                    &#39;512th&#39;: Fraction(1, 512), &#39;1024th&#39;: Fraction(1, 1024)}
+
+  def __init__(self, state):
+    self.duration = 0                   # MusicXML duration
+    self.midi_ticks = 0                 # Duration in MIDI ticks
+    self.seconds = 0                    # Duration in seconds
+    self.time_position = 0              # Onset time in seconds
+    self.dots = 0                       # Number of augmentation dots
+    self._type = &#39;quarter&#39;              # MusicXML duration type
+    self.tuplet_ratio = Fraction(1, 1)  # Ratio for tuplets (default to 1)
+    self.is_grace_note = True           # Assume true until not found
+    self.state = state
+
+  def parse_duration(self, is_in_chord, is_grace_note, duration):
+    &#34;&#34;&#34;Parse the duration of a note and compute timings.&#34;&#34;&#34;
+    self.duration = int(duration)
+
+    # Due to an error in Sibelius&#39; export, force this note to have the
+    # duration of the previous note if it is in a chord
+    if is_in_chord:
+      self.duration = self.state.previous_note.note_duration.duration
+
+    self.midi_ticks = self.duration
+    self.midi_ticks *= (constants.STANDARD_PPQ / self.state.divisions)
+
+    self.seconds = (self.midi_ticks / constants.STANDARD_PPQ)
+    self.seconds *= self.state.seconds_per_quarter
+
+    self.time_position = self.state.time_position
+
+    # Not sure how to handle durations of grace notes yet as they
+    # steal time from subsequent notes and they do not have a
+    # &lt;duration&gt; tag in the MusicXML
+    self.is_grace_note = is_grace_note
+
+    if is_in_chord:
+      # If this is a chord, set the time position to the time position
+      # of the previous note (i.e. all the notes in the chord will have
+      # the same time position)
+      self.time_position = self.state.previous_note.note_duration.time_position
+    else:
+      # Only increment time positions once in chord
+      self.state.time_position += self.seconds
+
+  def _convert_type_to_ratio(self):
+    &#34;&#34;&#34;Convert the MusicXML note-type-value to a Python Fraction.
+
+    Examples:
+    - whole = 1/1
+    - half = 1/2
+    - quarter = 1/4
+    - 32nd = 1/32
+
+    Returns:
+      A Fraction object representing the note type.
+    &#34;&#34;&#34;
+    return self.TYPE_RATIO_MAP[self.type]
+
+  def duration_ratio(self):
+    &#34;&#34;&#34;Compute the duration ratio of the note as a Python Fraction.
+
+    Examples:
+    - Whole Note = 1
+    - Quarter Note = 1/4
+    - Dotted Quarter Note = 3/8
+    - Triplet eighth note = 1/12
+
+    Returns:
+      The duration ratio as a Python Fraction.
+    &#34;&#34;&#34;
+    # Get ratio from MusicXML note type
+    duration_ratio = Fraction(1, 1)
+    type_ratio = self._convert_type_to_ratio()
+
+    # Compute tuplet ratio
+    duration_ratio /= self.tuplet_ratio
+    type_ratio /= self.tuplet_ratio
+
+    # Add augmentation dots
+    one_half = Fraction(1, 2)
+    dot_sum = Fraction(0, 1)
+    for dot in range(self.dots):
+      dot_sum += (one_half ** (dot + 1)) * type_ratio
+
+    duration_ratio = type_ratio + dot_sum
+
+    # If the note is a grace note, force its ratio to be 0
+    # because it does not have a &lt;duration&gt; tag
+    if self.is_grace_note:
+      duration_ratio = Fraction(0, 1)
+
+    return duration_ratio
+
+  def duration_float(self):
+    &#34;&#34;&#34;Return the duration ratio as a float.&#34;&#34;&#34;
+    ratio = self.duration_ratio()
+    return ratio.numerator / ratio.denominator
+
+  @property
+  def type(self):
+    return self._type
+
+  @type.setter
+  def type(self, new_type):
+    if new_type not in self.TYPE_RATIO_MAP:
+      raise InvalidNoteDurationTypeError(
+          &#39;Note duration type &#34;{}&#34; is not valid&#39;.format(new_type))
+    self._type = new_type
+
+
+class ChordSymbol(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML chord symbol &lt;harmony&gt; element.
+
+  This represents a chord symbol with four components:
+
+  1) Root: a string representing the chord root pitch class, e.g. &#34;C#&#34;.
+  2) Kind: a string representing the chord kind, e.g. &#34;m7&#34; for minor-seventh,
+      &#34;9&#34; for dominant-ninth, or the empty string for major triad.
+  3) Scale degree modifications: a list of strings representing scale degree
+      modifications for the chord, e.g. &#34;add9&#34; to add an unaltered ninth scale
+      degree (without the seventh), &#34;b5&#34; to flatten the fifth scale degree,
+      &#34;no3&#34; to remove the third scale degree, etc.
+  4) Bass: a string representing the chord bass pitch class, or None if the bass
+      pitch class is the same as the root pitch class.
+
+  There&#39;s also a special chord kind &#34;N.C.&#34; representing no harmony, for which
+  all other fields should be None.
+
+  Use the `get_figure_string` method to get a string representation of the chord
+  symbol as might appear in a lead sheet. This string representation is what we
+  use to represent chord symbols in NoteSequence protos, as text annotations.
+  While the MusicXML representation has more structure, using an unstructured
+  string provides more flexibility and allows us to ingest chords from other
+  sources, e.g. guitar tabs on the web.
+  &#34;&#34;&#34;
+
+  # The below dictionary maps chord kinds to an abbreviated string as would
+  # appear in a chord symbol in a standard lead sheet. There are often multiple
+  # standard abbreviations for the same chord type, e.g. &#34;+&#34; and &#34;aug&#34; both
+  # refer to an augmented chord, and &#34;maj7&#34;, &#34;M7&#34;, and a Delta character all
+  # refer to a major-seventh chord; this dictionary attempts to be consistent
+  # but the choice of abbreviation is somewhat arbitrary.
+  #
+  # The MusicXML-defined chord kinds are listed here:
+  # http://usermanuals.musicxml.com/MusicXML/Content/ST-MusicXML-kind-value.htm
+
+  CHORD_KIND_ABBREVIATIONS = {
+      # These chord kinds are in the MusicXML spec.
+      &#39;major&#39;: &#39;&#39;,
+      &#39;minor&#39;: &#39;m&#39;,
+      &#39;augmented&#39;: &#39;aug&#39;,
+      &#39;diminished&#39;: &#39;dim&#39;,
+      &#39;dominant&#39;: &#39;7&#39;,
+      &#39;major-seventh&#39;: &#39;maj7&#39;,
+      &#39;minor-seventh&#39;: &#39;m7&#39;,
+      &#39;diminished-seventh&#39;: &#39;dim7&#39;,
+      &#39;augmented-seventh&#39;: &#39;aug7&#39;,
+      &#39;half-diminished&#39;: &#39;m7b5&#39;,
+      &#39;major-minor&#39;: &#39;m(maj7)&#39;,
+      &#39;major-sixth&#39;: &#39;6&#39;,
+      &#39;minor-sixth&#39;: &#39;m6&#39;,
+      &#39;dominant-ninth&#39;: &#39;9&#39;,
+      &#39;major-ninth&#39;: &#39;maj9&#39;,
+      &#39;minor-ninth&#39;: &#39;m9&#39;,
+      &#39;dominant-11th&#39;: &#39;11&#39;,
+      &#39;major-11th&#39;: &#39;maj11&#39;,
+      &#39;minor-11th&#39;: &#39;m11&#39;,
+      &#39;dominant-13th&#39;: &#39;13&#39;,
+      &#39;major-13th&#39;: &#39;maj13&#39;,
+      &#39;minor-13th&#39;: &#39;m13&#39;,
+      &#39;suspended-second&#39;: &#39;sus2&#39;,
+      &#39;suspended-fourth&#39;: &#39;sus&#39;,
+      &#39;pedal&#39;: &#39;ped&#39;,
+      &#39;power&#39;: &#39;5&#39;,
+      &#39;none&#39;: &#39;N.C.&#39;,
+
+      # These are not in the spec, but show up frequently in the wild.
+      &#39;dominant-seventh&#39;: &#39;7&#39;,
+      &#39;augmented-ninth&#39;: &#39;aug9&#39;,
+      &#39;minor-major&#39;: &#39;m(maj7)&#39;,
+
+      # Some abbreviated kinds also show up frequently in the wild.
+      &#39;&#39;: &#39;&#39;,
+      &#39;min&#39;: &#39;m&#39;,
+      &#39;aug&#39;: &#39;aug&#39;,
+      &#39;dim&#39;: &#39;dim&#39;,
+      &#39;7&#39;: &#39;7&#39;,
+      &#39;maj7&#39;: &#39;maj7&#39;,
+      &#39;min7&#39;: &#39;m7&#39;,
+      &#39;dim7&#39;: &#39;dim7&#39;,
+      &#39;m7b5&#39;: &#39;m7b5&#39;,
+      &#39;minMaj7&#39;: &#39;m(maj7)&#39;,
+      &#39;6&#39;: &#39;6&#39;,
+      &#39;min6&#39;: &#39;m6&#39;,
+      &#39;maj69&#39;: &#39;6(add9)&#39;,
+      &#39;9&#39;: &#39;9&#39;,
+      &#39;maj9&#39;: &#39;maj9&#39;,
+      &#39;min9&#39;: &#39;m9&#39;,
+      &#39;sus47&#39;: &#39;sus7&#39;
+  }
+
+  def __init__(self, xml_harmony, state):
+    self.xml_harmony = xml_harmony
+    self.time_position = -1
+    self.root = None
+    self.kind = &#39;&#39;
+    self.degrees = []
+    self.bass = None
+    self.state = state
+    self._parse()
+
+  def _alter_to_string(self, alter_text):
+    &#34;&#34;&#34;Parse alter text to a string of one or two sharps/flats.
+
+    Args:
+      alter_text: A string representation of an integer number of semitones.
+
+    Returns:
+      A string, one of &#39;bb&#39;, &#39;b&#39;, &#39;#&#39;, &#39;##&#39;, or the empty string.
+
+    Raises:
+      ChordSymbolParseError: If `alter_text` cannot be parsed to an integer,
+          or if the integer is not a valid number of semitones between -2 and 2
+          inclusive.
+    &#34;&#34;&#34;
+    # Parse alter text to an integer number of semitones.
+    try:
+      alter_semitones = int(alter_text)
+    except ValueError:
+      raise ChordSymbolParseError(&#39;Non-integer alter: &#39; + str(alter_text))
+
+    # Visual alter representation
+    if alter_semitones == -2:
+      alter_string = &#39;bb&#39;
+    elif alter_semitones == -1:
+      alter_string = &#39;b&#39;
+    elif alter_semitones == 0:
+      alter_string = &#39;&#39;
+    elif alter_semitones == 1:
+      alter_string = &#39;#&#39;
+    elif alter_semitones == 2:
+      alter_string = &#39;##&#39;
+    else:
+      raise ChordSymbolParseError(&#39;Invalid alter: &#39; + str(alter_semitones))
+
+    return alter_string
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;harmony&gt; element.&#34;&#34;&#34;
+    self.time_position = self.state.time_position
+
+    for child in self.xml_harmony:
+      if child.tag == &#39;root&#39;:
+        self._parse_root(child)
+      elif child.tag == &#39;kind&#39;:
+        if child.text is None:
+          # Seems like this shouldn&#39;t happen but frequently does in the wild...
+          continue
+        kind_text = str(child.text).strip()
+        if kind_text not in self.CHORD_KIND_ABBREVIATIONS:
+          raise ChordSymbolParseError(&#39;Unknown chord kind: &#39; + kind_text)
+        self.kind = self.CHORD_KIND_ABBREVIATIONS[kind_text]
+      elif child.tag == &#39;degree&#39;:
+        self.degrees.append(self._parse_degree(child))
+      elif child.tag == &#39;bass&#39;:
+        self._parse_bass(child)
+      elif child.tag == &#39;offset&#39;:
+        # Offset tag moves chord symbol time position.
+        try:
+          offset = int(child.text)
+        except ValueError:
+          raise ChordSymbolParseError(&#39;Non-integer offset: &#39; + str(child.text))
+        midi_ticks = offset * constants.STANDARD_PPQ / self.state.divisions
+        seconds = (midi_ticks / constants.STANDARD_PPQ *
+                   self.state.seconds_per_quarter)
+        self.time_position += seconds
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+    if self.root is None and self.kind != &#39;N.C.&#39;:
+      raise ChordSymbolParseError(&#39;Chord symbol must have a root&#39;)
+
+  def _parse_pitch(self, xml_pitch, step_tag, alter_tag):
+    &#34;&#34;&#34;Parse and return the pitch-like &lt;root&gt; or &lt;bass&gt; element.&#34;&#34;&#34;
+    if xml_pitch.find(step_tag) is None:
+      raise ChordSymbolParseError(&#39;Missing pitch step&#39;)
+    step = xml_pitch.find(step_tag).text
+
+    alter_string = &#39;&#39;
+    if xml_pitch.find(alter_tag) is not None:
+      alter_text = xml_pitch.find(alter_tag).text
+      alter_string = self._alter_to_string(alter_text)
+
+    if self.state.transpose:
+      raise ChordSymbolParseError(
+          &#39;Transposition of chord symbols currently unsupported&#39;)
+
+    return step + alter_string
+
+  def _parse_root(self, xml_root):
+    &#34;&#34;&#34;Parse the &lt;root&gt; tag for a chord symbol.&#34;&#34;&#34;
+    self.root = self._parse_pitch(xml_root, step_tag=&#39;root-step&#39;,
+                                  alter_tag=&#39;root-alter&#39;)
+
+  def _parse_bass(self, xml_bass):
+    &#34;&#34;&#34;Parse the &lt;bass&gt; tag for a chord symbol.&#34;&#34;&#34;
+    self.bass = self._parse_pitch(xml_bass, step_tag=&#39;bass-step&#39;,
+                                  alter_tag=&#39;bass-alter&#39;)
+
+  def _parse_degree(self, xml_degree):
+    &#34;&#34;&#34;Parse and return the &lt;degree&gt; scale degree modification element.&#34;&#34;&#34;
+    if xml_degree.find(&#39;degree-value&#39;) is None:
+      raise ChordSymbolParseError(&#39;Missing scale degree value in harmony&#39;)
+    value_text = xml_degree.find(&#39;degree-value&#39;).text
+    if value_text is None:
+      raise ChordSymbolParseError(&#39;Missing scale degree&#39;)
+    try:
+      value = int(value_text)
+    except ValueError:
+      raise ChordSymbolParseError(
+          &#39;Non-integer scale degree: &#39; + str(value_text))
+
+    alter_string = &#39;&#39;
+    if xml_degree.find(&#39;degree-alter&#39;) is not None:
+      alter_text = xml_degree.find(&#39;degree-alter&#39;).text
+      alter_string = self._alter_to_string(alter_text)
+
+    if xml_degree.find(&#39;degree-type&#39;) is None:
+      raise ChordSymbolParseError(&#39;Missing degree modification type&#39;)
+    type_text = xml_degree.find(&#39;degree-type&#39;).text
+
+    if type_text == &#39;add&#39;:
+      if not alter_string:
+        # When adding unaltered scale degree, use &#34;add&#34; string.
+        type_string = &#39;add&#39;
+      else:
+        # When adding altered scale degree, &#34;add&#34; not necessary.
+        type_string = &#39;&#39;
+    elif type_text == &#39;subtract&#39;:
+      type_string = &#39;no&#39;
+      # Alter should be irrelevant when removing scale degree.
+      alter_string = &#39;&#39;
+    elif type_text == &#39;alter&#39;:
+      if not alter_string:
+        raise ChordSymbolParseError(&#39;Degree alteration by zero semitones&#39;)
+      # No type string necessary as merely appending e.g. &#34;#9&#34; suffices.
+      type_string = &#39;&#39;
+    else:
+      raise ChordSymbolParseError(
+          &#39;Invalid degree modification type: &#39; + str(type_text))
+
+    # Return a scale degree modification string that can be appended to a chord
+    # symbol figure string.
+    return type_string + alter_string + str(value)
+
+  def __str__(self):
+    if self.kind == &#39;N.C.&#39;:
+      note_string = &#39;{kind: &#39; + self.kind + &#39;} &#39;
+    else:
+      note_string = &#39;{root: &#39; + self.root
+      note_string += &#39;, kind: &#39; + self.kind
+      note_string += &#39;, degrees: [%s]&#39; % &#39;, &#39;.join(degree
+                                                   for degree in self.degrees)
+      note_string += &#39;, bass: &#39; + self.bass + &#39;} &#39;
+    note_string += &#39;(@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return note_string
+
+  def get_figure_string(self):
+    &#34;&#34;&#34;Return a chord symbol figure string.&#34;&#34;&#34;
+    if self.kind == &#39;N.C.&#39;:
+      return self.kind
+    else:
+      degrees_string = &#39;&#39;.join(&#39;(%s)&#39; % degree for degree in self.degrees)
+      figure = self.root + self.kind + degrees_string
+      if self.bass:
+        figure += &#39;/&#39; + self.bass
+      return figure
+
+
+class TimeSignature(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML time signature.
+
+  Does not support:
+  - Composite time signatures: 3+2/8
+  - Alternating time signatures 2/4 + 3/8
+  - Senza misura
+  &#34;&#34;&#34;
+
+  def __init__(self, state, xml_time=None):
+    self.xml_time = xml_time
+    self.numerator = -1
+    self.denominator = -1
+    self.time_position = 0
+    self.state = state
+    if xml_time is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;time&gt; element.&#34;&#34;&#34;
+    if (len(self.xml_time.findall(&#39;beats&#39;)) &gt; 1 or
+        len(self.xml_time.findall(&#39;beat-type&#39;)) &gt; 1):
+      # If more than 1 beats or beat-type found, this time signature is
+      # not supported (ex: alternating meter)
+      raise AlternatingTimeSignatureError(&#39;Alternating Time Signature&#39;)
+
+    beats = self.xml_time.find(&#39;beats&#39;).text
+    beat_type = self.xml_time.find(&#39;beat-type&#39;).text
+    try:
+      self.numerator = int(beats)
+      self.denominator = int(beat_type)
+    except ValueError:
+      raise TimeSignatureParseError(
+          &#39;Could not parse time signature: {}/{}&#39;.format(beats, beat_type))
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    time_sig_str = str(self.numerator) + &#39;/&#39; + str(self.denominator)
+    time_sig_str += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return time_sig_str
+
+  def __eq__(self, other):
+    isequal = self.numerator == other.numerator
+    isequal = isequal and (self.denominator == other.denominator)
+    isequal = isequal and (self.time_position == other.time_position)
+    return isequal
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+
+class KeySignature(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML key signature.&#34;&#34;&#34;
+
+  def __init__(self, state, xml_key=None):
+    self.xml_key = xml_key
+    # MIDI and MusicXML identify key by using &#34;fifths&#34;:
+    # -1 = F, 0 = C, 1 = G etc.
+    self.key = 0
+    # mode is &#34;major&#34; or &#34;minor&#34; only: MIDI only supports major and minor
+    self.mode = &#39;major&#39;
+    self.time_position = -1
+    self.state = state
+    if xml_key is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;key&gt; element into a MIDI compatible key.
+
+    If the mode is not minor (e.g. dorian), default to &#34;major&#34;
+    because MIDI only supports major and minor modes.
+
+
+    Raises:
+      KeyParseError: If the fifths element is missing.
+    &#34;&#34;&#34;
+    fifths = self.xml_key.find(&#39;fifths&#39;)
+    if fifths is None:
+      raise KeyParseError(
+          &#39;Could not find fifths attribute in key signature.&#39;)
+    self.key = int(self.xml_key.find(&#39;fifths&#39;).text)
+    mode = self.xml_key.find(&#39;mode&#39;)
+    # Anything not minor will be interpreted as major
+    if mode != &#39;minor&#39;:
+      mode = &#39;major&#39;
+    self.mode = mode
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    keys = ([&#39;Cb&#39;, &#39;Gb&#39;, &#39;Db&#39;, &#39;Ab&#39;, &#39;Eb&#39;, &#39;Bb&#39;, &#39;F&#39;, &#39;C&#39;, &#39;G&#39;, &#39;D&#39;,
+             &#39;A&#39;, &#39;E&#39;, &#39;B&#39;, &#39;F#&#39;, &#39;C#&#39;])
+    key_string = keys[self.key + 7] + &#39; &#39; + self.mode
+    key_string += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return key_string
+
+  def __eq__(self, other):
+    isequal = self.key == other.key
+    isequal = isequal and (self.mode == other.mode)
+    isequal = isequal and (self.time_position == other.time_position)
+    return isequal
+
+
+class Tempo(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML tempo.&#34;&#34;&#34;
+
+  def __init__(self, state, xml_sound=None):
+    self.xml_sound = xml_sound
+    self.qpm = -1
+    self.time_position = -1
+    self.state = state
+    if xml_sound is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;sound&gt; element and retrieve the tempo.
+
+    If no tempo is specified, default to DEFAULT_QUARTERS_PER_MINUTE
+    &#34;&#34;&#34;
+    self.qpm = float(self.xml_sound.get(&#39;tempo&#39;))
+    if self.qpm == 0:
+      # If tempo is 0, set it to default
+      self.qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    tempo_str = &#39;Tempo: &#39; + str(self.qpm)
+    tempo_str += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return tempo_str</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.musicxml_parser.AlternatingTimeSignatureError"><code class="flex name class">
+<span>class <span class="ident">AlternatingTimeSignatureError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when an alternating time signature is encountered.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AlternatingTimeSignatureError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when an alternating time signature is encountered.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.ChordSymbol"><code class="flex name class">
+<span>class <span class="ident">ChordSymbol</span></span>
+<span>(</span><span>xml_harmony, state)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML chord symbol <harmony> element.</p>
+<p>This represents a chord symbol with four components:</p>
+<p>1) Root: a string representing the chord root pitch class, e.g. "C#".
+2) Kind: a string representing the chord kind, e.g. "m7" for minor-seventh,
+"9" for dominant-ninth, or the empty string for major triad.
+3) Scale degree modifications: a list of strings representing scale degree
+modifications for the chord, e.g. "add9" to add an unaltered ninth scale
+degree (without the seventh), "b5" to flatten the fifth scale degree,
+"no3" to remove the third scale degree, etc.
+4) Bass: a string representing the chord bass pitch class, or None if the bass
+pitch class is the same as the root pitch class.</p>
+<p>There's also a special chord kind "N.C." representing no harmony, for which
+all other fields should be None.</p>
+<p>Use the <code>get_figure_string</code> method to get a string representation of the chord
+symbol as might appear in a lead sheet. This string representation is what we
+use to represent chord symbols in NoteSequence protos, as text annotations.
+While the MusicXML representation has more structure, using an unstructured
+string provides more flexibility and allows us to ingest chords from other
+sources, e.g. guitar tabs on the web.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordSymbol(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML chord symbol &lt;harmony&gt; element.
+
+  This represents a chord symbol with four components:
+
+  1) Root: a string representing the chord root pitch class, e.g. &#34;C#&#34;.
+  2) Kind: a string representing the chord kind, e.g. &#34;m7&#34; for minor-seventh,
+      &#34;9&#34; for dominant-ninth, or the empty string for major triad.
+  3) Scale degree modifications: a list of strings representing scale degree
+      modifications for the chord, e.g. &#34;add9&#34; to add an unaltered ninth scale
+      degree (without the seventh), &#34;b5&#34; to flatten the fifth scale degree,
+      &#34;no3&#34; to remove the third scale degree, etc.
+  4) Bass: a string representing the chord bass pitch class, or None if the bass
+      pitch class is the same as the root pitch class.
+
+  There&#39;s also a special chord kind &#34;N.C.&#34; representing no harmony, for which
+  all other fields should be None.
+
+  Use the `get_figure_string` method to get a string representation of the chord
+  symbol as might appear in a lead sheet. This string representation is what we
+  use to represent chord symbols in NoteSequence protos, as text annotations.
+  While the MusicXML representation has more structure, using an unstructured
+  string provides more flexibility and allows us to ingest chords from other
+  sources, e.g. guitar tabs on the web.
+  &#34;&#34;&#34;
+
+  # The below dictionary maps chord kinds to an abbreviated string as would
+  # appear in a chord symbol in a standard lead sheet. There are often multiple
+  # standard abbreviations for the same chord type, e.g. &#34;+&#34; and &#34;aug&#34; both
+  # refer to an augmented chord, and &#34;maj7&#34;, &#34;M7&#34;, and a Delta character all
+  # refer to a major-seventh chord; this dictionary attempts to be consistent
+  # but the choice of abbreviation is somewhat arbitrary.
+  #
+  # The MusicXML-defined chord kinds are listed here:
+  # http://usermanuals.musicxml.com/MusicXML/Content/ST-MusicXML-kind-value.htm
+
+  CHORD_KIND_ABBREVIATIONS = {
+      # These chord kinds are in the MusicXML spec.
+      &#39;major&#39;: &#39;&#39;,
+      &#39;minor&#39;: &#39;m&#39;,
+      &#39;augmented&#39;: &#39;aug&#39;,
+      &#39;diminished&#39;: &#39;dim&#39;,
+      &#39;dominant&#39;: &#39;7&#39;,
+      &#39;major-seventh&#39;: &#39;maj7&#39;,
+      &#39;minor-seventh&#39;: &#39;m7&#39;,
+      &#39;diminished-seventh&#39;: &#39;dim7&#39;,
+      &#39;augmented-seventh&#39;: &#39;aug7&#39;,
+      &#39;half-diminished&#39;: &#39;m7b5&#39;,
+      &#39;major-minor&#39;: &#39;m(maj7)&#39;,
+      &#39;major-sixth&#39;: &#39;6&#39;,
+      &#39;minor-sixth&#39;: &#39;m6&#39;,
+      &#39;dominant-ninth&#39;: &#39;9&#39;,
+      &#39;major-ninth&#39;: &#39;maj9&#39;,
+      &#39;minor-ninth&#39;: &#39;m9&#39;,
+      &#39;dominant-11th&#39;: &#39;11&#39;,
+      &#39;major-11th&#39;: &#39;maj11&#39;,
+      &#39;minor-11th&#39;: &#39;m11&#39;,
+      &#39;dominant-13th&#39;: &#39;13&#39;,
+      &#39;major-13th&#39;: &#39;maj13&#39;,
+      &#39;minor-13th&#39;: &#39;m13&#39;,
+      &#39;suspended-second&#39;: &#39;sus2&#39;,
+      &#39;suspended-fourth&#39;: &#39;sus&#39;,
+      &#39;pedal&#39;: &#39;ped&#39;,
+      &#39;power&#39;: &#39;5&#39;,
+      &#39;none&#39;: &#39;N.C.&#39;,
+
+      # These are not in the spec, but show up frequently in the wild.
+      &#39;dominant-seventh&#39;: &#39;7&#39;,
+      &#39;augmented-ninth&#39;: &#39;aug9&#39;,
+      &#39;minor-major&#39;: &#39;m(maj7)&#39;,
+
+      # Some abbreviated kinds also show up frequently in the wild.
+      &#39;&#39;: &#39;&#39;,
+      &#39;min&#39;: &#39;m&#39;,
+      &#39;aug&#39;: &#39;aug&#39;,
+      &#39;dim&#39;: &#39;dim&#39;,
+      &#39;7&#39;: &#39;7&#39;,
+      &#39;maj7&#39;: &#39;maj7&#39;,
+      &#39;min7&#39;: &#39;m7&#39;,
+      &#39;dim7&#39;: &#39;dim7&#39;,
+      &#39;m7b5&#39;: &#39;m7b5&#39;,
+      &#39;minMaj7&#39;: &#39;m(maj7)&#39;,
+      &#39;6&#39;: &#39;6&#39;,
+      &#39;min6&#39;: &#39;m6&#39;,
+      &#39;maj69&#39;: &#39;6(add9)&#39;,
+      &#39;9&#39;: &#39;9&#39;,
+      &#39;maj9&#39;: &#39;maj9&#39;,
+      &#39;min9&#39;: &#39;m9&#39;,
+      &#39;sus47&#39;: &#39;sus7&#39;
+  }
+
+  def __init__(self, xml_harmony, state):
+    self.xml_harmony = xml_harmony
+    self.time_position = -1
+    self.root = None
+    self.kind = &#39;&#39;
+    self.degrees = []
+    self.bass = None
+    self.state = state
+    self._parse()
+
+  def _alter_to_string(self, alter_text):
+    &#34;&#34;&#34;Parse alter text to a string of one or two sharps/flats.
+
+    Args:
+      alter_text: A string representation of an integer number of semitones.
+
+    Returns:
+      A string, one of &#39;bb&#39;, &#39;b&#39;, &#39;#&#39;, &#39;##&#39;, or the empty string.
+
+    Raises:
+      ChordSymbolParseError: If `alter_text` cannot be parsed to an integer,
+          or if the integer is not a valid number of semitones between -2 and 2
+          inclusive.
+    &#34;&#34;&#34;
+    # Parse alter text to an integer number of semitones.
+    try:
+      alter_semitones = int(alter_text)
+    except ValueError:
+      raise ChordSymbolParseError(&#39;Non-integer alter: &#39; + str(alter_text))
+
+    # Visual alter representation
+    if alter_semitones == -2:
+      alter_string = &#39;bb&#39;
+    elif alter_semitones == -1:
+      alter_string = &#39;b&#39;
+    elif alter_semitones == 0:
+      alter_string = &#39;&#39;
+    elif alter_semitones == 1:
+      alter_string = &#39;#&#39;
+    elif alter_semitones == 2:
+      alter_string = &#39;##&#39;
+    else:
+      raise ChordSymbolParseError(&#39;Invalid alter: &#39; + str(alter_semitones))
+
+    return alter_string
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;harmony&gt; element.&#34;&#34;&#34;
+    self.time_position = self.state.time_position
+
+    for child in self.xml_harmony:
+      if child.tag == &#39;root&#39;:
+        self._parse_root(child)
+      elif child.tag == &#39;kind&#39;:
+        if child.text is None:
+          # Seems like this shouldn&#39;t happen but frequently does in the wild...
+          continue
+        kind_text = str(child.text).strip()
+        if kind_text not in self.CHORD_KIND_ABBREVIATIONS:
+          raise ChordSymbolParseError(&#39;Unknown chord kind: &#39; + kind_text)
+        self.kind = self.CHORD_KIND_ABBREVIATIONS[kind_text]
+      elif child.tag == &#39;degree&#39;:
+        self.degrees.append(self._parse_degree(child))
+      elif child.tag == &#39;bass&#39;:
+        self._parse_bass(child)
+      elif child.tag == &#39;offset&#39;:
+        # Offset tag moves chord symbol time position.
+        try:
+          offset = int(child.text)
+        except ValueError:
+          raise ChordSymbolParseError(&#39;Non-integer offset: &#39; + str(child.text))
+        midi_ticks = offset * constants.STANDARD_PPQ / self.state.divisions
+        seconds = (midi_ticks / constants.STANDARD_PPQ *
+                   self.state.seconds_per_quarter)
+        self.time_position += seconds
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+    if self.root is None and self.kind != &#39;N.C.&#39;:
+      raise ChordSymbolParseError(&#39;Chord symbol must have a root&#39;)
+
+  def _parse_pitch(self, xml_pitch, step_tag, alter_tag):
+    &#34;&#34;&#34;Parse and return the pitch-like &lt;root&gt; or &lt;bass&gt; element.&#34;&#34;&#34;
+    if xml_pitch.find(step_tag) is None:
+      raise ChordSymbolParseError(&#39;Missing pitch step&#39;)
+    step = xml_pitch.find(step_tag).text
+
+    alter_string = &#39;&#39;
+    if xml_pitch.find(alter_tag) is not None:
+      alter_text = xml_pitch.find(alter_tag).text
+      alter_string = self._alter_to_string(alter_text)
+
+    if self.state.transpose:
+      raise ChordSymbolParseError(
+          &#39;Transposition of chord symbols currently unsupported&#39;)
+
+    return step + alter_string
+
+  def _parse_root(self, xml_root):
+    &#34;&#34;&#34;Parse the &lt;root&gt; tag for a chord symbol.&#34;&#34;&#34;
+    self.root = self._parse_pitch(xml_root, step_tag=&#39;root-step&#39;,
+                                  alter_tag=&#39;root-alter&#39;)
+
+  def _parse_bass(self, xml_bass):
+    &#34;&#34;&#34;Parse the &lt;bass&gt; tag for a chord symbol.&#34;&#34;&#34;
+    self.bass = self._parse_pitch(xml_bass, step_tag=&#39;bass-step&#39;,
+                                  alter_tag=&#39;bass-alter&#39;)
+
+  def _parse_degree(self, xml_degree):
+    &#34;&#34;&#34;Parse and return the &lt;degree&gt; scale degree modification element.&#34;&#34;&#34;
+    if xml_degree.find(&#39;degree-value&#39;) is None:
+      raise ChordSymbolParseError(&#39;Missing scale degree value in harmony&#39;)
+    value_text = xml_degree.find(&#39;degree-value&#39;).text
+    if value_text is None:
+      raise ChordSymbolParseError(&#39;Missing scale degree&#39;)
+    try:
+      value = int(value_text)
+    except ValueError:
+      raise ChordSymbolParseError(
+          &#39;Non-integer scale degree: &#39; + str(value_text))
+
+    alter_string = &#39;&#39;
+    if xml_degree.find(&#39;degree-alter&#39;) is not None:
+      alter_text = xml_degree.find(&#39;degree-alter&#39;).text
+      alter_string = self._alter_to_string(alter_text)
+
+    if xml_degree.find(&#39;degree-type&#39;) is None:
+      raise ChordSymbolParseError(&#39;Missing degree modification type&#39;)
+    type_text = xml_degree.find(&#39;degree-type&#39;).text
+
+    if type_text == &#39;add&#39;:
+      if not alter_string:
+        # When adding unaltered scale degree, use &#34;add&#34; string.
+        type_string = &#39;add&#39;
+      else:
+        # When adding altered scale degree, &#34;add&#34; not necessary.
+        type_string = &#39;&#39;
+    elif type_text == &#39;subtract&#39;:
+      type_string = &#39;no&#39;
+      # Alter should be irrelevant when removing scale degree.
+      alter_string = &#39;&#39;
+    elif type_text == &#39;alter&#39;:
+      if not alter_string:
+        raise ChordSymbolParseError(&#39;Degree alteration by zero semitones&#39;)
+      # No type string necessary as merely appending e.g. &#34;#9&#34; suffices.
+      type_string = &#39;&#39;
+    else:
+      raise ChordSymbolParseError(
+          &#39;Invalid degree modification type: &#39; + str(type_text))
+
+    # Return a scale degree modification string that can be appended to a chord
+    # symbol figure string.
+    return type_string + alter_string + str(value)
+
+  def __str__(self):
+    if self.kind == &#39;N.C.&#39;:
+      note_string = &#39;{kind: &#39; + self.kind + &#39;} &#39;
+    else:
+      note_string = &#39;{root: &#39; + self.root
+      note_string += &#39;, kind: &#39; + self.kind
+      note_string += &#39;, degrees: [%s]&#39; % &#39;, &#39;.join(degree
+                                                   for degree in self.degrees)
+      note_string += &#39;, bass: &#39; + self.bass + &#39;} &#39;
+    note_string += &#39;(@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return note_string
+
+  def get_figure_string(self):
+    &#34;&#34;&#34;Return a chord symbol figure string.&#34;&#34;&#34;
+    if self.kind == &#39;N.C.&#39;:
+      return self.kind
+    else:
+      degrees_string = &#39;&#39;.join(&#39;(%s)&#39; % degree for degree in self.degrees)
+      figure = self.root + self.kind + degrees_string
+      if self.bass:
+        figure += &#39;/&#39; + self.bass
+      return figure</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.ChordSymbol.CHORD_KIND_ABBREVIATIONS"><code class="name">var <span class="ident">CHORD_KIND_ABBREVIATIONS</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.ChordSymbol.get_figure_string"><code class="name flex">
+<span>def <span class="ident">get_figure_string</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a chord symbol figure string.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_figure_string(self):
+  &#34;&#34;&#34;Return a chord symbol figure string.&#34;&#34;&#34;
+  if self.kind == &#39;N.C.&#39;:
+    return self.kind
+  else:
+    degrees_string = &#39;&#39;.join(&#39;(%s)&#39; % degree for degree in self.degrees)
+    figure = self.root + self.kind + degrees_string
+    if self.bass:
+      figure += &#39;/&#39; + self.bass
+    return figure</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.musicxml_parser.ChordSymbolParseError"><code class="flex name class">
+<span>class <span class="ident">ChordSymbolParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when a chord symbol cannot be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ChordSymbolParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a chord symbol cannot be parsed.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.InvalidNoteDurationTypeError"><code class="flex name class">
+<span>class <span class="ident">InvalidNoteDurationTypeError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when a note's duration type is invalid.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InvalidNoteDurationTypeError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a note&#39;s duration type is invalid.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.KeyParseError"><code class="flex name class">
+<span>class <span class="ident">KeyParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when a key signature cannot be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class KeyParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a key signature cannot be parsed.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.KeySignature"><code class="flex name class">
+<span>class <span class="ident">KeySignature</span></span>
+<span>(</span><span>state, xml_key=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML key signature.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class KeySignature(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML key signature.&#34;&#34;&#34;
+
+  def __init__(self, state, xml_key=None):
+    self.xml_key = xml_key
+    # MIDI and MusicXML identify key by using &#34;fifths&#34;:
+    # -1 = F, 0 = C, 1 = G etc.
+    self.key = 0
+    # mode is &#34;major&#34; or &#34;minor&#34; only: MIDI only supports major and minor
+    self.mode = &#39;major&#39;
+    self.time_position = -1
+    self.state = state
+    if xml_key is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;key&gt; element into a MIDI compatible key.
+
+    If the mode is not minor (e.g. dorian), default to &#34;major&#34;
+    because MIDI only supports major and minor modes.
+
+
+    Raises:
+      KeyParseError: If the fifths element is missing.
+    &#34;&#34;&#34;
+    fifths = self.xml_key.find(&#39;fifths&#39;)
+    if fifths is None:
+      raise KeyParseError(
+          &#39;Could not find fifths attribute in key signature.&#39;)
+    self.key = int(self.xml_key.find(&#39;fifths&#39;).text)
+    mode = self.xml_key.find(&#39;mode&#39;)
+    # Anything not minor will be interpreted as major
+    if mode != &#39;minor&#39;:
+      mode = &#39;major&#39;
+    self.mode = mode
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    keys = ([&#39;Cb&#39;, &#39;Gb&#39;, &#39;Db&#39;, &#39;Ab&#39;, &#39;Eb&#39;, &#39;Bb&#39;, &#39;F&#39;, &#39;C&#39;, &#39;G&#39;, &#39;D&#39;,
+             &#39;A&#39;, &#39;E&#39;, &#39;B&#39;, &#39;F#&#39;, &#39;C#&#39;])
+    key_string = keys[self.key + 7] + &#39; &#39; + self.mode
+    key_string += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return key_string
+
+  def __eq__(self, other):
+    isequal = self.key == other.key
+    isequal = isequal and (self.mode == other.mode)
+    isequal = isequal and (self.time_position == other.time_position)
+    return isequal</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.Measure"><code class="flex name class">
+<span>class <span class="ident">Measure</span></span>
+<span>(</span><span>xml_measure, state)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal represention of the MusicXML <measure> element.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Measure(object):
+  &#34;&#34;&#34;Internal represention of the MusicXML &lt;measure&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_measure, state):
+    self.xml_measure = xml_measure
+    self.notes = []
+    self.chord_symbols = []
+    self.tempos = []
+    self.time_signature = None
+    self.key_signature = None
+    # Cumulative duration in MusicXML duration.
+    # Used for time signature calculations
+    self.duration = 0
+    self.state = state
+    # Record the starting time of this measure so that time signatures
+    # can be inserted at the beginning of the measure
+    self.start_time_position = self.state.time_position
+    self._parse()
+    # Update the time signature if a partial or pickup measure
+    self._fix_time_signature()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the &lt;measure&gt; element.&#34;&#34;&#34;
+
+    for child in self.xml_measure:
+      if child.tag == &#39;attributes&#39;:
+        self._parse_attributes(child)
+      elif child.tag == &#39;backup&#39;:
+        self._parse_backup(child)
+      elif child.tag == &#39;direction&#39;:
+        self._parse_direction(child)
+      elif child.tag == &#39;forward&#39;:
+        self._parse_forward(child)
+      elif child.tag == &#39;note&#39;:
+        note = Note(child, self.state)
+        self.notes.append(note)
+        # Keep track of current note as previous note for chord timings
+        self.state.previous_note = note
+
+        # Sum up the MusicXML durations in voice 1 of this measure
+        if note.voice == 1 and not note.is_in_chord:
+          self.duration += note.note_duration.duration
+      elif child.tag == &#39;harmony&#39;:
+        chord_symbol = ChordSymbol(child, self.state)
+        self.chord_symbols.append(chord_symbol)
+
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_attributes(self, xml_attributes):
+    &#34;&#34;&#34;Parse the MusicXML &lt;attributes&gt; element.&#34;&#34;&#34;
+
+    for child in xml_attributes:
+      if child.tag == &#39;divisions&#39;:
+        self.state.divisions = int(child.text)
+      elif child.tag == &#39;key&#39;:
+        self.key_signature = KeySignature(self.state, child)
+      elif child.tag == &#39;time&#39;:
+        if self.time_signature is None:
+          self.time_signature = TimeSignature(self.state, child)
+          self.state.time_signature = self.time_signature
+        else:
+          raise MultipleTimeSignatureError(&#39;Multiple time signatures&#39;)
+      elif child.tag == &#39;transpose&#39;:
+        transpose = int(child.find(&#39;chromatic&#39;).text)
+        self.state.transpose = transpose
+        if self.key_signature is not None:
+          # Transposition is chromatic. Every half step up is 5 steps backward
+          # on the circle of fifths, which has 12 positions.
+          key_transpose = (transpose * -5) % 12
+          new_key = self.key_signature.key + key_transpose
+          # If the new key has &gt;6 sharps, translate to flats.
+          # TODO(fjord): Could be more smart about when to use sharps vs. flats
+          # when there are enharmonic equivalents.
+          if new_key &gt; 6:
+            new_key %= -6
+          self.key_signature.key = new_key
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_backup(self, xml_backup):
+    &#34;&#34;&#34;Parse the MusicXML &lt;backup&gt; element.
+
+    This moves the global time position backwards.
+
+    Args:
+      xml_backup: XML element with tag type &#39;backup&#39;.
+    &#34;&#34;&#34;
+
+    xml_duration = xml_backup.find(&#39;duration&#39;)
+    backup_duration = int(xml_duration.text)
+    midi_ticks = backup_duration * (constants.STANDARD_PPQ
+                                    / self.state.divisions)
+    seconds = ((midi_ticks / constants.STANDARD_PPQ)
+               * self.state.seconds_per_quarter)
+    self.state.time_position -= seconds
+
+  def _parse_direction(self, xml_direction):
+    &#34;&#34;&#34;Parse the MusicXML &lt;direction&gt; element.&#34;&#34;&#34;
+
+    for child in xml_direction:
+      if child.tag == &#39;sound&#39;:
+        if child.get(&#39;tempo&#39;) is not None:
+          tempo = Tempo(self.state, child)
+          self.tempos.append(tempo)
+          self.state.qpm = tempo.qpm
+          self.state.seconds_per_quarter = 60 / self.state.qpm
+          if child.get(&#39;dynamics&#39;) is not None:
+            self.state.velocity = int(child.get(&#39;dynamics&#39;))
+
+  def _parse_forward(self, xml_forward):
+    &#34;&#34;&#34;Parse the MusicXML &lt;forward&gt; element.
+
+    This moves the global time position forward.
+
+    Args:
+      xml_forward: XML element with tag type &#39;forward&#39;.
+    &#34;&#34;&#34;
+
+    xml_duration = xml_forward.find(&#39;duration&#39;)
+    forward_duration = int(xml_duration.text)
+    midi_ticks = forward_duration * (constants.STANDARD_PPQ
+                                     / self.state.divisions)
+    seconds = ((midi_ticks / constants.STANDARD_PPQ)
+               * self.state.seconds_per_quarter)
+    self.state.time_position += seconds
+
+  def _fix_time_signature(self):
+    &#34;&#34;&#34;Correct the time signature for incomplete measures.
+
+    If the measure is incomplete or a pickup, insert an appropriate
+    time signature into this Measure.
+    &#34;&#34;&#34;
+    # Compute the fractional time signature (duration / divisions)
+    # Multiply divisions by 4 because division is always parts per quarter note
+    numerator = self.duration
+    denominator = self.state.divisions * 4
+    fractional_time_signature = Fraction(numerator, denominator)
+
+    if self.state.time_signature is None and self.time_signature is None:
+      # No global time signature yet and no measure time signature defined
+      # in this measure (no time signature or senza misura).
+      # Insert the fractional time signature as the time signature
+      # for this measure
+      self.time_signature = TimeSignature(self.state)
+      self.time_signature.numerator = fractional_time_signature.numerator
+      self.time_signature.denominator = fractional_time_signature.denominator
+      self.state.time_signature = self.time_signature
+    else:
+      fractional_state_time_signature = Fraction(
+          self.state.time_signature.numerator,
+          self.state.time_signature.denominator)
+
+      # Check for pickup measure. Reset time signature to smaller numerator
+      pickup_measure = False
+      if numerator &lt; self.state.time_signature.numerator:
+        pickup_measure = True
+
+      # Get the current time signature denominator
+      global_time_signature_denominator = self.state.time_signature.denominator
+
+      # If the fractional time signature = 1 (e.g. 4/4),
+      # make the numerator the same as the global denominator
+      if fractional_time_signature == 1 and not pickup_measure:
+        new_time_signature = TimeSignature(self.state)
+        new_time_signature.numerator = global_time_signature_denominator
+        new_time_signature.denominator = global_time_signature_denominator
+      else:
+        # Otherwise, set the time signature to the fractional time signature
+        # Issue #674 - Use the original numerator and denominator
+        # instead of the fractional one
+        new_time_signature = TimeSignature(self.state)
+        new_time_signature.numerator = numerator
+        new_time_signature.denominator = denominator
+
+        new_time_sig_fraction = Fraction(numerator, denominator)
+
+        if new_time_sig_fraction == fractional_time_signature:
+          new_time_signature.numerator = fractional_time_signature.numerator
+          new_time_signature.denominator = fractional_time_signature.denominator
+
+      # Insert a new time signature only if it does not equal the global
+      # time signature.
+      if (pickup_measure or
+          (self.time_signature is None
+           and (fractional_time_signature != fractional_state_time_signature))):
+        new_time_signature.time_position = self.start_time_position
+        self.time_signature = new_time_signature
+        self.state.time_signature = new_time_signature</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.MultipleTimeSignatureError"><code class="flex name class">
+<span>class <span class="ident">MultipleTimeSignatureError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when multiple time signatures found in a measure.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultipleTimeSignatureError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when multiple time signatures found in a measure.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLDocument"><code class="flex name class">
+<span>class <span class="ident">MusicXMLDocument</span></span>
+<span>(</span><span>filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML Document.</p>
+<p>Represents the top level object which holds the MusicXML document
+Responsible for loading the .xml or .mxl file using the _get_score method
+If the file is .mxl, this class uncompresses it</p>
+<p>After the file is loaded, this class then parses the document into memory
+using the parse method.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicXMLDocument(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML Document.
+
+  Represents the top level object which holds the MusicXML document
+  Responsible for loading the .xml or .mxl file using the _get_score method
+  If the file is .mxl, this class uncompresses it
+
+  After the file is loaded, this class then parses the document into memory
+  using the parse method.
+  &#34;&#34;&#34;
+
+  def __init__(self, filename):
+    self._score = self._get_score(filename)
+    self.parts = []
+    # ScoreParts indexed by id.
+    self._score_parts = {}
+    self.midi_resolution = constants.STANDARD_PPQ
+    self._state = MusicXMLParserState()
+    # Total time in seconds
+    self.total_time_secs = 0
+    self._parse()
+
+  @staticmethod
+  def _get_score(filename):
+    &#34;&#34;&#34;Given a MusicXML file, return the score as an xml.etree.ElementTree.
+
+    Given a MusicXML file, return the score as an xml.etree.ElementTree
+    If the file is compress (ends in .mxl), uncompress it first
+
+    Args:
+        filename: The path of a MusicXML file
+
+    Returns:
+      The score as an xml.etree.ElementTree.
+
+    Raises:
+      MusicXMLParseError: if the file cannot be parsed.
+    &#34;&#34;&#34;
+    score = None
+    if filename.endswith(&#39;.mxl&#39;):
+      # Compressed MXL file. Uncompress in memory.
+      try:
+        mxlzip = zipfile.ZipFile(filename)
+      except zipfile.BadZipfile as exception:
+        raise MusicXMLParseError(exception)
+
+      # A compressed MXL file may contain multiple files, but only one
+      # MusicXML file. Read the META-INF/container.xml file inside of the
+      # MXL file to locate the MusicXML file within the MXL file
+      # http://www.musicxml.com/tutorial/compressed-mxl-files/zip-archive-structure/
+
+      # Raise a MusicXMLParseError if multiple MusicXML files found
+
+      infolist = mxlzip.infolist()
+      # In py3, instead of returning raw bytes, ZipFile.infolist() tries to
+      # guess the filenames&#39; encoding based on file headers, and decodes using
+      # this encoding in order to return a list of strings. If the utf-8
+      # header is missing, it decodes using the DOS code page 437 encoding
+      # which is almost definitely wrong. Here we need to explicitly check
+      # for when this has occurred and change the encoding to utf-8.
+      # https://stackoverflow.com/questions/37723505/namelist-from-zipfile-returns-strings-with-an-invalid-encoding
+      zip_filename_utf8_flag = 0x800
+      for info in infolist:
+        if info.flag_bits &amp; zip_filename_utf8_flag == 0:
+          filename_bytes = info.filename.encode(&#39;437&#39;)
+          filename = filename_bytes.decode(&#39;utf-8&#39;, &#39;replace&#39;)
+          info.filename = filename
+
+      container_file = [x for x in infolist
+                        if x.filename == &#39;META-INF/container.xml&#39;]
+      compressed_file_name = &#39;&#39;
+
+      if container_file:
+        try:
+          container = ET.fromstring(mxlzip.read(container_file[0]))
+          for rootfile_tag in container.findall(&#39;./rootfiles/rootfile&#39;):
+            if &#39;media-type&#39; in rootfile_tag.attrib:
+              if rootfile_tag.attrib[&#39;media-type&#39;] == MUSICXML_MIME_TYPE:
+                if not compressed_file_name:
+                  compressed_file_name = rootfile_tag.attrib[&#39;full-path&#39;]
+                else:
+                  raise MusicXMLParseError(
+                      &#39;Multiple MusicXML files found in compressed archive&#39;)
+            else:
+              # No media-type attribute, so assume this is the MusicXML file
+              if not compressed_file_name:
+                compressed_file_name = rootfile_tag.attrib[&#39;full-path&#39;]
+              else:
+                raise MusicXMLParseError(
+                    &#39;Multiple MusicXML files found in compressed archive&#39;)
+        except ET.ParseError as exception:
+          raise MusicXMLParseError(exception)
+
+      if not compressed_file_name:
+        raise MusicXMLParseError(
+            &#39;Unable to locate main .xml file in compressed archive.&#39;)
+      try:
+        compressed_file_info = [x for x in infolist
+                                if x.filename == compressed_file_name][0]
+      except IndexError:
+        raise MusicXMLParseError(
+            &#39;Score file %s not found in zip archive&#39; % compressed_file_name)
+      score_string = mxlzip.read(compressed_file_info)
+      try:
+        score = ET.fromstring(score_string)
+      except ET.ParseError as exception:
+        raise MusicXMLParseError(exception)
+    else:
+      # Uncompressed XML file.
+      try:
+        tree = ET.parse(filename)
+        score = tree.getroot()
+      except ET.ParseError as exception:
+        raise MusicXMLParseError(exception)
+
+    return score
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the uncompressed MusicXML document.&#34;&#34;&#34;
+    # Parse part-list
+    xml_part_list = self._score.find(&#39;part-list&#39;)
+    if xml_part_list is not None:
+      for element in xml_part_list:
+        if element.tag == &#39;score-part&#39;:
+          score_part = ScorePart(element)
+          self._score_parts[score_part.id] = score_part
+
+    # Parse parts
+    for score_part_index, child in enumerate(self._score.findall(&#39;part&#39;)):
+      part = Part(child, self._score_parts, self._state)
+      self.parts.append(part)
+      score_part_index += 1
+      if self._state.time_position &gt; self.total_time_secs:
+        self.total_time_secs = self._state.time_position
+
+  def get_chord_symbols(self):
+    &#34;&#34;&#34;Return a list of all the chord symbols used in this score.&#34;&#34;&#34;
+    chord_symbols = []
+    for part in self.parts:
+      for measure in part.measures:
+        for chord_symbol in measure.chord_symbols:
+          if chord_symbol not in chord_symbols:
+            # Prevent duplicate chord symbols
+            chord_symbols.append(chord_symbol)
+    return chord_symbols
+
+  def get_time_signatures(self):
+    &#34;&#34;&#34;Return a list of all the time signatures used in this score.
+
+    Does not support polymeter (i.e. assumes all parts have the same
+    time signature, such as Part 1 having a time signature of 6/8
+    while Part 2 has a simultaneous time signature of 2/4).
+
+    Ignores duplicate time signatures to prevent Magenta duplicate
+    time signature error. This happens when multiple parts have the
+    same time signature is used in multiple parts at the same time.
+
+    Example: If Part 1 has a time siganture of 4/4 and Part 2 also
+    has a time signature of 4/4, then only instance of 4/4 is sent
+    to Magenta.
+
+    Returns:
+      A list of all TimeSignature objects used in this score.
+    &#34;&#34;&#34;
+    time_signatures = []
+    for part in self.parts:
+      for measure in part.measures:
+        if measure.time_signature is not None:
+          if measure.time_signature not in time_signatures:
+            # Prevent duplicate time signatures
+            time_signatures.append(measure.time_signature)
+
+    return time_signatures
+
+  def get_key_signatures(self):
+    &#34;&#34;&#34;Return a list of all the key signatures used in this score.
+
+    Support different key signatures in different parts (score in
+    written pitch).
+
+    Ignores duplicate key signatures to prevent Magenta duplicate key
+    signature error. This happens when multiple parts have the same
+    key signature at the same time.
+
+    Example: If the score is in written pitch and the
+    flute is written in the key of Bb major, the trombone will also be
+    written in the key of Bb major. However, the clarinet and trumpet
+    will be written in the key of C major because they are Bb transposing
+    instruments.
+
+    If no key signatures are found, create a default key signature of
+    C major.
+
+    Returns:
+      A list of all KeySignature objects used in this score.
+    &#34;&#34;&#34;
+    key_signatures = []
+    for part in self.parts:
+      for measure in part.measures:
+        if measure.key_signature is not None:
+          if measure.key_signature not in key_signatures:
+            # Prevent duplicate key signatures
+            key_signatures.append(measure.key_signature)
+
+    if not key_signatures:
+      # If there are no key signatures, add C major at the beginning
+      key_signature = KeySignature(self._state)
+      key_signature.time_position = 0
+      key_signatures.append(key_signature)
+
+    return key_signatures
+
+  def get_tempos(self):
+    &#34;&#34;&#34;Return a list of all tempos in this score.
+
+    If no tempos are found, create a default tempo of 120 qpm.
+
+    Returns:
+      A list of all Tempo objects used in this score.
+    &#34;&#34;&#34;
+    tempos = []
+
+    if self.parts:
+      part = self.parts[0]  # Use only first part
+      for measure in part.measures:
+        for tempo in measure.tempos:
+          tempos.append(tempo)
+
+    # If no tempos, add a default of 120 at beginning
+    if not tempos:
+      tempo = Tempo(self._state)
+      tempo.qpm = self._state.qpm
+      tempo.time_position = 0
+      tempos.append(tempo)
+
+    return tempos</code></pre>
+</details>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.MusicXMLDocument.get_chord_symbols"><code class="name flex">
+<span>def <span class="ident">get_chord_symbols</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of all the chord symbols used in this score.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_chord_symbols(self):
+  &#34;&#34;&#34;Return a list of all the chord symbols used in this score.&#34;&#34;&#34;
+  chord_symbols = []
+  for part in self.parts:
+    for measure in part.measures:
+      for chord_symbol in measure.chord_symbols:
+        if chord_symbol not in chord_symbols:
+          # Prevent duplicate chord symbols
+          chord_symbols.append(chord_symbol)
+  return chord_symbols</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLDocument.get_key_signatures"><code class="name flex">
+<span>def <span class="ident">get_key_signatures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of all the key signatures used in this score.</p>
+<p>Support different key signatures in different parts (score in
+written pitch).</p>
+<p>Ignores duplicate key signatures to prevent Magenta duplicate key
+signature error. This happens when multiple parts have the same
+key signature at the same time.</p>
+<p>Example: If the score is in written pitch and the
+flute is written in the key of Bb major, the trombone will also be
+written in the key of Bb major. However, the clarinet and trumpet
+will be written in the key of C major because they are Bb transposing
+instruments.</p>
+<p>If no key signatures are found, create a default key signature of
+C major.</p>
+<h2 id="returns">Returns</h2>
+<p>A list of all KeySignature objects used in this score.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_key_signatures(self):
+  &#34;&#34;&#34;Return a list of all the key signatures used in this score.
+
+  Support different key signatures in different parts (score in
+  written pitch).
+
+  Ignores duplicate key signatures to prevent Magenta duplicate key
+  signature error. This happens when multiple parts have the same
+  key signature at the same time.
+
+  Example: If the score is in written pitch and the
+  flute is written in the key of Bb major, the trombone will also be
+  written in the key of Bb major. However, the clarinet and trumpet
+  will be written in the key of C major because they are Bb transposing
+  instruments.
+
+  If no key signatures are found, create a default key signature of
+  C major.
+
+  Returns:
+    A list of all KeySignature objects used in this score.
+  &#34;&#34;&#34;
+  key_signatures = []
+  for part in self.parts:
+    for measure in part.measures:
+      if measure.key_signature is not None:
+        if measure.key_signature not in key_signatures:
+          # Prevent duplicate key signatures
+          key_signatures.append(measure.key_signature)
+
+  if not key_signatures:
+    # If there are no key signatures, add C major at the beginning
+    key_signature = KeySignature(self._state)
+    key_signature.time_position = 0
+    key_signatures.append(key_signature)
+
+  return key_signatures</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLDocument.get_tempos"><code class="name flex">
+<span>def <span class="ident">get_tempos</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of all tempos in this score.</p>
+<p>If no tempos are found, create a default tempo of 120 qpm.</p>
+<h2 id="returns">Returns</h2>
+<p>A list of all Tempo objects used in this score.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_tempos(self):
+  &#34;&#34;&#34;Return a list of all tempos in this score.
+
+  If no tempos are found, create a default tempo of 120 qpm.
+
+  Returns:
+    A list of all Tempo objects used in this score.
+  &#34;&#34;&#34;
+  tempos = []
+
+  if self.parts:
+    part = self.parts[0]  # Use only first part
+    for measure in part.measures:
+      for tempo in measure.tempos:
+        tempos.append(tempo)
+
+  # If no tempos, add a default of 120 at beginning
+  if not tempos:
+    tempo = Tempo(self._state)
+    tempo.qpm = self._state.qpm
+    tempo.time_position = 0
+    tempos.append(tempo)
+
+  return tempos</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLDocument.get_time_signatures"><code class="name flex">
+<span>def <span class="ident">get_time_signatures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of all the time signatures used in this score.</p>
+<p>Does not support polymeter (i.e. assumes all parts have the same
+time signature, such as Part 1 having a time signature of 6/8
+while Part 2 has a simultaneous time signature of 2/4).</p>
+<p>Ignores duplicate time signatures to prevent Magenta duplicate
+time signature error. This happens when multiple parts have the
+same time signature is used in multiple parts at the same time.</p>
+<p>Example: If Part 1 has a time siganture of 4/4 and Part 2 also
+has a time signature of 4/4, then only instance of 4/4 is sent
+to Magenta.</p>
+<h2 id="returns">Returns</h2>
+<p>A list of all TimeSignature objects used in this score.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_time_signatures(self):
+  &#34;&#34;&#34;Return a list of all the time signatures used in this score.
+
+  Does not support polymeter (i.e. assumes all parts have the same
+  time signature, such as Part 1 having a time signature of 6/8
+  while Part 2 has a simultaneous time signature of 2/4).
+
+  Ignores duplicate time signatures to prevent Magenta duplicate
+  time signature error. This happens when multiple parts have the
+  same time signature is used in multiple parts at the same time.
+
+  Example: If Part 1 has a time siganture of 4/4 and Part 2 also
+  has a time signature of 4/4, then only instance of 4/4 is sent
+  to Magenta.
+
+  Returns:
+    A list of all TimeSignature objects used in this score.
+  &#34;&#34;&#34;
+  time_signatures = []
+  for part in self.parts:
+    for measure in part.measures:
+      if measure.time_signature is not None:
+        if measure.time_signature not in time_signatures:
+          # Prevent duplicate time signatures
+          time_signatures.append(measure.time_signature)
+
+  return time_signatures</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLParseError"><code class="flex name class">
+<span>class <span class="ident">MusicXMLParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when the MusicXML contents cannot be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicXMLParseError(Exception):
+  &#34;&#34;&#34;Exception thrown when the MusicXML contents cannot be parsed.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.AlternatingTimeSignatureError" href="#note_seq.musicxml_parser.AlternatingTimeSignatureError">AlternatingTimeSignatureError</a></li>
+<li><a title="note_seq.musicxml_parser.ChordSymbolParseError" href="#note_seq.musicxml_parser.ChordSymbolParseError">ChordSymbolParseError</a></li>
+<li><a title="note_seq.musicxml_parser.InvalidNoteDurationTypeError" href="#note_seq.musicxml_parser.InvalidNoteDurationTypeError">InvalidNoteDurationTypeError</a></li>
+<li><a title="note_seq.musicxml_parser.KeyParseError" href="#note_seq.musicxml_parser.KeyParseError">KeyParseError</a></li>
+<li><a title="note_seq.musicxml_parser.MultipleTimeSignatureError" href="#note_seq.musicxml_parser.MultipleTimeSignatureError">MultipleTimeSignatureError</a></li>
+<li><a title="note_seq.musicxml_parser.PitchStepParseError" href="#note_seq.musicxml_parser.PitchStepParseError">PitchStepParseError</a></li>
+<li><a title="note_seq.musicxml_parser.TimeSignatureParseError" href="#note_seq.musicxml_parser.TimeSignatureParseError">TimeSignatureParseError</a></li>
+<li><a title="note_seq.musicxml_parser.UnpitchedNoteError" href="#note_seq.musicxml_parser.UnpitchedNoteError">UnpitchedNoteError</a></li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.MusicXMLParserState"><code class="flex name class">
+<span>class <span class="ident">MusicXMLParserState</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Maintains internal state of the MusicXML parser.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicXMLParserState(object):
+  &#34;&#34;&#34;Maintains internal state of the MusicXML parser.&#34;&#34;&#34;
+
+  def __init__(self):
+    # Default to one division per measure
+    # From the MusicXML documentation: &#34;The divisions element indicates
+    # how many divisions per quarter note are used to indicate a note&#39;s
+    # duration. For example, if duration = 1 and divisions = 2,
+    # this is an eighth note duration.&#34;
+    self.divisions = 1
+
+    # Default to a tempo of 120 quarter notes per minute
+    # MusicXML calls this tempo, but Magenta calls this qpm
+    # Therefore, the variable is called qpm, but reads the
+    # MusicXML tempo attribute
+    # (120 qpm is the default tempo according to the
+    # Standard MIDI Files 1.0 Specification)
+    self.qpm = 120
+
+    # Duration of a single quarter note in seconds
+    self.seconds_per_quarter = 0.5
+
+    # Running total of time for the current event in seconds.
+    # Resets to 0 on every part. Affected by &lt;forward&gt; and &lt;backup&gt; elements
+    self.time_position = 0
+
+    # Default to a MIDI velocity of 64 (mf)
+    self.velocity = 64
+
+    # Default MIDI program (0 = grand piano)
+    self.midi_program = DEFAULT_MIDI_PROGRAM
+
+    # Current MIDI channel (usually equal to the part number)
+    self.midi_channel = DEFAULT_MIDI_CHANNEL
+
+    # Keep track of previous note to get chord timing correct
+    # This variable stores an instance of the Note class (defined below)
+    self.previous_note = None
+
+    # Keep track of current transposition level in +/- semitones.
+    self.transpose = 0
+
+    # Keep track of current time signature. Does not support polymeter.
+    self.time_signature = None</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.Note"><code class="flex name class">
+<span>class <span class="ident">Note</span></span>
+<span>(</span><span>xml_note, state)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML <note> element.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Note(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML &lt;note&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_note, state):
+    self.xml_note = xml_note
+    self.voice = 1
+    self.is_rest = False
+    self.is_in_chord = False
+    self.is_grace_note = False
+    self.pitch = None               # Tuple (Pitch Name, MIDI number)
+    self.note_duration = NoteDuration(state)
+    self.state = state
+    self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;note&gt; element.&#34;&#34;&#34;
+
+    self.midi_channel = self.state.midi_channel
+    self.midi_program = self.state.midi_program
+    self.velocity = self.state.velocity
+
+    for child in self.xml_note:
+      if child.tag == &#39;chord&#39;:
+        self.is_in_chord = True
+      elif child.tag == &#39;duration&#39;:
+        self.note_duration.parse_duration(self.is_in_chord, self.is_grace_note,
+                                          child.text)
+      elif child.tag == &#39;pitch&#39;:
+        self._parse_pitch(child)
+      elif child.tag == &#39;rest&#39;:
+        self.is_rest = True
+      elif child.tag == &#39;voice&#39;:
+        self.voice = int(child.text)
+      elif child.tag == &#39;dot&#39;:
+        self.note_duration.dots += 1
+      elif child.tag == &#39;type&#39;:
+        self.note_duration.type = child.text
+      elif child.tag == &#39;time-modification&#39;:
+        # A time-modification element represents a tuplet_ratio
+        self._parse_tuplet(child)
+      elif child.tag == &#39;unpitched&#39;:
+        raise UnpitchedNoteError(&#39;Unpitched notes are not supported&#39;)
+      else:
+        # Ignore other tag types because they are not relevant to Magenta.
+        pass
+
+  def _parse_pitch(self, xml_pitch):
+    &#34;&#34;&#34;Parse the MusicXML &lt;pitch&gt; element.&#34;&#34;&#34;
+    step = xml_pitch.find(&#39;step&#39;).text
+    alter_text = &#39;&#39;
+    alter = 0.0
+    if xml_pitch.find(&#39;alter&#39;) is not None:
+      alter_text = xml_pitch.find(&#39;alter&#39;).text
+    octave = xml_pitch.find(&#39;octave&#39;).text
+
+    # Parse alter string to a float (floats represent microtonal alterations)
+    if alter_text:
+      alter = float(alter_text)
+
+    # Check if this is a semitone alter (i.e. an integer) or microtonal (float)
+    alter_semitones = int(alter)  # Number of semitones
+    is_microtonal_alter = (alter != alter_semitones)
+
+    # Visual pitch representation
+    alter_string = &#39;&#39;
+    if alter_semitones == -2:
+      alter_string = &#39;bb&#39;
+    elif alter_semitones == -1:
+      alter_string = &#39;b&#39;
+    elif alter_semitones == 1:
+      alter_string = &#39;#&#39;
+    elif alter_semitones == 2:
+      alter_string = &#39;x&#39;
+
+    if is_microtonal_alter:
+      alter_string += &#39; (+microtones) &#39;
+
+    # N.B. - pitch_string does not account for transposition
+    pitch_string = step + alter_string + octave
+
+    # Compute MIDI pitch number (C4 = 60, C1 = 24, C0 = 12)
+    midi_pitch = self.pitch_to_midi_pitch(step, alter, octave)
+    # Transpose MIDI pitch
+    midi_pitch += self.state.transpose
+    self.pitch = (pitch_string, midi_pitch)
+
+  def _parse_tuplet(self, xml_time_modification):
+    &#34;&#34;&#34;Parses a tuplet ratio.
+
+    Represented in MusicXML by the &lt;time-modification&gt; element.
+
+    Args:
+      xml_time_modification: An xml time-modification element.
+    &#34;&#34;&#34;
+    numerator = int(xml_time_modification.find(&#39;actual-notes&#39;).text)
+    denominator = int(xml_time_modification.find(&#39;normal-notes&#39;).text)
+    self.note_duration.tuplet_ratio = Fraction(numerator, denominator)
+
+  @staticmethod
+  def pitch_to_midi_pitch(step, alter, octave):
+    &#34;&#34;&#34;Convert MusicXML pitch representation to MIDI pitch number.&#34;&#34;&#34;
+    pitch_class = 0
+    if step == &#39;C&#39;:
+      pitch_class = 0
+    elif step == &#39;D&#39;:
+      pitch_class = 2
+    elif step == &#39;E&#39;:
+      pitch_class = 4
+    elif step == &#39;F&#39;:
+      pitch_class = 5
+    elif step == &#39;G&#39;:
+      pitch_class = 7
+    elif step == &#39;A&#39;:
+      pitch_class = 9
+    elif step == &#39;B&#39;:
+      pitch_class = 11
+    else:
+      # Raise exception for unknown step (ex: &#39;Q&#39;)
+      raise PitchStepParseError(&#39;Unable to parse pitch step &#39; + step)
+
+    pitch_class = (pitch_class + int(alter)) % 12
+    midi_pitch = (12 + pitch_class) + (int(octave) * 12)
+    return midi_pitch
+
+  def __str__(self):
+    note_string = &#39;{duration: &#39; + str(self.note_duration.duration)
+    note_string += &#39;, midi_ticks: &#39; + str(self.note_duration.midi_ticks)
+    note_string += &#39;, seconds: &#39; + str(self.note_duration.seconds)
+    if self.is_rest:
+      note_string += &#39;, rest: &#39; + str(self.is_rest)
+    else:
+      note_string += &#39;, pitch: &#39; + self.pitch[0]
+      note_string += &#39;, MIDI pitch: &#39; + str(self.pitch[1])
+
+    note_string += &#39;, voice: &#39; + str(self.voice)
+    note_string += &#39;, velocity: &#39; + str(self.velocity) + &#39;} &#39;
+    note_string += &#39;(@time: &#39; + str(self.note_duration.time_position) + &#39;)&#39;
+    return note_string</code></pre>
+</details>
+<h3>Static methods</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.Note.pitch_to_midi_pitch"><code class="name flex">
+<span>def <span class="ident">pitch_to_midi_pitch</span></span>(<span>step, alter, octave)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert MusicXML pitch representation to MIDI pitch number.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def pitch_to_midi_pitch(step, alter, octave):
+  &#34;&#34;&#34;Convert MusicXML pitch representation to MIDI pitch number.&#34;&#34;&#34;
+  pitch_class = 0
+  if step == &#39;C&#39;:
+    pitch_class = 0
+  elif step == &#39;D&#39;:
+    pitch_class = 2
+  elif step == &#39;E&#39;:
+    pitch_class = 4
+  elif step == &#39;F&#39;:
+    pitch_class = 5
+  elif step == &#39;G&#39;:
+    pitch_class = 7
+  elif step == &#39;A&#39;:
+    pitch_class = 9
+  elif step == &#39;B&#39;:
+    pitch_class = 11
+  else:
+    # Raise exception for unknown step (ex: &#39;Q&#39;)
+    raise PitchStepParseError(&#39;Unable to parse pitch step &#39; + step)
+
+  pitch_class = (pitch_class + int(alter)) % 12
+  midi_pitch = (12 + pitch_class) + (int(octave) * 12)
+  return midi_pitch</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.musicxml_parser.NoteDuration"><code class="flex name class">
+<span>class <span class="ident">NoteDuration</span></span>
+<span>(</span><span>state)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML note's duration properties.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NoteDuration(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML note&#39;s duration properties.&#34;&#34;&#34;
+
+  TYPE_RATIO_MAP = {&#39;maxima&#39;: Fraction(8, 1), &#39;long&#39;: Fraction(4, 1),
+                    &#39;breve&#39;: Fraction(2, 1), &#39;whole&#39;: Fraction(1, 1),
+                    &#39;half&#39;: Fraction(1, 2), &#39;quarter&#39;: Fraction(1, 4),
+                    &#39;eighth&#39;: Fraction(1, 8), &#39;16th&#39;: Fraction(1, 16),
+                    &#39;32nd&#39;: Fraction(1, 32), &#39;64th&#39;: Fraction(1, 64),
+                    &#39;128th&#39;: Fraction(1, 128), &#39;256th&#39;: Fraction(1, 256),
+                    &#39;512th&#39;: Fraction(1, 512), &#39;1024th&#39;: Fraction(1, 1024)}
+
+  def __init__(self, state):
+    self.duration = 0                   # MusicXML duration
+    self.midi_ticks = 0                 # Duration in MIDI ticks
+    self.seconds = 0                    # Duration in seconds
+    self.time_position = 0              # Onset time in seconds
+    self.dots = 0                       # Number of augmentation dots
+    self._type = &#39;quarter&#39;              # MusicXML duration type
+    self.tuplet_ratio = Fraction(1, 1)  # Ratio for tuplets (default to 1)
+    self.is_grace_note = True           # Assume true until not found
+    self.state = state
+
+  def parse_duration(self, is_in_chord, is_grace_note, duration):
+    &#34;&#34;&#34;Parse the duration of a note and compute timings.&#34;&#34;&#34;
+    self.duration = int(duration)
+
+    # Due to an error in Sibelius&#39; export, force this note to have the
+    # duration of the previous note if it is in a chord
+    if is_in_chord:
+      self.duration = self.state.previous_note.note_duration.duration
+
+    self.midi_ticks = self.duration
+    self.midi_ticks *= (constants.STANDARD_PPQ / self.state.divisions)
+
+    self.seconds = (self.midi_ticks / constants.STANDARD_PPQ)
+    self.seconds *= self.state.seconds_per_quarter
+
+    self.time_position = self.state.time_position
+
+    # Not sure how to handle durations of grace notes yet as they
+    # steal time from subsequent notes and they do not have a
+    # &lt;duration&gt; tag in the MusicXML
+    self.is_grace_note = is_grace_note
+
+    if is_in_chord:
+      # If this is a chord, set the time position to the time position
+      # of the previous note (i.e. all the notes in the chord will have
+      # the same time position)
+      self.time_position = self.state.previous_note.note_duration.time_position
+    else:
+      # Only increment time positions once in chord
+      self.state.time_position += self.seconds
+
+  def _convert_type_to_ratio(self):
+    &#34;&#34;&#34;Convert the MusicXML note-type-value to a Python Fraction.
+
+    Examples:
+    - whole = 1/1
+    - half = 1/2
+    - quarter = 1/4
+    - 32nd = 1/32
+
+    Returns:
+      A Fraction object representing the note type.
+    &#34;&#34;&#34;
+    return self.TYPE_RATIO_MAP[self.type]
+
+  def duration_ratio(self):
+    &#34;&#34;&#34;Compute the duration ratio of the note as a Python Fraction.
+
+    Examples:
+    - Whole Note = 1
+    - Quarter Note = 1/4
+    - Dotted Quarter Note = 3/8
+    - Triplet eighth note = 1/12
+
+    Returns:
+      The duration ratio as a Python Fraction.
+    &#34;&#34;&#34;
+    # Get ratio from MusicXML note type
+    duration_ratio = Fraction(1, 1)
+    type_ratio = self._convert_type_to_ratio()
+
+    # Compute tuplet ratio
+    duration_ratio /= self.tuplet_ratio
+    type_ratio /= self.tuplet_ratio
+
+    # Add augmentation dots
+    one_half = Fraction(1, 2)
+    dot_sum = Fraction(0, 1)
+    for dot in range(self.dots):
+      dot_sum += (one_half ** (dot + 1)) * type_ratio
+
+    duration_ratio = type_ratio + dot_sum
+
+    # If the note is a grace note, force its ratio to be 0
+    # because it does not have a &lt;duration&gt; tag
+    if self.is_grace_note:
+      duration_ratio = Fraction(0, 1)
+
+    return duration_ratio
+
+  def duration_float(self):
+    &#34;&#34;&#34;Return the duration ratio as a float.&#34;&#34;&#34;
+    ratio = self.duration_ratio()
+    return ratio.numerator / ratio.denominator
+
+  @property
+  def type(self):
+    return self._type
+
+  @type.setter
+  def type(self, new_type):
+    if new_type not in self.TYPE_RATIO_MAP:
+      raise InvalidNoteDurationTypeError(
+          &#39;Note duration type &#34;{}&#34; is not valid&#39;.format(new_type))
+    self._type = new_type</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.NoteDuration.TYPE_RATIO_MAP"><code class="name">var <span class="ident">TYPE_RATIO_MAP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.NoteDuration.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def type(self):
+  return self._type</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.musicxml_parser.NoteDuration.duration_float"><code class="name flex">
+<span>def <span class="ident">duration_float</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return the duration ratio as a float.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def duration_float(self):
+  &#34;&#34;&#34;Return the duration ratio as a float.&#34;&#34;&#34;
+  ratio = self.duration_ratio()
+  return ratio.numerator / ratio.denominator</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.NoteDuration.duration_ratio"><code class="name flex">
+<span>def <span class="ident">duration_ratio</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compute the duration ratio of the note as a Python Fraction.</p>
+<p>Examples:
+- Whole Note = 1
+- Quarter Note = 1/4
+- Dotted Quarter Note = 3/8
+- Triplet eighth note = 1/12</p>
+<h2 id="returns">Returns</h2>
+<p>The duration ratio as a Python Fraction.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def duration_ratio(self):
+  &#34;&#34;&#34;Compute the duration ratio of the note as a Python Fraction.
+
+  Examples:
+  - Whole Note = 1
+  - Quarter Note = 1/4
+  - Dotted Quarter Note = 3/8
+  - Triplet eighth note = 1/12
+
+  Returns:
+    The duration ratio as a Python Fraction.
+  &#34;&#34;&#34;
+  # Get ratio from MusicXML note type
+  duration_ratio = Fraction(1, 1)
+  type_ratio = self._convert_type_to_ratio()
+
+  # Compute tuplet ratio
+  duration_ratio /= self.tuplet_ratio
+  type_ratio /= self.tuplet_ratio
+
+  # Add augmentation dots
+  one_half = Fraction(1, 2)
+  dot_sum = Fraction(0, 1)
+  for dot in range(self.dots):
+    dot_sum += (one_half ** (dot + 1)) * type_ratio
+
+  duration_ratio = type_ratio + dot_sum
+
+  # If the note is a grace note, force its ratio to be 0
+  # because it does not have a &lt;duration&gt; tag
+  if self.is_grace_note:
+    duration_ratio = Fraction(0, 1)
+
+  return duration_ratio</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.NoteDuration.parse_duration"><code class="name flex">
+<span>def <span class="ident">parse_duration</span></span>(<span>self, is_in_chord, is_grace_note, duration)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Parse the duration of a note and compute timings.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def parse_duration(self, is_in_chord, is_grace_note, duration):
+  &#34;&#34;&#34;Parse the duration of a note and compute timings.&#34;&#34;&#34;
+  self.duration = int(duration)
+
+  # Due to an error in Sibelius&#39; export, force this note to have the
+  # duration of the previous note if it is in a chord
+  if is_in_chord:
+    self.duration = self.state.previous_note.note_duration.duration
+
+  self.midi_ticks = self.duration
+  self.midi_ticks *= (constants.STANDARD_PPQ / self.state.divisions)
+
+  self.seconds = (self.midi_ticks / constants.STANDARD_PPQ)
+  self.seconds *= self.state.seconds_per_quarter
+
+  self.time_position = self.state.time_position
+
+  # Not sure how to handle durations of grace notes yet as they
+  # steal time from subsequent notes and they do not have a
+  # &lt;duration&gt; tag in the MusicXML
+  self.is_grace_note = is_grace_note
+
+  if is_in_chord:
+    # If this is a chord, set the time position to the time position
+    # of the previous note (i.e. all the notes in the chord will have
+    # the same time position)
+    self.time_position = self.state.previous_note.note_duration.time_position
+  else:
+    # Only increment time positions once in chord
+    self.state.time_position += self.seconds</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.musicxml_parser.Part"><code class="flex name class">
+<span>class <span class="ident">Part</span></span>
+<span>(</span><span>xml_part, score_parts, state)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal represention of a MusicXML <part> element.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Part(object):
+  &#34;&#34;&#34;Internal represention of a MusicXML &lt;part&gt; element.&#34;&#34;&#34;
+
+  def __init__(self, xml_part, score_parts, state):
+    self.id = &#39;&#39;
+    self.score_part = None
+    self.measures = []
+    self._state = state
+    self._parse(xml_part, score_parts)
+
+  def _parse(self, xml_part, score_parts):
+    &#34;&#34;&#34;Parse the &lt;part&gt; element.&#34;&#34;&#34;
+    if &#39;id&#39; in xml_part.attrib:
+      self.id = xml_part.attrib[&#39;id&#39;]
+    if self.id in score_parts:
+      self.score_part = score_parts[self.id]
+    else:
+      # If this part references a score-part id that was not found in the file,
+      # construct a default score-part.
+      self.score_part = ScorePart()
+
+    # Reset the time position when parsing each part
+    self._state.time_position = 0
+    self._state.midi_channel = self.score_part.midi_channel
+    self._state.midi_program = self.score_part.midi_program
+    self._state.transpose = 0
+
+    xml_measures = xml_part.findall(&#39;measure&#39;)
+    for measure in xml_measures:
+      # Issue #674: Repair measures that do not contain notes
+      # by inserting a whole measure rest
+      self._repair_empty_measure(measure)
+      parsed_measure = Measure(measure, self._state)
+      self.measures.append(parsed_measure)
+
+  def _repair_empty_measure(self, measure):
+    &#34;&#34;&#34;Repair a measure if it is empty by inserting a whole measure rest.
+
+    If a &lt;measure&gt; only consists of a &lt;forward&gt; element that advances
+    the time cursor, remove the &lt;forward&gt; element and replace
+    with a whole measure rest of the same duration.
+
+    Args:
+      measure: The measure to repair.
+    &#34;&#34;&#34;
+    # Issue #674 - If the &lt;forward&gt; element is in a measure without
+    # any &lt;note&gt; elements, treat it as if it were a whole measure
+    # rest by inserting a rest of that duration
+    forward_count = len(measure.findall(&#39;forward&#39;))
+    note_count = len(measure.findall(&#39;note&#39;))
+    if note_count == 0 and forward_count == 1:
+      # Get the duration of the &lt;forward&gt; element
+      xml_forward = measure.find(&#39;forward&#39;)
+      xml_duration = xml_forward.find(&#39;duration&#39;)
+      forward_duration = int(xml_duration.text)
+
+      # Delete the &lt;forward&gt; element
+      measure.remove(xml_forward)
+
+      # Insert the new note
+      new_note = &#39;&lt;note&gt;&#39;
+      new_note += &#39;&lt;rest /&gt;&lt;duration&gt;&#39; + str(forward_duration) + &#39;&lt;/duration&gt;&#39;
+      new_note += &#39;&lt;voice&gt;1&lt;/voice&gt;&lt;type&gt;whole&lt;/type&gt;&lt;staff&gt;1&lt;/staff&gt;&#39;
+      new_note += &#39;&lt;/note&gt;&#39;
+      new_note_xml = ET.fromstring(new_note)
+      measure.append(new_note_xml)
+
+  def __str__(self):
+    part_str = &#39;Part: &#39; + self.score_part.part_name
+    return part_str</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.PitchStepParseError"><code class="flex name class">
+<span>class <span class="ident">PitchStepParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when a pitch step cannot be parsed.</p>
+<p>Will happen if pitch step is not one of A, B, C, D, E, F, or G</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PitchStepParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when a pitch step cannot be parsed.
+
+  Will happen if pitch step is not one of A, B, C, D, E, F, or G
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.ScorePart"><code class="flex name class">
+<span>class <span class="ident">ScorePart</span></span>
+<span>(</span><span>xml_score_part=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>"Internal representation of a MusicXML <score-part>.</p>
+<p>A <score-part> element contains MIDI program and channel info
+for the <part> elements in the MusicXML document.</p>
+<p>If no MIDI info is found for the part, use the default MIDI channel (0)
+and default to the Grand Piano program (MIDI Program #1).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ScorePart(object):
+  &#34;&#34;&#34;&#34;Internal representation of a MusicXML &lt;score-part&gt;.
+
+  A &lt;score-part&gt; element contains MIDI program and channel info
+  for the &lt;part&gt; elements in the MusicXML document.
+
+  If no MIDI info is found for the part, use the default MIDI channel (0)
+  and default to the Grand Piano program (MIDI Program #1).
+  &#34;&#34;&#34;
+
+  def __init__(self, xml_score_part=None):
+    self.id = &#39;&#39;
+    self.part_name = &#39;&#39;
+    self.midi_channel = DEFAULT_MIDI_CHANNEL
+    self.midi_program = DEFAULT_MIDI_PROGRAM
+    if xml_score_part is not None:
+      self._parse(xml_score_part)
+
+  def _parse(self, xml_score_part):
+    &#34;&#34;&#34;Parse the &lt;score-part&gt; element to an in-memory representation.&#34;&#34;&#34;
+    self.id = xml_score_part.attrib[&#39;id&#39;]
+
+    if xml_score_part.find(&#39;part-name&#39;) is not None:
+      self.part_name = xml_score_part.find(&#39;part-name&#39;).text or &#39;&#39;
+
+    xml_midi_instrument = xml_score_part.find(&#39;midi-instrument&#39;)
+    if (xml_midi_instrument is not None and
+        xml_midi_instrument.find(&#39;midi-channel&#39;) is not None and
+        xml_midi_instrument.find(&#39;midi-program&#39;) is not None):
+      self.midi_channel = int(xml_midi_instrument.find(&#39;midi-channel&#39;).text)
+      self.midi_program = int(xml_midi_instrument.find(&#39;midi-program&#39;).text)
+    else:
+      # If no MIDI info, use the default MIDI channel.
+      self.midi_channel = DEFAULT_MIDI_CHANNEL
+      # Use the default MIDI program
+      self.midi_program = DEFAULT_MIDI_PROGRAM
+
+  def __str__(self):
+    score_str = &#39;ScorePart: &#39; + self.part_name
+    score_str += &#39;, Channel: &#39; + str(self.midi_channel)
+    score_str += &#39;, Program: &#39; + str(self.midi_program)
+    return score_str</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.Tempo"><code class="flex name class">
+<span>class <span class="ident">Tempo</span></span>
+<span>(</span><span>state, xml_sound=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML tempo.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Tempo(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML tempo.&#34;&#34;&#34;
+
+  def __init__(self, state, xml_sound=None):
+    self.xml_sound = xml_sound
+    self.qpm = -1
+    self.time_position = -1
+    self.state = state
+    if xml_sound is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;sound&gt; element and retrieve the tempo.
+
+    If no tempo is specified, default to DEFAULT_QUARTERS_PER_MINUTE
+    &#34;&#34;&#34;
+    self.qpm = float(self.xml_sound.get(&#39;tempo&#39;))
+    if self.qpm == 0:
+      # If tempo is 0, set it to default
+      self.qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    tempo_str = &#39;Tempo: &#39; + str(self.qpm)
+    tempo_str += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return tempo_str</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.TimeSignature"><code class="flex name class">
+<span>class <span class="ident">TimeSignature</span></span>
+<span>(</span><span>state, xml_time=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Internal representation of a MusicXML time signature.</p>
+<p>Does not support:
+- Composite time signatures: 3+2/8
+- Alternating time signatures 2/4 + 3/8
+- Senza misura</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TimeSignature(object):
+  &#34;&#34;&#34;Internal representation of a MusicXML time signature.
+
+  Does not support:
+  - Composite time signatures: 3+2/8
+  - Alternating time signatures 2/4 + 3/8
+  - Senza misura
+  &#34;&#34;&#34;
+
+  def __init__(self, state, xml_time=None):
+    self.xml_time = xml_time
+    self.numerator = -1
+    self.denominator = -1
+    self.time_position = 0
+    self.state = state
+    if xml_time is not None:
+      self._parse()
+
+  def _parse(self):
+    &#34;&#34;&#34;Parse the MusicXML &lt;time&gt; element.&#34;&#34;&#34;
+    if (len(self.xml_time.findall(&#39;beats&#39;)) &gt; 1 or
+        len(self.xml_time.findall(&#39;beat-type&#39;)) &gt; 1):
+      # If more than 1 beats or beat-type found, this time signature is
+      # not supported (ex: alternating meter)
+      raise AlternatingTimeSignatureError(&#39;Alternating Time Signature&#39;)
+
+    beats = self.xml_time.find(&#39;beats&#39;).text
+    beat_type = self.xml_time.find(&#39;beat-type&#39;).text
+    try:
+      self.numerator = int(beats)
+      self.denominator = int(beat_type)
+    except ValueError:
+      raise TimeSignatureParseError(
+          &#39;Could not parse time signature: {}/{}&#39;.format(beats, beat_type))
+    self.time_position = self.state.time_position
+
+  def __str__(self):
+    time_sig_str = str(self.numerator) + &#39;/&#39; + str(self.denominator)
+    time_sig_str += &#39; (@time: &#39; + str(self.time_position) + &#39;)&#39;
+    return time_sig_str
+
+  def __eq__(self, other):
+    isequal = self.numerator == other.numerator
+    isequal = isequal and (self.denominator == other.denominator)
+    isequal = isequal and (self.time_position == other.time_position)
+    return isequal
+
+  def __ne__(self, other):
+    return not self.__eq__(other)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser.TimeSignatureParseError"><code class="flex name class">
+<span>class <span class="ident">TimeSignatureParseError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when the time signature could not be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TimeSignatureParseError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when the time signature could not be parsed.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.musicxml_parser.UnpitchedNoteError"><code class="flex name class">
+<span>class <span class="ident">UnpitchedNoteError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception thrown when an unpitched note is encountered.</p>
+<p>We do not currently support parsing files with unpitched notes (e.g.,
+percussion scores).</p>
+<p><a href="http://www.musicxml.com/tutorial/percussion/unpitched-notes/">http://www.musicxml.com/tutorial/percussion/unpitched-notes/</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class UnpitchedNoteError(MusicXMLParseError):
+  &#34;&#34;&#34;Exception thrown when an unpitched note is encountered.
+
+  We do not currently support parsing files with unpitched notes (e.g.,
+  percussion scores).
+
+  http://www.musicxml.com/tutorial/percussion/unpitched-notes/
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.AlternatingTimeSignatureError" href="#note_seq.musicxml_parser.AlternatingTimeSignatureError">AlternatingTimeSignatureError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.ChordSymbol" href="#note_seq.musicxml_parser.ChordSymbol">ChordSymbol</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicxml_parser.ChordSymbol.CHORD_KIND_ABBREVIATIONS" href="#note_seq.musicxml_parser.ChordSymbol.CHORD_KIND_ABBREVIATIONS">CHORD_KIND_ABBREVIATIONS</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.ChordSymbol.get_figure_string" href="#note_seq.musicxml_parser.ChordSymbol.get_figure_string">get_figure_string</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.ChordSymbolParseError" href="#note_seq.musicxml_parser.ChordSymbolParseError">ChordSymbolParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.InvalidNoteDurationTypeError" href="#note_seq.musicxml_parser.InvalidNoteDurationTypeError">InvalidNoteDurationTypeError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.KeyParseError" href="#note_seq.musicxml_parser.KeyParseError">KeyParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.KeySignature" href="#note_seq.musicxml_parser.KeySignature">KeySignature</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.Measure" href="#note_seq.musicxml_parser.Measure">Measure</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.MultipleTimeSignatureError" href="#note_seq.musicxml_parser.MultipleTimeSignatureError">MultipleTimeSignatureError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.MusicXMLDocument" href="#note_seq.musicxml_parser.MusicXMLDocument">MusicXMLDocument</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicxml_parser.MusicXMLDocument.get_chord_symbols" href="#note_seq.musicxml_parser.MusicXMLDocument.get_chord_symbols">get_chord_symbols</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.MusicXMLDocument.get_key_signatures" href="#note_seq.musicxml_parser.MusicXMLDocument.get_key_signatures">get_key_signatures</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.MusicXMLDocument.get_tempos" href="#note_seq.musicxml_parser.MusicXMLDocument.get_tempos">get_tempos</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.MusicXMLDocument.get_time_signatures" href="#note_seq.musicxml_parser.MusicXMLDocument.get_time_signatures">get_time_signatures</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.MusicXMLParseError" href="#note_seq.musicxml_parser.MusicXMLParseError">MusicXMLParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.MusicXMLParserState" href="#note_seq.musicxml_parser.MusicXMLParserState">MusicXMLParserState</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.Note" href="#note_seq.musicxml_parser.Note">Note</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicxml_parser.Note.pitch_to_midi_pitch" href="#note_seq.musicxml_parser.Note.pitch_to_midi_pitch">pitch_to_midi_pitch</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.NoteDuration" href="#note_seq.musicxml_parser.NoteDuration">NoteDuration</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicxml_parser.NoteDuration.TYPE_RATIO_MAP" href="#note_seq.musicxml_parser.NoteDuration.TYPE_RATIO_MAP">TYPE_RATIO_MAP</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.NoteDuration.duration_float" href="#note_seq.musicxml_parser.NoteDuration.duration_float">duration_float</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.NoteDuration.duration_ratio" href="#note_seq.musicxml_parser.NoteDuration.duration_ratio">duration_ratio</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.NoteDuration.parse_duration" href="#note_seq.musicxml_parser.NoteDuration.parse_duration">parse_duration</a></code></li>
+<li><code><a title="note_seq.musicxml_parser.NoteDuration.type" href="#note_seq.musicxml_parser.NoteDuration.type">type</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.Part" href="#note_seq.musicxml_parser.Part">Part</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.PitchStepParseError" href="#note_seq.musicxml_parser.PitchStepParseError">PitchStepParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.ScorePart" href="#note_seq.musicxml_parser.ScorePart">ScorePart</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.Tempo" href="#note_seq.musicxml_parser.Tempo">Tempo</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.TimeSignature" href="#note_seq.musicxml_parser.TimeSignature">TimeSignature</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.TimeSignatureParseError" href="#note_seq.musicxml_parser.TimeSignatureParseError">TimeSignatureParseError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.musicxml_parser.UnpitchedNoteError" href="#note_seq.musicxml_parser.UnpitchedNoteError">UnpitchedNoteError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/musicxml_parser_test.html
+++ b/docs/musicxml_parser_test.html
@@ -1,0 +1,5810 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.musicxml_parser_test API documentation</title>
+<meta name="description" content="Test to ensure correct import of MusicXML." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.musicxml_parser_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Test to ensure correct import of MusicXML.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Test to ensure correct import of MusicXML.&#34;&#34;&#34;
+
+import collections
+import operator
+import os.path
+import tempfile
+import zipfile
+
+from absl.testing import absltest
+from note_seq import musicxml_parser
+from note_seq import musicxml_reader
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+# Shortcut to CHORD_SYMBOL annotation type.
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+class MusicXMLParserTest(testing_lib.ProtoTestCase):
+  &#34;&#34;&#34;Class to test the MusicXML parser use cases.
+
+  self.flute_scale_filename contains an F-major scale of 8 quarter notes each
+
+  self.clarinet_scale_filename contains a F-major scale of 8 quarter notes
+  each appearing as written pitch. This means the key is written as
+  G-major but sounds as F-major. The MIDI pitch numbers must be transposed
+  to be input into Magenta
+
+  self.band_score_filename contains a number of instruments in written
+  pitch. The score has two time signatures (6/8 and 2/4) and two sounding
+  keys (Bb-major and Eb major). The file also contains chords and
+  multiple voices (see Oboe part in measure 57), as well as dynamics,
+  articulations, slurs, ties, hairpins, grace notes, tempo changes,
+  and multiple barline types (double, repeat)
+
+  self.compressed_filename contains the same content as
+  self.flute_scale_filename, but compressed in MXL format
+
+  self.rhythm_durations_filename contains a variety of rhythms (long, short,
+  dotted, tuplet, and dotted tuplet) to test the computation of rhythmic
+  ratios.
+
+  self.atonal_transposition_filename contains a change of instrument
+  from a non-transposing (Flute) to transposing (Bb Clarinet) in a score
+  with no key / atonal. This ensures that transposition works properly when
+  no key signature is found (Issue #355)
+
+  self.st_anne_filename contains a 4-voice piece written in two parts.
+
+  self.whole_measure_rest_forward_filename contains 4 measures:
+  Measures 1 and 2 contain whole note rests in 4/4. The first is a &lt;note&gt;,
+  the second uses a &lt;forward&gt;. The durations must match.
+  Measures 3 and 4 contain whole note rests in 2/4. The first is a &lt;note&gt;,
+  the second uses a &lt;forward&gt;. The durations must match.
+  (Issue #674).
+
+  self.meter_test_filename contains a different meter in each measure:
+  - 1/4 through 7/4 inclusive
+  - 1/8 through 12/8 inclusive
+  - 2/2 through 4/2 inclusive
+  - Common time and Cut time meters
+  &#34;&#34;&#34;
+
+  def setUp(self):
+    self.maxDiff = None   # pylint:disable=invalid-name
+
+    self.steps_per_quarter = 4
+
+    self.flute_scale_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale.xml&#39;)
+
+    self.clarinet_scale_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;clarinet_scale.xml&#39;)
+
+    self.band_score_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;el_capitan.xml&#39;)
+
+    self.compressed_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale.mxl&#39;)
+
+    self.multiple_rootfile_compressed_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale_with_png.mxl&#39;)
+
+    self.rhythm_durations_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;rhythm_durations.xml&#39;)
+
+    self.st_anne_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;st_anne.xml&#39;)
+
+    self.atonal_transposition_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;atonal_transposition_change.xml&#39;)
+
+    self.chord_symbols_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;chord_symbols.xml&#39;)
+
+    self.time_signature_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;st_anne.xml&#39;)
+
+    self.unmetered_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unmetered_example.xml&#39;)
+
+    self.alternating_meter_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;alternating_meter.xml&#39;)
+
+    self.mid_measure_meter_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;mid_measure_time_signature.xml&#39;)
+
+    self.whole_measure_rest_forward_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;whole_measure_rest_forward.xml&#39;)
+
+    self.meter_test_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;meter_test.xml&#39;)
+
+    super().setUp()
+
+  def check_musicxml_and_sequence(self, musicxml, sequence_proto):
+    &#34;&#34;&#34;Compares MusicXMLDocument object against a sequence proto.
+
+    Args:
+      musicxml: A MusicXMLDocument object.
+      sequence_proto: A NoteSequence proto.
+    &#34;&#34;&#34;
+    # Test time signature changes.
+    self.assertEqual(len(musicxml.get_time_signatures()),
+                     len(sequence_proto.time_signatures))
+    for musicxml_time, sequence_time in zip(musicxml.get_time_signatures(),
+                                            sequence_proto.time_signatures):
+      self.assertEqual(musicxml_time.numerator, sequence_time.numerator)
+      self.assertEqual(musicxml_time.denominator, sequence_time.denominator)
+      self.assertAlmostEqual(musicxml_time.time_position, sequence_time.time)
+
+    # Test key signature changes.
+    self.assertEqual(len(musicxml.get_key_signatures()),
+                     len(sequence_proto.key_signatures))
+    for musicxml_key, sequence_key in zip(musicxml.get_key_signatures(),
+                                          sequence_proto.key_signatures):
+
+      if musicxml_key.mode == &#39;major&#39;:
+        mode = 0
+      elif musicxml_key.mode == &#39;minor&#39;:
+        mode = 1
+
+      # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
+      # Convert from MIDI / MusicXML key to music.proto key
+      music_proto_keys = [11, 6, 1, 8, 3, 10, 5, 0, 7, 2, 9, 4, 11, 6, 1]
+      key = music_proto_keys[musicxml_key.key + 7]
+      self.assertEqual(key, sequence_key.key)
+      self.assertEqual(mode, sequence_key.mode)
+      self.assertAlmostEqual(musicxml_key.time_position, sequence_key.time)
+
+    # Test tempos.
+    musicxml_tempos = musicxml.get_tempos()
+    self.assertEqual(len(musicxml_tempos),
+                     len(sequence_proto.tempos))
+    for musicxml_tempo, sequence_tempo in zip(
+        musicxml_tempos, sequence_proto.tempos):
+      self.assertAlmostEqual(musicxml_tempo.qpm, sequence_tempo.qpm)
+      self.assertAlmostEqual(musicxml_tempo.time_position,
+                             sequence_tempo.time)
+
+    # Test parts/instruments.
+    seq_parts = collections.defaultdict(list)
+    for seq_note in sequence_proto.notes:
+      seq_parts[seq_note.part].append(seq_note)
+
+    self.assertEqual(len(musicxml.parts), len(seq_parts))
+    for musicxml_part, seq_part_id in zip(
+        musicxml.parts, sorted(seq_parts.keys())):
+
+      seq_instrument_notes = seq_parts[seq_part_id]
+      musicxml_notes = []
+      for musicxml_measure in musicxml_part.measures:
+        for musicxml_note in musicxml_measure.notes:
+          if not musicxml_note.is_rest:
+            musicxml_notes.append(musicxml_note)
+
+      self.assertEqual(len(musicxml_notes), len(seq_instrument_notes))
+      for musicxml_note, sequence_note in zip(musicxml_notes,
+                                              seq_instrument_notes):
+        self.assertEqual(musicxml_note.pitch[1], sequence_note.pitch)
+        self.assertEqual(musicxml_note.velocity, sequence_note.velocity)
+        self.assertAlmostEqual(musicxml_note.note_duration.time_position,
+                               sequence_note.start_time)
+        self.assertAlmostEqual(musicxml_note.note_duration.time_position
+                               + musicxml_note.note_duration.seconds,
+                               sequence_note.end_time)
+        # Check that the duration specified in the MusicXML and the
+        # duration float match to within +/- 1 (delta = 1)
+        # Delta is used because duration in MusicXML is always an integer
+        # For example, a 3:2 half note might have a durationfloat of 341.333
+        # but would have the 1/3 distributed in the MusicXML as
+        # 341.0, 341.0, 342.0.
+        # Check that (3 * 341.333) = (341 + 341 + 342) is true by checking
+        # that 341.0 and 342.0 are +/- 1 of 341.333
+        self.assertAlmostEqual(
+            musicxml_note.note_duration.duration,
+            musicxml_note.state.divisions * 4
+            * musicxml_note.note_duration.duration_float(),
+            delta=1)
+
+  def check_musicxml_to_sequence(self, filename):
+    &#34;&#34;&#34;Test the translation from MusicXML to Sequence proto.&#34;&#34;&#34;
+    source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+    sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+    self.check_musicxml_and_sequence(source_musicxml, sequence_proto)
+
+  def check_fmajor_scale(self, filename, part_name):
+    &#34;&#34;&#34;Verify MusicXML scale file.
+
+    Verify that it contains the correct pitches (sounding pitch) and durations.
+
+    Args:
+      filename: file to test.
+      part_name: name of the part the sequence is expected to contain.
+    &#34;&#34;&#34;
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: F
+          time: 0
+        }
+        time_signatures {
+          numerator: 4
+          denominator: 4
+        }
+        tempos {
+          qpm: 120.0
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+
+    part_info = expected_ns.part_infos.add()
+    part_info.name = part_name
+
+    expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.part = 0
+      note.voice = 1
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+
+    # Convert MusicXML to NoteSequence
+    source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+    sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+
+    # Check equality
+    self.assertProtoEquals(expected_ns, sequence_proto)
+
+  def testsimplemusicxmltosequence(self):
+    &#34;&#34;&#34;Test the simple flute scale MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.flute_scale_filename)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testcomplexmusicxmltosequence(self):
+    &#34;&#34;&#34;Test the complex band score MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.band_score_filename)
+
+  def testtransposedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from transposed MusicXML to Sequence proto.
+
+    Compare a transposed MusicXML file (clarinet) to an identical untransposed
+    sequence (flute).
+    &#34;&#34;&#34;
+    untransposed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    transposed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.clarinet_scale_filename)
+    untransposed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        untransposed_musicxml)
+    self.check_musicxml_and_sequence(transposed_musicxml, untransposed_proto)
+    self.check_fmajor_scale(self.clarinet_scale_filename, &#39;Clarinet in Bb&#39;)
+
+  def testcompressedmxlunicodefilename(self):
+    &#34;&#34;&#34;Test an MXL file containing a unicode filename within its zip archive.&#34;&#34;&#34;
+
+    unicode_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unicode_filename.mxl&#39;)
+    sequence = musicxml_reader.musicxml_file_to_sequence_proto(unicode_filename)
+    self.assertLen(sequence.notes, 8)
+
+  def testcompressedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from compressed MusicXML to Sequence proto.
+
+    Compare a compressed MusicXML file to an identical uncompressed sequence.
+    &#34;&#34;&#34;
+    uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    compressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.compressed_filename)
+    uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        uncompressed_musicxml)
+    self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testmultiplecompressedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from compressed MusicXML with multiple rootfiles.
+
+    The example MXL file contains a MusicXML file of the Flute F Major scale,
+    as well as the PNG rendering of the score contained within the single MXL
+    file.
+    &#34;&#34;&#34;
+    uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    compressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.multiple_rootfile_compressed_filename)
+    uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        uncompressed_musicxml)
+    self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testrhythmdurationsxmltosequence(self):
+    &#34;&#34;&#34;Test the rhythm durations MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.rhythm_durations_filename)
+
+  def testFluteScale(self):
+    &#34;&#34;&#34;Verify properties of the flute scale.&#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.flute_scale_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+          key: F
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        part_infos {
+          part: 0
+          name: &#34;Flute&#34;
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+    expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.part = 0
+      note.voice = 1
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_atonal_transposition(self):
+    &#34;&#34;&#34;Test that transposition works when changing instrument transposition.
+
+    This can occur within a single part in a score where the score
+    has no key signature / is atonal. Examples include changing from a
+    non-transposing instrument to a transposing one (ex. Flute to Bb Clarinet)
+    or vice versa, or changing among transposing instruments (ex. Bb Clarinet
+    to Eb Alto Saxophone).
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.atonal_transposition_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+        }
+        part_infos {
+          part: 0
+          name: &#34;Flute&#34;
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+    expected_pitches = [72, 74, 76, 77, 79, 77, 76, 74]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+      note.voice = 1
+    self.maxDiff = None
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_incomplete_measures(self):
+    &#34;&#34;&#34;Test that incomplete measures have the correct time signature.
+
+    This can occur in pickup bars or incomplete measures. For example,
+    if the time signature in the MusicXML is 4/4, but the measure only
+    contains one quarter note, Magenta expects this pickup measure to have
+    a time signature of 1/4.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.time_signature_filename)
+
+    # One time signature per measure
+    self.assertLen(ns.time_signatures, 6)
+    self.assertLen(ns.key_signatures, 1)
+    self.assertLen(ns.notes, 112)
+
+  def test_unmetered_music(self):
+    &#34;&#34;&#34;Test that time signatures are inserted for music without time signatures.
+
+    MusicXML does not require the use of time signatures. Music without
+    time signatures occur in medieval chant, cadenzas, and contemporary music.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.unmetered_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 11
+          denominator: 8
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 0.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 74
+          velocity: 64
+          start_time: 0.5
+          end_time: 0.75
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 76
+          velocity: 64
+          start_time: 0.75
+          end_time: 1.25
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 77
+          velocity: 64
+          start_time: 1.25
+          end_time: 1.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 79
+          velocity: 64
+          start_time: 1.75
+          end_time: 2.75
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        total_time: 2.75
+        &#34;&#34;&#34;)
+    self.maxDiff = None
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_st_anne(self):
+    &#34;&#34;&#34;Verify properties of the St. Anne file.
+
+    The file contains 2 parts and 4 voices.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.st_anne_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 0.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 6.5
+          numerator: 3
+          denominator: 4
+        }
+        time_signatures {
+          time: 8.0
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 8.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 14.5
+          numerator: 3
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+          key: C
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        part_infos {
+          part: 0
+          name: &#34;Harpsichord&#34;
+        }
+        part_infos {
+          part: 1
+          name: &#34;Piano&#34;
+        }
+        total_time: 16.0
+        &#34;&#34;&#34;)
+    pitches_0_1 = [
+        (67, .5),
+
+        (64, .5),
+        (69, .5),
+        (67, .5),
+        (72, .5),
+
+        (72, .5),
+        (71, .5),
+        (72, .5),
+        (67, .5),
+
+        (72, .5),
+        (67, .5),
+        (69, .5),
+        (66, .5),
+
+        (67, 1.5),
+
+        (71, .5),
+
+        (72, .5),
+        (69, .5),
+        (74, .5),
+        (71, .5),
+
+        (72, .5),
+        (69, .5),
+        (71, .5),
+        (67, .5),
+
+        (69, .5),
+        (72, .5),
+        (74, .5),
+        (71, .5),
+
+        (72, 1.5),
+    ]
+    pitches_0_2 = [
+        (60, .5),
+
+        (60, .5),
+        (60, .5),
+        (60, .5),
+        (64, .5),
+
+        (62, .5),
+        (62, .5),
+        (64, .5),
+        (64, .5),
+
+        (64, .5),
+        (64, .5),
+        (64, .5),
+        (62, .5),
+
+        (62, 1.5),
+
+        (62, .5),
+
+        (64, .5),
+        (60, .5),
+        (65, .5),
+        (62, .5),
+
+        (64, .75),
+        (62, .25),
+        (59, .5),
+        (60, .5),
+
+        (65, .5),
+        (64, .5),
+        (62, .5),
+        (62, .5),
+
+        (64, 1.5),
+    ]
+    pitches_1_1 = [
+        (52, .5),
+
+        (55, .5),
+        (57, .5),
+        (60, .5),
+        (60, .5),
+
+        (57, .5),
+        (55, .5),
+        (55, .5),
+        (60, .5),
+
+        (60, .5),
+        (59, .5),
+        (57, .5),
+        (57, .5),
+
+        (59, 1.5),
+
+        (55, .5),
+
+        (55, .5),
+        (57, .5),
+        (57, .5),
+        (55, .5),
+
+        (55, .5),
+        (57, .5),
+        (56, .5),
+        (55, .5),
+
+        (53, .5),
+        (55, .5),
+        (57, .5),
+        (55, .5),
+
+        (55, 1.5),
+    ]
+    pitches_1_2 = [
+        (48, .5),
+
+        (48, .5),
+        (53, .5),
+        (52, .5),
+        (57, .5),
+
+        (53, .5),
+        (55, .5),
+        (48, .5),
+        (48, .5),
+
+        (45, .5),
+        (52, .5),
+        (48, .5),
+        (50, .5),
+
+        (43, 1.5),
+
+        (55, .5),
+
+        (48, .5),
+        (53, .5),
+        (50, .5),
+        (55, .5),
+
+        (48, .5),
+        (53, .5),
+        (52, .5),
+        (52, .5),
+
+        (50, .5),
+        (48, .5),
+        (53, .5),
+        (55, .5),
+
+        (48, 1.5),
+    ]
+    part_voice_instrument_program_pitches = [
+        (0, 1, 1, 7, pitches_0_1),
+        (0, 2, 1, 7, pitches_0_2),
+        (1, 1, 2, 1, pitches_1_1),
+        (1, 2, 2, 1, pitches_1_2),
+    ]
+    for part, voice, instrument, program, pitches in (
+        part_voice_instrument_program_pitches):
+      time = 0
+      for pitch, duration in pitches:
+        note = expected_ns.notes.add()
+        note.part = part
+        note.voice = voice
+        note.pitch = pitch
+        note.start_time = time
+        time += duration
+        note.end_time = time
+        note.velocity = 64
+        note.instrument = instrument
+        note.program = program
+        if duration == .5:
+          note.numerator = 1
+          note.denominator = 4
+        if duration == .25:
+          note.numerator = 1
+          note.denominator = 8
+        if duration == .75:
+          note.numerator = 3
+          note.denominator = 8
+        if duration == 1.5:
+          note.numerator = 3
+          note.denominator = 4
+    expected_ns.notes.sort(
+        key=lambda note: (note.part, note.voice, note.start_time))
+    ns.notes.sort(
+        key=lambda note: (note.part, note.voice, note.start_time))
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_part_name(self):
+    &#34;&#34;&#34;Verify that a part with an empty name can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        part_infos {
+          part: 0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_part_list(self):
+    &#34;&#34;&#34;Verify that a part without a corresponding score-part can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        part_infos {
+          part: 0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_doc(self):
+    &#34;&#34;&#34;Verify that an empty doc can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_chord_symbols(self):
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.chord_symbols_filename)
+    chord_symbols = [(annotation.time, annotation.text)
+                     for annotation in ns.text_annotations
+                     if annotation.annotation_type == CHORD_SYMBOL]
+    chord_symbols = list(sorted(chord_symbols, key=operator.itemgetter(0)))
+
+    expected_beats_and_chords = [
+        (0.0, &#39;N.C.&#39;),
+        (4.0, &#39;Cmaj7&#39;),
+        (12.0, &#39;F6(add9)&#39;),
+        (16.0, &#39;F#dim7/A&#39;),
+        (20.0, &#39;Bm7b5&#39;),
+        (24.0, &#39;E7(#9)&#39;),
+        (28.0, &#39;A7(add9)(no3)&#39;),
+        (32.0, &#39;Bbsus2&#39;),
+        (36.0, &#39;Am(maj7)&#39;),
+        (38.0, &#39;D13&#39;),
+        (40.0, &#39;E5&#39;),
+        (44.0, &#39;Caug&#39;)
+    ]
+
+    # Adjust for 120 QPM.
+    expected_times_and_chords = [(beat / 2.0, chord)
+                                 for beat, chord in expected_beats_and_chords]
+    self.assertEqual(expected_times_and_chords, chord_symbols)
+
+  def test_alternating_meter(self):
+    with self.assertRaises(musicxml_parser.AlternatingTimeSignatureError):
+      musicxml_parser.MusicXMLDocument(self.alternating_meter_filename)
+
+  def test_mid_measure_meter_change(self):
+    with self.assertRaises(musicxml_parser.MultipleTimeSignatureError):
+      musicxml_parser.MusicXMLDocument(self.mid_measure_meter_filename)
+
+  def test_unpitched_notes(self):
+    with self.assertRaises(musicxml_parser.UnpitchedNoteError):
+      musicxml_parser.MusicXMLDocument(os.path.join(
+          testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))
+    with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+      musicxml_reader.musicxml_file_to_sequence_proto(os.path.join(
+          testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))
+
+  def test_empty_archive(self):
+    with tempfile.NamedTemporaryFile(suffix=&#39;.mxl&#39;) as temp_file:
+      z = zipfile.ZipFile(temp_file.name, &#39;w&#39;)
+      z.close()
+
+      with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+        musicxml_reader.musicxml_file_to_sequence_proto(
+            temp_file.name)
+
+  def test_whole_measure_rest_forward(self):
+    &#34;&#34;&#34;Test that a whole measure rest can be encoded using &lt;forward&gt;.
+
+    A whole measure rest is usually encoded as a &lt;note&gt; with a duration
+    equal to that of a whole measure. An alternative encoding is to
+    use the &lt;forward&gt; element to advance the time cursor to a duration
+    equal to that of a whole measure. This implies a whole measure rest
+    when there are no &lt;note&gt; elements in this measure.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.whole_measure_rest_forward_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 6.0
+          numerator: 2
+          denominator: 4
+        }
+        key_signatures {
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 2.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 4.0
+          end_time: 6.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 60
+          velocity: 64
+          start_time: 6.0
+          end_time: 7.0
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 60
+          velocity: 64
+          start_time: 8.0
+          end_time: 9.0
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        total_time: 9.0
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_meter(self):
+    &#34;&#34;&#34;Test that meters are encoded properly.
+
+    Musical meters are expressed as a ratio of beats to divisions.
+    The MusicXML parser uses this ratio in lowest terms for timing
+    purposes. However, the meters should be in the actual terms
+    when appearing in a NoteSequence.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.meter_test_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 0.5
+          numerator: 2
+          denominator: 4
+        }
+        time_signatures {
+          time: 1.5
+          numerator: 3
+          denominator: 4
+        }
+        time_signatures {
+          time: 3.0
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 5.0
+          numerator: 5
+          denominator: 4
+        }
+        time_signatures {
+          time: 7.5
+          numerator: 6
+          denominator: 4
+        }
+        time_signatures {
+          time: 10.5
+          numerator: 7
+          denominator: 4
+        }
+        time_signatures {
+          time: 14.0
+          numerator: 1
+          denominator: 8
+        }
+        time_signatures {
+          time: 14.25
+          numerator: 2
+          denominator: 8
+        }
+        time_signatures {
+          time: 14.75
+          numerator: 3
+          denominator: 8
+        }
+        time_signatures {
+          time: 15.5
+          numerator: 4
+          denominator: 8
+        }
+        time_signatures {
+          time: 16.5
+          numerator: 5
+          denominator: 8
+        }
+        time_signatures {
+          time: 17.75
+          numerator: 6
+          denominator: 8
+        }
+        time_signatures {
+          time: 19.25
+          numerator: 7
+          denominator: 8
+        }
+        time_signatures {
+          time: 21.0
+          numerator: 8
+          denominator: 8
+        }
+        time_signatures {
+          time: 23.0
+          numerator: 9
+          denominator: 8
+        }
+        time_signatures {
+          time: 25.25
+          numerator: 10
+          denominator: 8
+        }
+        time_signatures {
+          time: 27.75
+          numerator: 11
+          denominator: 8
+        }
+        time_signatures {
+          time: 30.5
+          numerator: 12
+          denominator: 8
+        }
+        time_signatures {
+          time: 33.5
+          numerator: 2
+          denominator: 2
+        }
+        time_signatures {
+          time: 35.5
+          numerator: 3
+          denominator: 2
+        }
+        time_signatures {
+          time: 38.5
+          numerator: 4
+          denominator: 2
+        }
+        time_signatures {
+          time: 42.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 44.5
+          numerator: 2
+          denominator: 2
+        }
+        key_signatures {
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 0.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 0.5
+          end_time: 1.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 1.5
+          end_time: 3.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 3.0
+          end_time: 5.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 5.0
+          end_time: 6.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 6.5
+          end_time: 7.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 7.5
+          end_time: 9.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 9.0
+          end_time: 10.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 10.5
+          end_time: 12.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 12.0
+          end_time: 13.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 13.5
+          end_time: 14.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.0
+          end_time: 14.25
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.25
+          end_time: 14.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.75
+          end_time: 15.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 15.5
+          end_time: 16.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 16.0
+          end_time: 16.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 16.5
+          end_time: 17.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.0
+          end_time: 17.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.5
+          end_time: 17.75
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.75
+          end_time: 18.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 18.5
+          end_time: 19.25
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 19.25
+          end_time: 20.0
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 20.0
+          end_time: 20.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 20.5
+          end_time: 21.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 21.0
+          end_time: 21.75
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 21.75
+          end_time: 22.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 22.5
+          end_time: 23.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 23.0
+          end_time: 24.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 24.5
+          end_time: 25.25
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 25.25
+          end_time: 26.75
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 26.75
+          end_time: 27.25
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 27.25
+          end_time: 27.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 27.75
+          end_time: 29.25
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 29.25
+          end_time: 30.0
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 30.0
+          end_time: 30.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 30.5
+          end_time: 32.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 32.0
+          end_time: 33.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 33.5
+          end_time: 34.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 34.5
+          end_time: 35.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 35.5
+          end_time: 36.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 36.5
+          end_time: 37.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 37.5
+          end_time: 38.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 38.5
+          end_time: 40.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 40.5
+          end_time: 42.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 42.5
+          end_time: 44.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 44.5
+          end_time: 46.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        total_time: 46.5
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_key_missing_fifths(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;key&gt;
+                &lt;!-- missing fifths element. --&gt;
+              &lt;/key&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.KeyParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_harmony_missing_degree(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+            &lt;harmony&gt;
+              &lt;degree&gt;
+                &lt;!-- missing degree-value text --&gt;
+                &lt;degree-value&gt;&lt;/degree-value&gt;
+              &lt;/degree&gt;
+            &lt;/harmony&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.ChordSymbolParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_transposed_keysig(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;4&lt;/divisions&gt;
+            &lt;key&gt;
+              &lt;fifths&gt;-3&lt;/fifths&gt;
+              &lt;mode&gt;major&lt;/mode&gt;
+            &lt;/key&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+            &lt;clef&gt;
+              &lt;sign&gt;G&lt;/sign&gt;
+              &lt;line&gt;2&lt;/line&gt;
+            &lt;/clef&gt;
+            &lt;transpose&gt;
+              &lt;diatonic&gt;-5&lt;/diatonic&gt;
+              &lt;chromatic&gt;-9&lt;/chromatic&gt;
+            &lt;/transpose&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      musicxml_parser.MusicXMLDocument(temp_file.name)
+      sequence = musicxml_reader.musicxml_file_to_sequence_proto(temp_file.name)
+      self.assertLen(sequence.key_signatures, 1)
+      self.assertEqual(music_pb2.NoteSequence.KeySignature.G_FLAT,
+                       sequence.key_signatures[0].key)
+
+  def test_beats_composite(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4+5&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.TimeSignatureParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_invalid_note_type(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;blarg&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.InvalidNoteDurationTypeError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest"><code class="flex name class">
+<span>class <span class="ident">MusicXMLParserTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Class to test the MusicXML parser use cases.</p>
+<p>self.flute_scale_filename contains an F-major scale of 8 quarter notes each</p>
+<p>self.clarinet_scale_filename contains a F-major scale of 8 quarter notes
+each appearing as written pitch. This means the key is written as
+G-major but sounds as F-major. The MIDI pitch numbers must be transposed
+to be input into Magenta</p>
+<p>self.band_score_filename contains a number of instruments in written
+pitch. The score has two time signatures (6/8 and 2/4) and two sounding
+keys (Bb-major and Eb major). The file also contains chords and
+multiple voices (see Oboe part in measure 57), as well as dynamics,
+articulations, slurs, ties, hairpins, grace notes, tempo changes,
+and multiple barline types (double, repeat)</p>
+<p>self.compressed_filename contains the same content as
+self.flute_scale_filename, but compressed in MXL format</p>
+<p>self.rhythm_durations_filename contains a variety of rhythms (long, short,
+dotted, tuplet, and dotted tuplet) to test the computation of rhythmic
+ratios.</p>
+<p>self.atonal_transposition_filename contains a change of instrument
+from a non-transposing (Flute) to transposing (Bb Clarinet) in a score
+with no key / atonal. This ensures that transposition works properly when
+no key signature is found (Issue #355)</p>
+<p>self.st_anne_filename contains a 4-voice piece written in two parts.</p>
+<p>self.whole_measure_rest_forward_filename contains 4 measures:
+Measures 1 and 2 contain whole note rests in 4/4. The first is a <note>,
+the second uses a <forward>. The durations must match.
+Measures 3 and 4 contain whole note rests in 2/4. The first is a <note>,
+the second uses a <forward>. The durations must match.
+(Issue #674).</p>
+<p>self.meter_test_filename contains a different meter in each measure:
+- 1/4 through 7/4 inclusive
+- 1/8 through 12/8 inclusive
+- 2/2 through 4/2 inclusive
+- Common time and Cut time meters</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicXMLParserTest(testing_lib.ProtoTestCase):
+  &#34;&#34;&#34;Class to test the MusicXML parser use cases.
+
+  self.flute_scale_filename contains an F-major scale of 8 quarter notes each
+
+  self.clarinet_scale_filename contains a F-major scale of 8 quarter notes
+  each appearing as written pitch. This means the key is written as
+  G-major but sounds as F-major. The MIDI pitch numbers must be transposed
+  to be input into Magenta
+
+  self.band_score_filename contains a number of instruments in written
+  pitch. The score has two time signatures (6/8 and 2/4) and two sounding
+  keys (Bb-major and Eb major). The file also contains chords and
+  multiple voices (see Oboe part in measure 57), as well as dynamics,
+  articulations, slurs, ties, hairpins, grace notes, tempo changes,
+  and multiple barline types (double, repeat)
+
+  self.compressed_filename contains the same content as
+  self.flute_scale_filename, but compressed in MXL format
+
+  self.rhythm_durations_filename contains a variety of rhythms (long, short,
+  dotted, tuplet, and dotted tuplet) to test the computation of rhythmic
+  ratios.
+
+  self.atonal_transposition_filename contains a change of instrument
+  from a non-transposing (Flute) to transposing (Bb Clarinet) in a score
+  with no key / atonal. This ensures that transposition works properly when
+  no key signature is found (Issue #355)
+
+  self.st_anne_filename contains a 4-voice piece written in two parts.
+
+  self.whole_measure_rest_forward_filename contains 4 measures:
+  Measures 1 and 2 contain whole note rests in 4/4. The first is a &lt;note&gt;,
+  the second uses a &lt;forward&gt;. The durations must match.
+  Measures 3 and 4 contain whole note rests in 2/4. The first is a &lt;note&gt;,
+  the second uses a &lt;forward&gt;. The durations must match.
+  (Issue #674).
+
+  self.meter_test_filename contains a different meter in each measure:
+  - 1/4 through 7/4 inclusive
+  - 1/8 through 12/8 inclusive
+  - 2/2 through 4/2 inclusive
+  - Common time and Cut time meters
+  &#34;&#34;&#34;
+
+  def setUp(self):
+    self.maxDiff = None   # pylint:disable=invalid-name
+
+    self.steps_per_quarter = 4
+
+    self.flute_scale_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale.xml&#39;)
+
+    self.clarinet_scale_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;clarinet_scale.xml&#39;)
+
+    self.band_score_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;el_capitan.xml&#39;)
+
+    self.compressed_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale.mxl&#39;)
+
+    self.multiple_rootfile_compressed_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;flute_scale_with_png.mxl&#39;)
+
+    self.rhythm_durations_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;rhythm_durations.xml&#39;)
+
+    self.st_anne_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;st_anne.xml&#39;)
+
+    self.atonal_transposition_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;atonal_transposition_change.xml&#39;)
+
+    self.chord_symbols_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;chord_symbols.xml&#39;)
+
+    self.time_signature_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;st_anne.xml&#39;)
+
+    self.unmetered_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unmetered_example.xml&#39;)
+
+    self.alternating_meter_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;alternating_meter.xml&#39;)
+
+    self.mid_measure_meter_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;mid_measure_time_signature.xml&#39;)
+
+    self.whole_measure_rest_forward_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;whole_measure_rest_forward.xml&#39;)
+
+    self.meter_test_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;meter_test.xml&#39;)
+
+    super().setUp()
+
+  def check_musicxml_and_sequence(self, musicxml, sequence_proto):
+    &#34;&#34;&#34;Compares MusicXMLDocument object against a sequence proto.
+
+    Args:
+      musicxml: A MusicXMLDocument object.
+      sequence_proto: A NoteSequence proto.
+    &#34;&#34;&#34;
+    # Test time signature changes.
+    self.assertEqual(len(musicxml.get_time_signatures()),
+                     len(sequence_proto.time_signatures))
+    for musicxml_time, sequence_time in zip(musicxml.get_time_signatures(),
+                                            sequence_proto.time_signatures):
+      self.assertEqual(musicxml_time.numerator, sequence_time.numerator)
+      self.assertEqual(musicxml_time.denominator, sequence_time.denominator)
+      self.assertAlmostEqual(musicxml_time.time_position, sequence_time.time)
+
+    # Test key signature changes.
+    self.assertEqual(len(musicxml.get_key_signatures()),
+                     len(sequence_proto.key_signatures))
+    for musicxml_key, sequence_key in zip(musicxml.get_key_signatures(),
+                                          sequence_proto.key_signatures):
+
+      if musicxml_key.mode == &#39;major&#39;:
+        mode = 0
+      elif musicxml_key.mode == &#39;minor&#39;:
+        mode = 1
+
+      # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
+      # Convert from MIDI / MusicXML key to music.proto key
+      music_proto_keys = [11, 6, 1, 8, 3, 10, 5, 0, 7, 2, 9, 4, 11, 6, 1]
+      key = music_proto_keys[musicxml_key.key + 7]
+      self.assertEqual(key, sequence_key.key)
+      self.assertEqual(mode, sequence_key.mode)
+      self.assertAlmostEqual(musicxml_key.time_position, sequence_key.time)
+
+    # Test tempos.
+    musicxml_tempos = musicxml.get_tempos()
+    self.assertEqual(len(musicxml_tempos),
+                     len(sequence_proto.tempos))
+    for musicxml_tempo, sequence_tempo in zip(
+        musicxml_tempos, sequence_proto.tempos):
+      self.assertAlmostEqual(musicxml_tempo.qpm, sequence_tempo.qpm)
+      self.assertAlmostEqual(musicxml_tempo.time_position,
+                             sequence_tempo.time)
+
+    # Test parts/instruments.
+    seq_parts = collections.defaultdict(list)
+    for seq_note in sequence_proto.notes:
+      seq_parts[seq_note.part].append(seq_note)
+
+    self.assertEqual(len(musicxml.parts), len(seq_parts))
+    for musicxml_part, seq_part_id in zip(
+        musicxml.parts, sorted(seq_parts.keys())):
+
+      seq_instrument_notes = seq_parts[seq_part_id]
+      musicxml_notes = []
+      for musicxml_measure in musicxml_part.measures:
+        for musicxml_note in musicxml_measure.notes:
+          if not musicxml_note.is_rest:
+            musicxml_notes.append(musicxml_note)
+
+      self.assertEqual(len(musicxml_notes), len(seq_instrument_notes))
+      for musicxml_note, sequence_note in zip(musicxml_notes,
+                                              seq_instrument_notes):
+        self.assertEqual(musicxml_note.pitch[1], sequence_note.pitch)
+        self.assertEqual(musicxml_note.velocity, sequence_note.velocity)
+        self.assertAlmostEqual(musicxml_note.note_duration.time_position,
+                               sequence_note.start_time)
+        self.assertAlmostEqual(musicxml_note.note_duration.time_position
+                               + musicxml_note.note_duration.seconds,
+                               sequence_note.end_time)
+        # Check that the duration specified in the MusicXML and the
+        # duration float match to within +/- 1 (delta = 1)
+        # Delta is used because duration in MusicXML is always an integer
+        # For example, a 3:2 half note might have a durationfloat of 341.333
+        # but would have the 1/3 distributed in the MusicXML as
+        # 341.0, 341.0, 342.0.
+        # Check that (3 * 341.333) = (341 + 341 + 342) is true by checking
+        # that 341.0 and 342.0 are +/- 1 of 341.333
+        self.assertAlmostEqual(
+            musicxml_note.note_duration.duration,
+            musicxml_note.state.divisions * 4
+            * musicxml_note.note_duration.duration_float(),
+            delta=1)
+
+  def check_musicxml_to_sequence(self, filename):
+    &#34;&#34;&#34;Test the translation from MusicXML to Sequence proto.&#34;&#34;&#34;
+    source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+    sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+    self.check_musicxml_and_sequence(source_musicxml, sequence_proto)
+
+  def check_fmajor_scale(self, filename, part_name):
+    &#34;&#34;&#34;Verify MusicXML scale file.
+
+    Verify that it contains the correct pitches (sounding pitch) and durations.
+
+    Args:
+      filename: file to test.
+      part_name: name of the part the sequence is expected to contain.
+    &#34;&#34;&#34;
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: F
+          time: 0
+        }
+        time_signatures {
+          numerator: 4
+          denominator: 4
+        }
+        tempos {
+          qpm: 120.0
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+
+    part_info = expected_ns.part_infos.add()
+    part_info.name = part_name
+
+    expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.part = 0
+      note.voice = 1
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+
+    # Convert MusicXML to NoteSequence
+    source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+    sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+
+    # Check equality
+    self.assertProtoEquals(expected_ns, sequence_proto)
+
+  def testsimplemusicxmltosequence(self):
+    &#34;&#34;&#34;Test the simple flute scale MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.flute_scale_filename)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testcomplexmusicxmltosequence(self):
+    &#34;&#34;&#34;Test the complex band score MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.band_score_filename)
+
+  def testtransposedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from transposed MusicXML to Sequence proto.
+
+    Compare a transposed MusicXML file (clarinet) to an identical untransposed
+    sequence (flute).
+    &#34;&#34;&#34;
+    untransposed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    transposed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.clarinet_scale_filename)
+    untransposed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        untransposed_musicxml)
+    self.check_musicxml_and_sequence(transposed_musicxml, untransposed_proto)
+    self.check_fmajor_scale(self.clarinet_scale_filename, &#39;Clarinet in Bb&#39;)
+
+  def testcompressedmxlunicodefilename(self):
+    &#34;&#34;&#34;Test an MXL file containing a unicode filename within its zip archive.&#34;&#34;&#34;
+
+    unicode_filename = os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unicode_filename.mxl&#39;)
+    sequence = musicxml_reader.musicxml_file_to_sequence_proto(unicode_filename)
+    self.assertLen(sequence.notes, 8)
+
+  def testcompressedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from compressed MusicXML to Sequence proto.
+
+    Compare a compressed MusicXML file to an identical uncompressed sequence.
+    &#34;&#34;&#34;
+    uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    compressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.compressed_filename)
+    uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        uncompressed_musicxml)
+    self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testmultiplecompressedxmltosequence(self):
+    &#34;&#34;&#34;Test the translation from compressed MusicXML with multiple rootfiles.
+
+    The example MXL file contains a MusicXML file of the Flute F Major scale,
+    as well as the PNG rendering of the score contained within the single MXL
+    file.
+    &#34;&#34;&#34;
+    uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.flute_scale_filename)
+    compressed_musicxml = musicxml_parser.MusicXMLDocument(
+        self.multiple_rootfile_compressed_filename)
+    uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+        uncompressed_musicxml)
+    self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+    self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)
+
+  def testrhythmdurationsxmltosequence(self):
+    &#34;&#34;&#34;Test the rhythm durations MusicXML file.&#34;&#34;&#34;
+    self.check_musicxml_to_sequence(self.rhythm_durations_filename)
+
+  def testFluteScale(self):
+    &#34;&#34;&#34;Verify properties of the flute scale.&#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.flute_scale_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+          key: F
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        part_infos {
+          part: 0
+          name: &#34;Flute&#34;
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+    expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.part = 0
+      note.voice = 1
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_atonal_transposition(self):
+    &#34;&#34;&#34;Test that transposition works when changing instrument transposition.
+
+    This can occur within a single part in a score where the score
+    has no key signature / is atonal. Examples include changing from a
+    non-transposing instrument to a transposing one (ex. Flute to Bb Clarinet)
+    or vice versa, or changing among transposing instruments (ex. Bb Clarinet
+    to Eb Alto Saxophone).
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.atonal_transposition_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+        }
+        part_infos {
+          part: 0
+          name: &#34;Flute&#34;
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        total_time: 4.0
+        &#34;&#34;&#34;)
+    expected_pitches = [72, 74, 76, 77, 79, 77, 76, 74]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+      note.voice = 1
+    self.maxDiff = None
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_incomplete_measures(self):
+    &#34;&#34;&#34;Test that incomplete measures have the correct time signature.
+
+    This can occur in pickup bars or incomplete measures. For example,
+    if the time signature in the MusicXML is 4/4, but the measure only
+    contains one quarter note, Magenta expects this pickup measure to have
+    a time signature of 1/4.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.time_signature_filename)
+
+    # One time signature per measure
+    self.assertLen(ns.time_signatures, 6)
+    self.assertLen(ns.key_signatures, 1)
+    self.assertLen(ns.notes, 112)
+
+  def test_unmetered_music(self):
+    &#34;&#34;&#34;Test that time signatures are inserted for music without time signatures.
+
+    MusicXML does not require the use of time signatures. Music without
+    time signatures occur in medieval chant, cadenzas, and contemporary music.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.unmetered_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 11
+          denominator: 8
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 0.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 74
+          velocity: 64
+          start_time: 0.5
+          end_time: 0.75
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 76
+          velocity: 64
+          start_time: 0.75
+          end_time: 1.25
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 77
+          velocity: 64
+          start_time: 1.25
+          end_time: 1.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 79
+          velocity: 64
+          start_time: 1.75
+          end_time: 2.75
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        total_time: 2.75
+        &#34;&#34;&#34;)
+    self.maxDiff = None
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_st_anne(self):
+    &#34;&#34;&#34;Verify properties of the St. Anne file.
+
+    The file contains 2 parts and 4 voices.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.st_anne_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 0.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 6.5
+          numerator: 3
+          denominator: 4
+        }
+        time_signatures {
+          time: 8.0
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 8.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 14.5
+          numerator: 3
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+          key: C
+        }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        part_infos {
+          part: 0
+          name: &#34;Harpsichord&#34;
+        }
+        part_infos {
+          part: 1
+          name: &#34;Piano&#34;
+        }
+        total_time: 16.0
+        &#34;&#34;&#34;)
+    pitches_0_1 = [
+        (67, .5),
+
+        (64, .5),
+        (69, .5),
+        (67, .5),
+        (72, .5),
+
+        (72, .5),
+        (71, .5),
+        (72, .5),
+        (67, .5),
+
+        (72, .5),
+        (67, .5),
+        (69, .5),
+        (66, .5),
+
+        (67, 1.5),
+
+        (71, .5),
+
+        (72, .5),
+        (69, .5),
+        (74, .5),
+        (71, .5),
+
+        (72, .5),
+        (69, .5),
+        (71, .5),
+        (67, .5),
+
+        (69, .5),
+        (72, .5),
+        (74, .5),
+        (71, .5),
+
+        (72, 1.5),
+    ]
+    pitches_0_2 = [
+        (60, .5),
+
+        (60, .5),
+        (60, .5),
+        (60, .5),
+        (64, .5),
+
+        (62, .5),
+        (62, .5),
+        (64, .5),
+        (64, .5),
+
+        (64, .5),
+        (64, .5),
+        (64, .5),
+        (62, .5),
+
+        (62, 1.5),
+
+        (62, .5),
+
+        (64, .5),
+        (60, .5),
+        (65, .5),
+        (62, .5),
+
+        (64, .75),
+        (62, .25),
+        (59, .5),
+        (60, .5),
+
+        (65, .5),
+        (64, .5),
+        (62, .5),
+        (62, .5),
+
+        (64, 1.5),
+    ]
+    pitches_1_1 = [
+        (52, .5),
+
+        (55, .5),
+        (57, .5),
+        (60, .5),
+        (60, .5),
+
+        (57, .5),
+        (55, .5),
+        (55, .5),
+        (60, .5),
+
+        (60, .5),
+        (59, .5),
+        (57, .5),
+        (57, .5),
+
+        (59, 1.5),
+
+        (55, .5),
+
+        (55, .5),
+        (57, .5),
+        (57, .5),
+        (55, .5),
+
+        (55, .5),
+        (57, .5),
+        (56, .5),
+        (55, .5),
+
+        (53, .5),
+        (55, .5),
+        (57, .5),
+        (55, .5),
+
+        (55, 1.5),
+    ]
+    pitches_1_2 = [
+        (48, .5),
+
+        (48, .5),
+        (53, .5),
+        (52, .5),
+        (57, .5),
+
+        (53, .5),
+        (55, .5),
+        (48, .5),
+        (48, .5),
+
+        (45, .5),
+        (52, .5),
+        (48, .5),
+        (50, .5),
+
+        (43, 1.5),
+
+        (55, .5),
+
+        (48, .5),
+        (53, .5),
+        (50, .5),
+        (55, .5),
+
+        (48, .5),
+        (53, .5),
+        (52, .5),
+        (52, .5),
+
+        (50, .5),
+        (48, .5),
+        (53, .5),
+        (55, .5),
+
+        (48, 1.5),
+    ]
+    part_voice_instrument_program_pitches = [
+        (0, 1, 1, 7, pitches_0_1),
+        (0, 2, 1, 7, pitches_0_2),
+        (1, 1, 2, 1, pitches_1_1),
+        (1, 2, 2, 1, pitches_1_2),
+    ]
+    for part, voice, instrument, program, pitches in (
+        part_voice_instrument_program_pitches):
+      time = 0
+      for pitch, duration in pitches:
+        note = expected_ns.notes.add()
+        note.part = part
+        note.voice = voice
+        note.pitch = pitch
+        note.start_time = time
+        time += duration
+        note.end_time = time
+        note.velocity = 64
+        note.instrument = instrument
+        note.program = program
+        if duration == .5:
+          note.numerator = 1
+          note.denominator = 4
+        if duration == .25:
+          note.numerator = 1
+          note.denominator = 8
+        if duration == .75:
+          note.numerator = 3
+          note.denominator = 8
+        if duration == 1.5:
+          note.numerator = 3
+          note.denominator = 4
+    expected_ns.notes.sort(
+        key=lambda note: (note.part, note.voice, note.start_time))
+    ns.notes.sort(
+        key=lambda note: (note.part, note.voice, note.start_time))
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_part_name(self):
+    &#34;&#34;&#34;Verify that a part with an empty name can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        part_infos {
+          part: 0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_part_list(self):
+    &#34;&#34;&#34;Verify that a part without a corresponding score-part can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        part_infos {
+          part: 0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_empty_doc(self):
+    &#34;&#34;&#34;Verify that an empty doc can be parsed.&#34;&#34;&#34;
+
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      ns = musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)
+
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        key_signatures {
+          key: C
+          time: 0
+        }
+        tempos {
+          qpm: 120.0
+        }
+        total_time: 0.0
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_chord_symbols(self):
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.chord_symbols_filename)
+    chord_symbols = [(annotation.time, annotation.text)
+                     for annotation in ns.text_annotations
+                     if annotation.annotation_type == CHORD_SYMBOL]
+    chord_symbols = list(sorted(chord_symbols, key=operator.itemgetter(0)))
+
+    expected_beats_and_chords = [
+        (0.0, &#39;N.C.&#39;),
+        (4.0, &#39;Cmaj7&#39;),
+        (12.0, &#39;F6(add9)&#39;),
+        (16.0, &#39;F#dim7/A&#39;),
+        (20.0, &#39;Bm7b5&#39;),
+        (24.0, &#39;E7(#9)&#39;),
+        (28.0, &#39;A7(add9)(no3)&#39;),
+        (32.0, &#39;Bbsus2&#39;),
+        (36.0, &#39;Am(maj7)&#39;),
+        (38.0, &#39;D13&#39;),
+        (40.0, &#39;E5&#39;),
+        (44.0, &#39;Caug&#39;)
+    ]
+
+    # Adjust for 120 QPM.
+    expected_times_and_chords = [(beat / 2.0, chord)
+                                 for beat, chord in expected_beats_and_chords]
+    self.assertEqual(expected_times_and_chords, chord_symbols)
+
+  def test_alternating_meter(self):
+    with self.assertRaises(musicxml_parser.AlternatingTimeSignatureError):
+      musicxml_parser.MusicXMLDocument(self.alternating_meter_filename)
+
+  def test_mid_measure_meter_change(self):
+    with self.assertRaises(musicxml_parser.MultipleTimeSignatureError):
+      musicxml_parser.MusicXMLDocument(self.mid_measure_meter_filename)
+
+  def test_unpitched_notes(self):
+    with self.assertRaises(musicxml_parser.UnpitchedNoteError):
+      musicxml_parser.MusicXMLDocument(os.path.join(
+          testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))
+    with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+      musicxml_reader.musicxml_file_to_sequence_proto(os.path.join(
+          testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))
+
+  def test_empty_archive(self):
+    with tempfile.NamedTemporaryFile(suffix=&#39;.mxl&#39;) as temp_file:
+      z = zipfile.ZipFile(temp_file.name, &#39;w&#39;)
+      z.close()
+
+      with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+        musicxml_reader.musicxml_file_to_sequence_proto(
+            temp_file.name)
+
+  def test_whole_measure_rest_forward(self):
+    &#34;&#34;&#34;Test that a whole measure rest can be encoded using &lt;forward&gt;.
+
+    A whole measure rest is usually encoded as a &lt;note&gt; with a duration
+    equal to that of a whole measure. An alternative encoding is to
+    use the &lt;forward&gt; element to advance the time cursor to a duration
+    equal to that of a whole measure. This implies a whole measure rest
+    when there are no &lt;note&gt; elements in this measure.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.whole_measure_rest_forward_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 6.0
+          numerator: 2
+          denominator: 4
+        }
+        key_signatures {
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 2.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 4.0
+          end_time: 6.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 60
+          velocity: 64
+          start_time: 6.0
+          end_time: 7.0
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 60
+          velocity: 64
+          start_time: 8.0
+          end_time: 9.0
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        total_time: 9.0
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_meter(self):
+    &#34;&#34;&#34;Test that meters are encoded properly.
+
+    Musical meters are expressed as a ratio of beats to divisions.
+    The MusicXML parser uses this ratio in lowest terms for timing
+    purposes. However, the meters should be in the actual terms
+    when appearing in a NoteSequence.
+    &#34;&#34;&#34;
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.meter_test_filename)
+    expected_ns = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        ticks_per_quarter: 220
+        time_signatures {
+          numerator: 1
+          denominator: 4
+        }
+        time_signatures {
+          time: 0.5
+          numerator: 2
+          denominator: 4
+        }
+        time_signatures {
+          time: 1.5
+          numerator: 3
+          denominator: 4
+        }
+        time_signatures {
+          time: 3.0
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 5.0
+          numerator: 5
+          denominator: 4
+        }
+        time_signatures {
+          time: 7.5
+          numerator: 6
+          denominator: 4
+        }
+        time_signatures {
+          time: 10.5
+          numerator: 7
+          denominator: 4
+        }
+        time_signatures {
+          time: 14.0
+          numerator: 1
+          denominator: 8
+        }
+        time_signatures {
+          time: 14.25
+          numerator: 2
+          denominator: 8
+        }
+        time_signatures {
+          time: 14.75
+          numerator: 3
+          denominator: 8
+        }
+        time_signatures {
+          time: 15.5
+          numerator: 4
+          denominator: 8
+        }
+        time_signatures {
+          time: 16.5
+          numerator: 5
+          denominator: 8
+        }
+        time_signatures {
+          time: 17.75
+          numerator: 6
+          denominator: 8
+        }
+        time_signatures {
+          time: 19.25
+          numerator: 7
+          denominator: 8
+        }
+        time_signatures {
+          time: 21.0
+          numerator: 8
+          denominator: 8
+        }
+        time_signatures {
+          time: 23.0
+          numerator: 9
+          denominator: 8
+        }
+        time_signatures {
+          time: 25.25
+          numerator: 10
+          denominator: 8
+        }
+        time_signatures {
+          time: 27.75
+          numerator: 11
+          denominator: 8
+        }
+        time_signatures {
+          time: 30.5
+          numerator: 12
+          denominator: 8
+        }
+        time_signatures {
+          time: 33.5
+          numerator: 2
+          denominator: 2
+        }
+        time_signatures {
+          time: 35.5
+          numerator: 3
+          denominator: 2
+        }
+        time_signatures {
+          time: 38.5
+          numerator: 4
+          denominator: 2
+        }
+        time_signatures {
+          time: 42.5
+          numerator: 4
+          denominator: 4
+        }
+        time_signatures {
+          time: 44.5
+          numerator: 2
+          denominator: 2
+        }
+        key_signatures {
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          end_time: 0.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 0.5
+          end_time: 1.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 1.5
+          end_time: 3.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 3.0
+          end_time: 5.0
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 5.0
+          end_time: 6.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 6.5
+          end_time: 7.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 7.5
+          end_time: 9.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 9.0
+          end_time: 10.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 10.5
+          end_time: 12.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 12.0
+          end_time: 13.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 13.5
+          end_time: 14.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.0
+          end_time: 14.25
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.25
+          end_time: 14.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 14.75
+          end_time: 15.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 15.5
+          end_time: 16.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 16.0
+          end_time: 16.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 16.5
+          end_time: 17.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.0
+          end_time: 17.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.5
+          end_time: 17.75
+          numerator: 1
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 17.75
+          end_time: 18.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 18.5
+          end_time: 19.25
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 19.25
+          end_time: 20.0
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 20.0
+          end_time: 20.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 20.5
+          end_time: 21.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 21.0
+          end_time: 21.75
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 21.75
+          end_time: 22.5
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 22.5
+          end_time: 23.0
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 23.0
+          end_time: 24.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 24.5
+          end_time: 25.25
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 25.25
+          end_time: 26.75
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 26.75
+          end_time: 27.25
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 27.25
+          end_time: 27.75
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 27.75
+          end_time: 29.25
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 29.25
+          end_time: 30.0
+          numerator: 3
+          denominator: 8
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 30.0
+          end_time: 30.5
+          numerator: 1
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 30.5
+          end_time: 32.0
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 32.0
+          end_time: 33.5
+          numerator: 3
+          denominator: 4
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 33.5
+          end_time: 34.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 34.5
+          end_time: 35.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 35.5
+          end_time: 36.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 36.5
+          end_time: 37.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 37.5
+          end_time: 38.5
+          numerator: 1
+          denominator: 2
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 38.5
+          end_time: 40.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 40.5
+          end_time: 42.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 42.5
+          end_time: 44.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        notes {
+          pitch: 72
+          velocity: 64
+          start_time: 44.5
+          end_time: 46.5
+          numerator: 1
+          denominator: 1
+          voice: 1
+        }
+        total_time: 46.5
+        part_infos {
+          name: &#34;Flute&#34;
+        }
+        source_info {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
+        &#34;&#34;&#34;)
+    self.assertProtoEquals(expected_ns, ns)
+
+  def test_key_missing_fifths(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;key&gt;
+                &lt;!-- missing fifths element. --&gt;
+              &lt;/key&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.KeyParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_harmony_missing_degree(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+            &lt;harmony&gt;
+              &lt;degree&gt;
+                &lt;!-- missing degree-value text --&gt;
+                &lt;degree-value&gt;&lt;/degree-value&gt;
+              &lt;/degree&gt;
+            &lt;/harmony&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.ChordSymbolParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_transposed_keysig(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;4&lt;/divisions&gt;
+            &lt;key&gt;
+              &lt;fifths&gt;-3&lt;/fifths&gt;
+              &lt;mode&gt;major&lt;/mode&gt;
+            &lt;/key&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+            &lt;clef&gt;
+              &lt;sign&gt;G&lt;/sign&gt;
+              &lt;line&gt;2&lt;/line&gt;
+            &lt;/clef&gt;
+            &lt;transpose&gt;
+              &lt;diatonic&gt;-5&lt;/diatonic&gt;
+              &lt;chromatic&gt;-9&lt;/chromatic&gt;
+            &lt;/transpose&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      musicxml_parser.MusicXMLDocument(temp_file.name)
+      sequence = musicxml_reader.musicxml_file_to_sequence_proto(temp_file.name)
+      self.assertLen(sequence.key_signatures, 1)
+      self.assertEqual(music_pb2.NoteSequence.KeySignature.G_FLAT,
+                       sequence.key_signatures[0].key)
+
+  def test_beats_composite(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4+5&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;quarter&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.TimeSignatureParseError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)
+
+  def test_invalid_note_type(self):
+    xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+      &lt;!DOCTYPE score-partwise PUBLIC
+          &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+          &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+      &lt;score-partwise version=&#34;3.0&#34;&gt;
+        &lt;part-list&gt;
+          &lt;score-part id=&#34;P1&#34;&gt;
+            &lt;part-name/&gt;
+          &lt;/score-part&gt;
+        &lt;/part-list&gt;
+        &lt;part id=&#34;P1&#34;&gt;
+          &lt;measure number=&#34;1&#34;&gt;
+            &lt;attributes&gt;
+              &lt;divisions&gt;2&lt;/divisions&gt;
+              &lt;time&gt;
+                &lt;beats&gt;4&lt;/beats&gt;
+                &lt;beat-type&gt;4&lt;/beat-type&gt;
+              &lt;/time&gt;
+            &lt;/attributes&gt;
+            &lt;note&gt;
+              &lt;pitch&gt;
+                &lt;step&gt;G&lt;/step&gt;
+                &lt;octave&gt;4&lt;/octave&gt;
+              &lt;/pitch&gt;
+              &lt;duration&gt;2&lt;/duration&gt;
+              &lt;voice&gt;1&lt;/voice&gt;
+              &lt;type&gt;blarg&lt;/type&gt;
+            &lt;/note&gt;
+          &lt;/measure&gt;
+        &lt;/part&gt;
+      &lt;/score-partwise&gt;
+    &#34;&#34;&#34;
+    with tempfile.NamedTemporaryFile() as temp_file:
+      temp_file.write(xml)
+      temp_file.flush()
+      with self.assertRaises(musicxml_parser.InvalidNoteDurationTypeError):
+        musicxml_parser.MusicXMLDocument(temp_file.name)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.check_fmajor_scale"><code class="name flex">
+<span>def <span class="ident">check_fmajor_scale</span></span>(<span>self, filename, part_name)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify MusicXML scale file.</p>
+<p>Verify that it contains the correct pitches (sounding pitch) and durations.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>filename</code></strong></dt>
+<dd>file to test.</dd>
+<dt><strong><code>part_name</code></strong></dt>
+<dd>name of the part the sequence is expected to contain.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_fmajor_scale(self, filename, part_name):
+  &#34;&#34;&#34;Verify MusicXML scale file.
+
+  Verify that it contains the correct pitches (sounding pitch) and durations.
+
+  Args:
+    filename: file to test.
+    part_name: name of the part the sequence is expected to contain.
+  &#34;&#34;&#34;
+
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      key_signatures {
+        key: F
+        time: 0
+      }
+      time_signatures {
+        numerator: 4
+        denominator: 4
+      }
+      tempos {
+        qpm: 120.0
+      }
+      total_time: 4.0
+      &#34;&#34;&#34;)
+
+  part_info = expected_ns.part_infos.add()
+  part_info.name = part_name
+
+  expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+  time = 0
+  for pitch in expected_pitches:
+    note = expected_ns.notes.add()
+    note.part = 0
+    note.voice = 1
+    note.pitch = pitch
+    note.start_time = time
+    time += .5
+    note.end_time = time
+    note.velocity = 64
+    note.numerator = 1
+    note.denominator = 4
+
+  # Convert MusicXML to NoteSequence
+  source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+  sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+
+  # Check equality
+  self.assertProtoEquals(expected_ns, sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_and_sequence"><code class="name flex">
+<span>def <span class="ident">check_musicxml_and_sequence</span></span>(<span>self, musicxml, sequence_proto)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compares MusicXMLDocument object against a sequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>musicxml</code></strong></dt>
+<dd>A MusicXMLDocument object.</dd>
+<dt><strong><code>sequence_proto</code></strong></dt>
+<dd>A NoteSequence proto.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_musicxml_and_sequence(self, musicxml, sequence_proto):
+  &#34;&#34;&#34;Compares MusicXMLDocument object against a sequence proto.
+
+  Args:
+    musicxml: A MusicXMLDocument object.
+    sequence_proto: A NoteSequence proto.
+  &#34;&#34;&#34;
+  # Test time signature changes.
+  self.assertEqual(len(musicxml.get_time_signatures()),
+                   len(sequence_proto.time_signatures))
+  for musicxml_time, sequence_time in zip(musicxml.get_time_signatures(),
+                                          sequence_proto.time_signatures):
+    self.assertEqual(musicxml_time.numerator, sequence_time.numerator)
+    self.assertEqual(musicxml_time.denominator, sequence_time.denominator)
+    self.assertAlmostEqual(musicxml_time.time_position, sequence_time.time)
+
+  # Test key signature changes.
+  self.assertEqual(len(musicxml.get_key_signatures()),
+                   len(sequence_proto.key_signatures))
+  for musicxml_key, sequence_key in zip(musicxml.get_key_signatures(),
+                                        sequence_proto.key_signatures):
+
+    if musicxml_key.mode == &#39;major&#39;:
+      mode = 0
+    elif musicxml_key.mode == &#39;minor&#39;:
+      mode = 1
+
+    # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
+    # Convert from MIDI / MusicXML key to music.proto key
+    music_proto_keys = [11, 6, 1, 8, 3, 10, 5, 0, 7, 2, 9, 4, 11, 6, 1]
+    key = music_proto_keys[musicxml_key.key + 7]
+    self.assertEqual(key, sequence_key.key)
+    self.assertEqual(mode, sequence_key.mode)
+    self.assertAlmostEqual(musicxml_key.time_position, sequence_key.time)
+
+  # Test tempos.
+  musicxml_tempos = musicxml.get_tempos()
+  self.assertEqual(len(musicxml_tempos),
+                   len(sequence_proto.tempos))
+  for musicxml_tempo, sequence_tempo in zip(
+      musicxml_tempos, sequence_proto.tempos):
+    self.assertAlmostEqual(musicxml_tempo.qpm, sequence_tempo.qpm)
+    self.assertAlmostEqual(musicxml_tempo.time_position,
+                           sequence_tempo.time)
+
+  # Test parts/instruments.
+  seq_parts = collections.defaultdict(list)
+  for seq_note in sequence_proto.notes:
+    seq_parts[seq_note.part].append(seq_note)
+
+  self.assertEqual(len(musicxml.parts), len(seq_parts))
+  for musicxml_part, seq_part_id in zip(
+      musicxml.parts, sorted(seq_parts.keys())):
+
+    seq_instrument_notes = seq_parts[seq_part_id]
+    musicxml_notes = []
+    for musicxml_measure in musicxml_part.measures:
+      for musicxml_note in musicxml_measure.notes:
+        if not musicxml_note.is_rest:
+          musicxml_notes.append(musicxml_note)
+
+    self.assertEqual(len(musicxml_notes), len(seq_instrument_notes))
+    for musicxml_note, sequence_note in zip(musicxml_notes,
+                                            seq_instrument_notes):
+      self.assertEqual(musicxml_note.pitch[1], sequence_note.pitch)
+      self.assertEqual(musicxml_note.velocity, sequence_note.velocity)
+      self.assertAlmostEqual(musicxml_note.note_duration.time_position,
+                             sequence_note.start_time)
+      self.assertAlmostEqual(musicxml_note.note_duration.time_position
+                             + musicxml_note.note_duration.seconds,
+                             sequence_note.end_time)
+      # Check that the duration specified in the MusicXML and the
+      # duration float match to within +/- 1 (delta = 1)
+      # Delta is used because duration in MusicXML is always an integer
+      # For example, a 3:2 half note might have a durationfloat of 341.333
+      # but would have the 1/3 distributed in the MusicXML as
+      # 341.0, 341.0, 342.0.
+      # Check that (3 * 341.333) = (341 + 341 + 342) is true by checking
+      # that 341.0 and 342.0 are +/- 1 of 341.333
+      self.assertAlmostEqual(
+          musicxml_note.note_duration.duration,
+          musicxml_note.state.divisions * 4
+          * musicxml_note.note_duration.duration_float(),
+          delta=1)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_to_sequence"><code class="name flex">
+<span>def <span class="ident">check_musicxml_to_sequence</span></span>(<span>self, filename)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from MusicXML to Sequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def check_musicxml_to_sequence(self, filename):
+  &#34;&#34;&#34;Test the translation from MusicXML to Sequence proto.&#34;&#34;&#34;
+  source_musicxml = musicxml_parser.MusicXMLDocument(filename)
+  sequence_proto = musicxml_reader.musicxml_to_sequence_proto(source_musicxml)
+  self.check_musicxml_and_sequence(source_musicxml, sequence_proto)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testFluteScale"><code class="name flex">
+<span>def <span class="ident">testFluteScale</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify properties of the flute scale.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFluteScale(self):
+  &#34;&#34;&#34;Verify properties of the flute scale.&#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.flute_scale_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures: {
+        numerator: 4
+        denominator: 4
+      }
+      tempos: {
+        qpm: 120
+      }
+      key_signatures: {
+        key: F
+      }
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      part_infos {
+        part: 0
+        name: &#34;Flute&#34;
+      }
+      total_time: 4.0
+      &#34;&#34;&#34;)
+  expected_pitches = [65, 67, 69, 70, 72, 74, 76, 77]
+  time = 0
+  for pitch in expected_pitches:
+    note = expected_ns.notes.add()
+    note.part = 0
+    note.voice = 1
+    note.pitch = pitch
+    note.start_time = time
+    time += .5
+    note.end_time = time
+    note.velocity = 64
+    note.numerator = 1
+    note.denominator = 4
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_alternating_meter"><code class="name flex">
+<span>def <span class="ident">test_alternating_meter</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_alternating_meter(self):
+  with self.assertRaises(musicxml_parser.AlternatingTimeSignatureError):
+    musicxml_parser.MusicXMLDocument(self.alternating_meter_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_atonal_transposition"><code class="name flex">
+<span>def <span class="ident">test_atonal_transposition</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test that transposition works when changing instrument transposition.</p>
+<p>This can occur within a single part in a score where the score
+has no key signature / is atonal. Examples include changing from a
+non-transposing instrument to a transposing one (ex. Flute to Bb Clarinet)
+or vice versa, or changing among transposing instruments (ex. Bb Clarinet
+to Eb Alto Saxophone).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_atonal_transposition(self):
+  &#34;&#34;&#34;Test that transposition works when changing instrument transposition.
+
+  This can occur within a single part in a score where the score
+  has no key signature / is atonal. Examples include changing from a
+  non-transposing instrument to a transposing one (ex. Flute to Bb Clarinet)
+  or vice versa, or changing among transposing instruments (ex. Bb Clarinet
+  to Eb Alto Saxophone).
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.atonal_transposition_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures: {
+        numerator: 4
+        denominator: 4
+      }
+      tempos: {
+        qpm: 120
+      }
+      key_signatures: {
+      }
+      part_infos {
+        part: 0
+        name: &#34;Flute&#34;
+      }
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      total_time: 4.0
+      &#34;&#34;&#34;)
+  expected_pitches = [72, 74, 76, 77, 79, 77, 76, 74]
+  time = 0
+  for pitch in expected_pitches:
+    note = expected_ns.notes.add()
+    note.pitch = pitch
+    note.start_time = time
+    time += .5
+    note.end_time = time
+    note.velocity = 64
+    note.numerator = 1
+    note.denominator = 4
+    note.voice = 1
+  self.maxDiff = None
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_beats_composite"><code class="name flex">
+<span>def <span class="ident">test_beats_composite</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_beats_composite(self):
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+        &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;2&lt;/divisions&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4+5&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+          &lt;/attributes&gt;
+          &lt;note&gt;
+            &lt;pitch&gt;
+              &lt;step&gt;G&lt;/step&gt;
+              &lt;octave&gt;4&lt;/octave&gt;
+            &lt;/pitch&gt;
+            &lt;duration&gt;2&lt;/duration&gt;
+            &lt;voice&gt;1&lt;/voice&gt;
+            &lt;type&gt;quarter&lt;/type&gt;
+          &lt;/note&gt;
+        &lt;/measure&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    with self.assertRaises(musicxml_parser.TimeSignatureParseError):
+      musicxml_parser.MusicXMLDocument(temp_file.name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_chord_symbols"><code class="name flex">
+<span>def <span class="ident">test_chord_symbols</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_chord_symbols(self):
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.chord_symbols_filename)
+  chord_symbols = [(annotation.time, annotation.text)
+                   for annotation in ns.text_annotations
+                   if annotation.annotation_type == CHORD_SYMBOL]
+  chord_symbols = list(sorted(chord_symbols, key=operator.itemgetter(0)))
+
+  expected_beats_and_chords = [
+      (0.0, &#39;N.C.&#39;),
+      (4.0, &#39;Cmaj7&#39;),
+      (12.0, &#39;F6(add9)&#39;),
+      (16.0, &#39;F#dim7/A&#39;),
+      (20.0, &#39;Bm7b5&#39;),
+      (24.0, &#39;E7(#9)&#39;),
+      (28.0, &#39;A7(add9)(no3)&#39;),
+      (32.0, &#39;Bbsus2&#39;),
+      (36.0, &#39;Am(maj7)&#39;),
+      (38.0, &#39;D13&#39;),
+      (40.0, &#39;E5&#39;),
+      (44.0, &#39;Caug&#39;)
+  ]
+
+  # Adjust for 120 QPM.
+  expected_times_and_chords = [(beat / 2.0, chord)
+                               for beat, chord in expected_beats_and_chords]
+  self.assertEqual(expected_times_and_chords, chord_symbols)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_archive"><code class="name flex">
+<span>def <span class="ident">test_empty_archive</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_empty_archive(self):
+  with tempfile.NamedTemporaryFile(suffix=&#39;.mxl&#39;) as temp_file:
+    z = zipfile.ZipFile(temp_file.name, &#39;w&#39;)
+    z.close()
+
+    with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+      musicxml_reader.musicxml_file_to_sequence_proto(
+          temp_file.name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_doc"><code class="name flex">
+<span>def <span class="ident">test_empty_doc</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify that an empty doc can be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_empty_doc(self):
+  &#34;&#34;&#34;Verify that an empty doc can be parsed.&#34;&#34;&#34;
+
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        temp_file.name)
+
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      key_signatures {
+        key: C
+        time: 0
+      }
+      tempos {
+        qpm: 120.0
+      }
+      total_time: 0.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_list"><code class="name flex">
+<span>def <span class="ident">test_empty_part_list</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify that a part without a corresponding score-part can be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_empty_part_list(self):
+  &#34;&#34;&#34;Verify that a part without a corresponding score-part can be parsed.&#34;&#34;&#34;
+
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        temp_file.name)
+
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      key_signatures {
+        key: C
+        time: 0
+      }
+      tempos {
+        qpm: 120.0
+      }
+      part_infos {
+        part: 0
+      }
+      total_time: 0.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_name"><code class="name flex">
+<span>def <span class="ident">test_empty_part_name</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify that a part with an empty name can be parsed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_empty_part_name(self):
+  &#34;&#34;&#34;Verify that a part with an empty name can be parsed.&#34;&#34;&#34;
+
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        temp_file.name)
+
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      key_signatures {
+        key: C
+        time: 0
+      }
+      tempos {
+        qpm: 120.0
+      }
+      part_infos {
+        part: 0
+      }
+      total_time: 0.0
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_harmony_missing_degree"><code class="name flex">
+<span>def <span class="ident">test_harmony_missing_degree</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_harmony_missing_degree(self):
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+        &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;2&lt;/divisions&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+          &lt;/attributes&gt;
+          &lt;note&gt;
+            &lt;pitch&gt;
+              &lt;step&gt;G&lt;/step&gt;
+              &lt;octave&gt;4&lt;/octave&gt;
+            &lt;/pitch&gt;
+            &lt;duration&gt;2&lt;/duration&gt;
+            &lt;voice&gt;1&lt;/voice&gt;
+            &lt;type&gt;quarter&lt;/type&gt;
+          &lt;/note&gt;
+          &lt;harmony&gt;
+            &lt;degree&gt;
+              &lt;!-- missing degree-value text --&gt;
+              &lt;degree-value&gt;&lt;/degree-value&gt;
+            &lt;/degree&gt;
+          &lt;/harmony&gt;
+        &lt;/measure&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    with self.assertRaises(musicxml_parser.ChordSymbolParseError):
+      musicxml_parser.MusicXMLDocument(temp_file.name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_incomplete_measures"><code class="name flex">
+<span>def <span class="ident">test_incomplete_measures</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test that incomplete measures have the correct time signature.</p>
+<p>This can occur in pickup bars or incomplete measures. For example,
+if the time signature in the MusicXML is 4/4, but the measure only
+contains one quarter note, Magenta expects this pickup measure to have
+a time signature of 1/4.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_incomplete_measures(self):
+  &#34;&#34;&#34;Test that incomplete measures have the correct time signature.
+
+  This can occur in pickup bars or incomplete measures. For example,
+  if the time signature in the MusicXML is 4/4, but the measure only
+  contains one quarter note, Magenta expects this pickup measure to have
+  a time signature of 1/4.
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.time_signature_filename)
+
+  # One time signature per measure
+  self.assertLen(ns.time_signatures, 6)
+  self.assertLen(ns.key_signatures, 1)
+  self.assertLen(ns.notes, 112)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_invalid_note_type"><code class="name flex">
+<span>def <span class="ident">test_invalid_note_type</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_invalid_note_type(self):
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+        &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;2&lt;/divisions&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+          &lt;/attributes&gt;
+          &lt;note&gt;
+            &lt;pitch&gt;
+              &lt;step&gt;G&lt;/step&gt;
+              &lt;octave&gt;4&lt;/octave&gt;
+            &lt;/pitch&gt;
+            &lt;duration&gt;2&lt;/duration&gt;
+            &lt;voice&gt;1&lt;/voice&gt;
+            &lt;type&gt;blarg&lt;/type&gt;
+          &lt;/note&gt;
+        &lt;/measure&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    with self.assertRaises(musicxml_parser.InvalidNoteDurationTypeError):
+      musicxml_parser.MusicXMLDocument(temp_file.name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_key_missing_fifths"><code class="name flex">
+<span>def <span class="ident">test_key_missing_fifths</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_key_missing_fifths(self):
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+        &lt;measure number=&#34;1&#34;&gt;
+          &lt;attributes&gt;
+            &lt;divisions&gt;2&lt;/divisions&gt;
+            &lt;key&gt;
+              &lt;!-- missing fifths element. --&gt;
+            &lt;/key&gt;
+            &lt;time&gt;
+              &lt;beats&gt;4&lt;/beats&gt;
+              &lt;beat-type&gt;4&lt;/beat-type&gt;
+            &lt;/time&gt;
+          &lt;/attributes&gt;
+          &lt;note&gt;
+            &lt;pitch&gt;
+              &lt;step&gt;G&lt;/step&gt;
+              &lt;octave&gt;4&lt;/octave&gt;
+            &lt;/pitch&gt;
+            &lt;duration&gt;2&lt;/duration&gt;
+            &lt;voice&gt;1&lt;/voice&gt;
+            &lt;type&gt;quarter&lt;/type&gt;
+          &lt;/note&gt;
+        &lt;/measure&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    with self.assertRaises(musicxml_parser.KeyParseError):
+      musicxml_parser.MusicXMLDocument(temp_file.name)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_meter"><code class="name flex">
+<span>def <span class="ident">test_meter</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test that meters are encoded properly.</p>
+<p>Musical meters are expressed as a ratio of beats to divisions.
+The MusicXML parser uses this ratio in lowest terms for timing
+purposes. However, the meters should be in the actual terms
+when appearing in a NoteSequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_meter(self):
+  &#34;&#34;&#34;Test that meters are encoded properly.
+
+  Musical meters are expressed as a ratio of beats to divisions.
+  The MusicXML parser uses this ratio in lowest terms for timing
+  purposes. However, the meters should be in the actual terms
+  when appearing in a NoteSequence.
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.meter_test_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures {
+        numerator: 1
+        denominator: 4
+      }
+      time_signatures {
+        time: 0.5
+        numerator: 2
+        denominator: 4
+      }
+      time_signatures {
+        time: 1.5
+        numerator: 3
+        denominator: 4
+      }
+      time_signatures {
+        time: 3.0
+        numerator: 4
+        denominator: 4
+      }
+      time_signatures {
+        time: 5.0
+        numerator: 5
+        denominator: 4
+      }
+      time_signatures {
+        time: 7.5
+        numerator: 6
+        denominator: 4
+      }
+      time_signatures {
+        time: 10.5
+        numerator: 7
+        denominator: 4
+      }
+      time_signatures {
+        time: 14.0
+        numerator: 1
+        denominator: 8
+      }
+      time_signatures {
+        time: 14.25
+        numerator: 2
+        denominator: 8
+      }
+      time_signatures {
+        time: 14.75
+        numerator: 3
+        denominator: 8
+      }
+      time_signatures {
+        time: 15.5
+        numerator: 4
+        denominator: 8
+      }
+      time_signatures {
+        time: 16.5
+        numerator: 5
+        denominator: 8
+      }
+      time_signatures {
+        time: 17.75
+        numerator: 6
+        denominator: 8
+      }
+      time_signatures {
+        time: 19.25
+        numerator: 7
+        denominator: 8
+      }
+      time_signatures {
+        time: 21.0
+        numerator: 8
+        denominator: 8
+      }
+      time_signatures {
+        time: 23.0
+        numerator: 9
+        denominator: 8
+      }
+      time_signatures {
+        time: 25.25
+        numerator: 10
+        denominator: 8
+      }
+      time_signatures {
+        time: 27.75
+        numerator: 11
+        denominator: 8
+      }
+      time_signatures {
+        time: 30.5
+        numerator: 12
+        denominator: 8
+      }
+      time_signatures {
+        time: 33.5
+        numerator: 2
+        denominator: 2
+      }
+      time_signatures {
+        time: 35.5
+        numerator: 3
+        denominator: 2
+      }
+      time_signatures {
+        time: 38.5
+        numerator: 4
+        denominator: 2
+      }
+      time_signatures {
+        time: 42.5
+        numerator: 4
+        denominator: 4
+      }
+      time_signatures {
+        time: 44.5
+        numerator: 2
+        denominator: 2
+      }
+      key_signatures {
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        end_time: 0.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 0.5
+        end_time: 1.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 1.5
+        end_time: 3.0
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 3.0
+        end_time: 5.0
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 5.0
+        end_time: 6.5
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 6.5
+        end_time: 7.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 7.5
+        end_time: 9.0
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 9.0
+        end_time: 10.5
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 10.5
+        end_time: 12.0
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 12.0
+        end_time: 13.5
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 13.5
+        end_time: 14.0
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 14.0
+        end_time: 14.25
+        numerator: 1
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 14.25
+        end_time: 14.75
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 14.75
+        end_time: 15.5
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 15.5
+        end_time: 16.0
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 16.0
+        end_time: 16.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 16.5
+        end_time: 17.0
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 17.0
+        end_time: 17.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 17.5
+        end_time: 17.75
+        numerator: 1
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 17.75
+        end_time: 18.5
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 18.5
+        end_time: 19.25
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 19.25
+        end_time: 20.0
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 20.0
+        end_time: 20.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 20.5
+        end_time: 21.0
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 21.0
+        end_time: 21.75
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 21.75
+        end_time: 22.5
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 22.5
+        end_time: 23.0
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 23.0
+        end_time: 24.5
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 24.5
+        end_time: 25.25
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 25.25
+        end_time: 26.75
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 26.75
+        end_time: 27.25
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 27.25
+        end_time: 27.75
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 27.75
+        end_time: 29.25
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 29.25
+        end_time: 30.0
+        numerator: 3
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 30.0
+        end_time: 30.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 30.5
+        end_time: 32.0
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 32.0
+        end_time: 33.5
+        numerator: 3
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 33.5
+        end_time: 34.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 34.5
+        end_time: 35.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 35.5
+        end_time: 36.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 36.5
+        end_time: 37.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 37.5
+        end_time: 38.5
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 38.5
+        end_time: 40.5
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 40.5
+        end_time: 42.5
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 42.5
+        end_time: 44.5
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 44.5
+        end_time: 46.5
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      total_time: 46.5
+      part_infos {
+        name: &#34;Flute&#34;
+      }
+      source_info {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_mid_measure_meter_change"><code class="name flex">
+<span>def <span class="ident">test_mid_measure_meter_change</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_mid_measure_meter_change(self):
+  with self.assertRaises(musicxml_parser.MultipleTimeSignatureError):
+    musicxml_parser.MusicXMLDocument(self.mid_measure_meter_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_st_anne"><code class="name flex">
+<span>def <span class="ident">test_st_anne</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify properties of the St. Anne file.</p>
+<p>The file contains 2 parts and 4 voices.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_st_anne(self):
+  &#34;&#34;&#34;Verify properties of the St. Anne file.
+
+  The file contains 2 parts and 4 voices.
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.st_anne_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures {
+        numerator: 1
+        denominator: 4
+      }
+      time_signatures {
+        time: 0.5
+        numerator: 4
+        denominator: 4
+      }
+      time_signatures {
+        time: 6.5
+        numerator: 3
+        denominator: 4
+      }
+      time_signatures {
+        time: 8.0
+        numerator: 1
+        denominator: 4
+      }
+      time_signatures {
+        time: 8.5
+        numerator: 4
+        denominator: 4
+      }
+      time_signatures {
+        time: 14.5
+        numerator: 3
+        denominator: 4
+      }
+      tempos: {
+        qpm: 120
+      }
+      key_signatures: {
+        key: C
+      }
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      part_infos {
+        part: 0
+        name: &#34;Harpsichord&#34;
+      }
+      part_infos {
+        part: 1
+        name: &#34;Piano&#34;
+      }
+      total_time: 16.0
+      &#34;&#34;&#34;)
+  pitches_0_1 = [
+      (67, .5),
+
+      (64, .5),
+      (69, .5),
+      (67, .5),
+      (72, .5),
+
+      (72, .5),
+      (71, .5),
+      (72, .5),
+      (67, .5),
+
+      (72, .5),
+      (67, .5),
+      (69, .5),
+      (66, .5),
+
+      (67, 1.5),
+
+      (71, .5),
+
+      (72, .5),
+      (69, .5),
+      (74, .5),
+      (71, .5),
+
+      (72, .5),
+      (69, .5),
+      (71, .5),
+      (67, .5),
+
+      (69, .5),
+      (72, .5),
+      (74, .5),
+      (71, .5),
+
+      (72, 1.5),
+  ]
+  pitches_0_2 = [
+      (60, .5),
+
+      (60, .5),
+      (60, .5),
+      (60, .5),
+      (64, .5),
+
+      (62, .5),
+      (62, .5),
+      (64, .5),
+      (64, .5),
+
+      (64, .5),
+      (64, .5),
+      (64, .5),
+      (62, .5),
+
+      (62, 1.5),
+
+      (62, .5),
+
+      (64, .5),
+      (60, .5),
+      (65, .5),
+      (62, .5),
+
+      (64, .75),
+      (62, .25),
+      (59, .5),
+      (60, .5),
+
+      (65, .5),
+      (64, .5),
+      (62, .5),
+      (62, .5),
+
+      (64, 1.5),
+  ]
+  pitches_1_1 = [
+      (52, .5),
+
+      (55, .5),
+      (57, .5),
+      (60, .5),
+      (60, .5),
+
+      (57, .5),
+      (55, .5),
+      (55, .5),
+      (60, .5),
+
+      (60, .5),
+      (59, .5),
+      (57, .5),
+      (57, .5),
+
+      (59, 1.5),
+
+      (55, .5),
+
+      (55, .5),
+      (57, .5),
+      (57, .5),
+      (55, .5),
+
+      (55, .5),
+      (57, .5),
+      (56, .5),
+      (55, .5),
+
+      (53, .5),
+      (55, .5),
+      (57, .5),
+      (55, .5),
+
+      (55, 1.5),
+  ]
+  pitches_1_2 = [
+      (48, .5),
+
+      (48, .5),
+      (53, .5),
+      (52, .5),
+      (57, .5),
+
+      (53, .5),
+      (55, .5),
+      (48, .5),
+      (48, .5),
+
+      (45, .5),
+      (52, .5),
+      (48, .5),
+      (50, .5),
+
+      (43, 1.5),
+
+      (55, .5),
+
+      (48, .5),
+      (53, .5),
+      (50, .5),
+      (55, .5),
+
+      (48, .5),
+      (53, .5),
+      (52, .5),
+      (52, .5),
+
+      (50, .5),
+      (48, .5),
+      (53, .5),
+      (55, .5),
+
+      (48, 1.5),
+  ]
+  part_voice_instrument_program_pitches = [
+      (0, 1, 1, 7, pitches_0_1),
+      (0, 2, 1, 7, pitches_0_2),
+      (1, 1, 2, 1, pitches_1_1),
+      (1, 2, 2, 1, pitches_1_2),
+  ]
+  for part, voice, instrument, program, pitches in (
+      part_voice_instrument_program_pitches):
+    time = 0
+    for pitch, duration in pitches:
+      note = expected_ns.notes.add()
+      note.part = part
+      note.voice = voice
+      note.pitch = pitch
+      note.start_time = time
+      time += duration
+      note.end_time = time
+      note.velocity = 64
+      note.instrument = instrument
+      note.program = program
+      if duration == .5:
+        note.numerator = 1
+        note.denominator = 4
+      if duration == .25:
+        note.numerator = 1
+        note.denominator = 8
+      if duration == .75:
+        note.numerator = 3
+        note.denominator = 8
+      if duration == 1.5:
+        note.numerator = 3
+        note.denominator = 4
+  expected_ns.notes.sort(
+      key=lambda note: (note.part, note.voice, note.start_time))
+  ns.notes.sort(
+      key=lambda note: (note.part, note.voice, note.start_time))
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_transposed_keysig"><code class="name flex">
+<span>def <span class="ident">test_transposed_keysig</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_transposed_keysig(self):
+  xml = br&#34;&#34;&#34;&lt;?xml version=&#34;1.0&#34; encoding=&#34;UTF-8&#34; standalone=&#34;no&#34;?&gt;
+    &lt;!DOCTYPE score-partwise PUBLIC
+        &#34;-//Recordare//DTD MusicXML 3.0 Partwise//EN&#34;
+        &#34;http://www.musicxml.org/dtds/partwise.dtd&#34;&gt;
+    &lt;score-partwise version=&#34;3.0&#34;&gt;
+      &lt;part-list&gt;
+        &lt;score-part id=&#34;P1&#34;&gt;
+          &lt;part-name/&gt;
+        &lt;/score-part&gt;
+      &lt;/part-list&gt;
+      &lt;part id=&#34;P1&#34;&gt;
+        &lt;measure number=&#34;1&#34;&gt;
+        &lt;attributes&gt;
+          &lt;divisions&gt;4&lt;/divisions&gt;
+          &lt;key&gt;
+            &lt;fifths&gt;-3&lt;/fifths&gt;
+            &lt;mode&gt;major&lt;/mode&gt;
+          &lt;/key&gt;
+          &lt;time&gt;
+            &lt;beats&gt;4&lt;/beats&gt;
+            &lt;beat-type&gt;4&lt;/beat-type&gt;
+          &lt;/time&gt;
+          &lt;clef&gt;
+            &lt;sign&gt;G&lt;/sign&gt;
+            &lt;line&gt;2&lt;/line&gt;
+          &lt;/clef&gt;
+          &lt;transpose&gt;
+            &lt;diatonic&gt;-5&lt;/diatonic&gt;
+            &lt;chromatic&gt;-9&lt;/chromatic&gt;
+          &lt;/transpose&gt;
+          &lt;/attributes&gt;
+          &lt;note&gt;
+            &lt;pitch&gt;
+              &lt;step&gt;G&lt;/step&gt;
+              &lt;octave&gt;4&lt;/octave&gt;
+            &lt;/pitch&gt;
+            &lt;duration&gt;2&lt;/duration&gt;
+            &lt;voice&gt;1&lt;/voice&gt;
+            &lt;type&gt;quarter&lt;/type&gt;
+          &lt;/note&gt;
+        &lt;/measure&gt;
+      &lt;/part&gt;
+    &lt;/score-partwise&gt;
+  &#34;&#34;&#34;
+  with tempfile.NamedTemporaryFile() as temp_file:
+    temp_file.write(xml)
+    temp_file.flush()
+    musicxml_parser.MusicXMLDocument(temp_file.name)
+    sequence = musicxml_reader.musicxml_file_to_sequence_proto(temp_file.name)
+    self.assertLen(sequence.key_signatures, 1)
+    self.assertEqual(music_pb2.NoteSequence.KeySignature.G_FLAT,
+                     sequence.key_signatures[0].key)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_unmetered_music"><code class="name flex">
+<span>def <span class="ident">test_unmetered_music</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test that time signatures are inserted for music without time signatures.</p>
+<p>MusicXML does not require the use of time signatures. Music without
+time signatures occur in medieval chant, cadenzas, and contemporary music.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_unmetered_music(self):
+  &#34;&#34;&#34;Test that time signatures are inserted for music without time signatures.
+
+  MusicXML does not require the use of time signatures. Music without
+  time signatures occur in medieval chant, cadenzas, and contemporary music.
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.unmetered_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures: {
+        numerator: 11
+        denominator: 8
+      }
+      tempos: {
+        qpm: 120
+      }
+      key_signatures: {
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        end_time: 0.5
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 74
+        velocity: 64
+        start_time: 0.5
+        end_time: 0.75
+        numerator: 1
+        denominator: 8
+        voice: 1
+      }
+      notes {
+        pitch: 76
+        velocity: 64
+        start_time: 0.75
+        end_time: 1.25
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 77
+        velocity: 64
+        start_time: 1.25
+        end_time: 1.75
+        numerator: 1
+        denominator: 4
+        voice: 1
+      }
+      notes {
+        pitch: 79
+        velocity: 64
+        start_time: 1.75
+        end_time: 2.75
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      part_infos {
+        name: &#34;Flute&#34;
+      }
+      source_info: {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      total_time: 2.75
+      &#34;&#34;&#34;)
+  self.maxDiff = None
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_unpitched_notes"><code class="name flex">
+<span>def <span class="ident">test_unpitched_notes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_unpitched_notes(self):
+  with self.assertRaises(musicxml_parser.UnpitchedNoteError):
+    musicxml_parser.MusicXMLDocument(os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))
+  with self.assertRaises(musicxml_reader.MusicXMLConversionError):
+    musicxml_reader.musicxml_file_to_sequence_proto(os.path.join(
+        testing_lib.get_testdata_dir(), &#39;unpitched.xml&#39;))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.test_whole_measure_rest_forward"><code class="name flex">
+<span>def <span class="ident">test_whole_measure_rest_forward</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test that a whole measure rest can be encoded using <forward>.</p>
+<p>A whole measure rest is usually encoded as a <note> with a duration
+equal to that of a whole measure. An alternative encoding is to
+use the <forward> element to advance the time cursor to a duration
+equal to that of a whole measure. This implies a whole measure rest
+when there are no <note> elements in this measure.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def test_whole_measure_rest_forward(self):
+  &#34;&#34;&#34;Test that a whole measure rest can be encoded using &lt;forward&gt;.
+
+  A whole measure rest is usually encoded as a &lt;note&gt; with a duration
+  equal to that of a whole measure. An alternative encoding is to
+  use the &lt;forward&gt; element to advance the time cursor to a duration
+  equal to that of a whole measure. This implies a whole measure rest
+  when there are no &lt;note&gt; elements in this measure.
+  &#34;&#34;&#34;
+  ns = musicxml_reader.musicxml_file_to_sequence_proto(
+      self.whole_measure_rest_forward_filename)
+  expected_ns = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      ticks_per_quarter: 220
+      time_signatures {
+        numerator: 4
+        denominator: 4
+      }
+      time_signatures {
+        time: 6.0
+        numerator: 2
+        denominator: 4
+      }
+      key_signatures {
+      }
+      tempos {
+        qpm: 120
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        end_time: 2.0
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 72
+        velocity: 64
+        start_time: 4.0
+        end_time: 6.0
+        numerator: 1
+        denominator: 1
+        voice: 1
+      }
+      notes {
+        pitch: 60
+        velocity: 64
+        start_time: 6.0
+        end_time: 7.0
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      notes {
+        pitch: 60
+        velocity: 64
+        start_time: 8.0
+        end_time: 9.0
+        numerator: 1
+        denominator: 2
+        voice: 1
+      }
+      total_time: 9.0
+      part_infos {
+        name: &#34;Flute&#34;
+      }
+      source_info {
+        source_type: SCORE_BASED
+        encoding_type: MUSIC_XML
+        parser: MAGENTA_MUSIC_XML
+      }
+      &#34;&#34;&#34;)
+  self.assertProtoEquals(expected_ns, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testcomplexmusicxmltosequence"><code class="name flex">
+<span>def <span class="ident">testcomplexmusicxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the complex band score MusicXML file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testcomplexmusicxmltosequence(self):
+  &#34;&#34;&#34;Test the complex band score MusicXML file.&#34;&#34;&#34;
+  self.check_musicxml_to_sequence(self.band_score_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedmxlunicodefilename"><code class="name flex">
+<span>def <span class="ident">testcompressedmxlunicodefilename</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test an MXL file containing a unicode filename within its zip archive.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testcompressedmxlunicodefilename(self):
+  &#34;&#34;&#34;Test an MXL file containing a unicode filename within its zip archive.&#34;&#34;&#34;
+
+  unicode_filename = os.path.join(
+      testing_lib.get_testdata_dir(), &#39;unicode_filename.mxl&#39;)
+  sequence = musicxml_reader.musicxml_file_to_sequence_proto(unicode_filename)
+  self.assertLen(sequence.notes, 8)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedxmltosequence"><code class="name flex">
+<span>def <span class="ident">testcompressedxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from compressed MusicXML to Sequence proto.</p>
+<p>Compare a compressed MusicXML file to an identical uncompressed sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testcompressedxmltosequence(self):
+  &#34;&#34;&#34;Test the translation from compressed MusicXML to Sequence proto.
+
+  Compare a compressed MusicXML file to an identical uncompressed sequence.
+  &#34;&#34;&#34;
+  uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.flute_scale_filename)
+  compressed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.compressed_filename)
+  uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+      uncompressed_musicxml)
+  self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+  self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testmultiplecompressedxmltosequence"><code class="name flex">
+<span>def <span class="ident">testmultiplecompressedxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from compressed MusicXML with multiple rootfiles.</p>
+<p>The example MXL file contains a MusicXML file of the Flute F Major scale,
+as well as the PNG rendering of the score contained within the single MXL
+file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testmultiplecompressedxmltosequence(self):
+  &#34;&#34;&#34;Test the translation from compressed MusicXML with multiple rootfiles.
+
+  The example MXL file contains a MusicXML file of the Flute F Major scale,
+  as well as the PNG rendering of the score contained within the single MXL
+  file.
+  &#34;&#34;&#34;
+  uncompressed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.flute_scale_filename)
+  compressed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.multiple_rootfile_compressed_filename)
+  uncompressed_proto = musicxml_reader.musicxml_to_sequence_proto(
+      uncompressed_musicxml)
+  self.check_musicxml_and_sequence(compressed_musicxml, uncompressed_proto)
+  self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testrhythmdurationsxmltosequence"><code class="name flex">
+<span>def <span class="ident">testrhythmdurationsxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the rhythm durations MusicXML file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testrhythmdurationsxmltosequence(self):
+  &#34;&#34;&#34;Test the rhythm durations MusicXML file.&#34;&#34;&#34;
+  self.check_musicxml_to_sequence(self.rhythm_durations_filename)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testsimplemusicxmltosequence"><code class="name flex">
+<span>def <span class="ident">testsimplemusicxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the simple flute scale MusicXML file.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testsimplemusicxmltosequence(self):
+  &#34;&#34;&#34;Test the simple flute scale MusicXML file.&#34;&#34;&#34;
+  self.check_musicxml_to_sequence(self.flute_scale_filename)
+  self.check_fmajor_scale(self.flute_scale_filename, &#39;Flute&#39;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_parser_test.MusicXMLParserTest.testtransposedxmltosequence"><code class="name flex">
+<span>def <span class="ident">testtransposedxmltosequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test the translation from transposed MusicXML to Sequence proto.</p>
+<p>Compare a transposed MusicXML file (clarinet) to an identical untransposed
+sequence (flute).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testtransposedxmltosequence(self):
+  &#34;&#34;&#34;Test the translation from transposed MusicXML to Sequence proto.
+
+  Compare a transposed MusicXML file (clarinet) to an identical untransposed
+  sequence (flute).
+  &#34;&#34;&#34;
+  untransposed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.flute_scale_filename)
+  transposed_musicxml = musicxml_parser.MusicXMLDocument(
+      self.clarinet_scale_filename)
+  untransposed_proto = musicxml_reader.musicxml_to_sequence_proto(
+      untransposed_musicxml)
+  self.check_musicxml_and_sequence(transposed_musicxml, untransposed_proto)
+  self.check_fmajor_scale(self.clarinet_scale_filename, &#39;Clarinet in Bb&#39;)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest" href="#note_seq.musicxml_parser_test.MusicXMLParserTest">MusicXMLParserTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.check_fmajor_scale" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.check_fmajor_scale">check_fmajor_scale</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_and_sequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_and_sequence">check_musicxml_and_sequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_to_sequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.check_musicxml_to_sequence">check_musicxml_to_sequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testFluteScale" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testFluteScale">testFluteScale</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_alternating_meter" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_alternating_meter">test_alternating_meter</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_atonal_transposition" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_atonal_transposition">test_atonal_transposition</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_beats_composite" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_beats_composite">test_beats_composite</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_chord_symbols" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_chord_symbols">test_chord_symbols</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_archive" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_archive">test_empty_archive</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_doc" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_doc">test_empty_doc</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_list" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_list">test_empty_part_list</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_name" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_empty_part_name">test_empty_part_name</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_harmony_missing_degree" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_harmony_missing_degree">test_harmony_missing_degree</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_incomplete_measures" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_incomplete_measures">test_incomplete_measures</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_invalid_note_type" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_invalid_note_type">test_invalid_note_type</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_key_missing_fifths" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_key_missing_fifths">test_key_missing_fifths</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_meter" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_meter">test_meter</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_mid_measure_meter_change" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_mid_measure_meter_change">test_mid_measure_meter_change</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_st_anne" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_st_anne">test_st_anne</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_transposed_keysig" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_transposed_keysig">test_transposed_keysig</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_unmetered_music" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_unmetered_music">test_unmetered_music</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_unpitched_notes" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_unpitched_notes">test_unpitched_notes</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.test_whole_measure_rest_forward" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.test_whole_measure_rest_forward">test_whole_measure_rest_forward</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testcomplexmusicxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testcomplexmusicxmltosequence">testcomplexmusicxmltosequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedmxlunicodefilename" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedmxlunicodefilename">testcompressedmxlunicodefilename</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testcompressedxmltosequence">testcompressedxmltosequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testmultiplecompressedxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testmultiplecompressedxmltosequence">testmultiplecompressedxmltosequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testrhythmdurationsxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testrhythmdurationsxmltosequence">testrhythmdurationsxmltosequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testsimplemusicxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testsimplemusicxmltosequence">testsimplemusicxmltosequence</a></code></li>
+<li><code><a title="note_seq.musicxml_parser_test.MusicXMLParserTest.testtransposedxmltosequence" href="#note_seq.musicxml_parser_test.MusicXMLParserTest.testtransposedxmltosequence">testtransposedxmltosequence</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/musicxml_reader.html
+++ b/docs/musicxml_reader.html
@@ -1,0 +1,402 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.musicxml_reader API documentation</title>
+<meta name="description" content="MusicXML import …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.musicxml_reader</code></h1>
+</header>
+<section id="section-intro">
+<p>MusicXML import.</p>
+<p>Input wrappers for converting MusicXML into NoteSequence.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;MusicXML import.
+
+Input wrappers for converting MusicXML into NoteSequence.
+&#34;&#34;&#34;
+
+from note_seq import musicxml_parser
+from note_seq.protobuf import music_pb2
+
+# Shortcut to CHORD_SYMBOL annotation type.
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+class MusicXMLConversionError(Exception):
+  &#34;&#34;&#34;MusicXML conversion error handler.&#34;&#34;&#34;
+  pass
+
+
+def musicxml_to_sequence_proto(musicxml_document):
+  &#34;&#34;&#34;Convert MusicXML file contents to a NoteSequence proto.
+
+  Converts a MusicXML file encoded as a string into a NoteSequence proto.
+
+  Args:
+    musicxml_document: A parsed MusicXML file. This file has been parsed by
+      class MusicXMLDocument
+
+  Returns:
+    A NoteSequence proto.
+
+  Raises:
+    MusicXMLConversionError: An error occurred when parsing the MusicXML file.
+  &#34;&#34;&#34;
+  sequence = music_pb2.NoteSequence()
+
+  # Standard MusicXML fields.
+  sequence.source_info.source_type = (
+      music_pb2.NoteSequence.SourceInfo.SCORE_BASED)
+  sequence.source_info.encoding_type = (
+      music_pb2.NoteSequence.SourceInfo.MUSIC_XML)
+  sequence.source_info.parser = (
+      music_pb2.NoteSequence.SourceInfo.MAGENTA_MUSIC_XML)
+
+  # Populate header.
+  sequence.ticks_per_quarter = musicxml_document.midi_resolution
+
+  # Populate time signatures.
+  musicxml_time_signatures = musicxml_document.get_time_signatures()
+  for musicxml_time_signature in musicxml_time_signatures:
+    time_signature = sequence.time_signatures.add()
+    time_signature.time = musicxml_time_signature.time_position
+    time_signature.numerator = musicxml_time_signature.numerator
+    time_signature.denominator = musicxml_time_signature.denominator
+
+  # Populate key signatures.
+  musicxml_key_signatures = musicxml_document.get_key_signatures()
+  for musicxml_key in musicxml_key_signatures:
+    key_signature = sequence.key_signatures.add()
+    key_signature.time = musicxml_key.time_position
+    # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
+    # Convert from MIDI / MusicXML key to music.proto key
+    music_proto_keys = [11, 6, 1, 8, 3, 10, 5, 0, 7, 2, 9, 4, 11, 6, 1]
+    key_signature.key = music_proto_keys[musicxml_key.key + 7]
+    if musicxml_key.mode == &#34;major&#34;:
+      key_signature.mode = key_signature.MAJOR
+    elif musicxml_key.mode == &#34;minor&#34;:
+      key_signature.mode = key_signature.MINOR
+
+  # Populate tempo changes.
+  musicxml_tempos = musicxml_document.get_tempos()
+  for musicxml_tempo in musicxml_tempos:
+    tempo = sequence.tempos.add()
+    tempo.time = musicxml_tempo.time_position
+    tempo.qpm = musicxml_tempo.qpm
+
+  # Populate notes from each MusicXML part across all voices
+  # Unlike MIDI import, notes are not sorted
+  sequence.total_time = musicxml_document.total_time_secs
+  for part_index, musicxml_part in enumerate(musicxml_document.parts):
+    part_info = sequence.part_infos.add()
+    part_info.part = part_index
+    part_info.name = musicxml_part.score_part.part_name
+
+    for musicxml_measure in musicxml_part.measures:
+      for musicxml_note in musicxml_measure.notes:
+        if not musicxml_note.is_rest:
+          note = sequence.notes.add()
+          note.part = part_index
+          note.voice = musicxml_note.voice
+          note.instrument = musicxml_note.midi_channel
+          note.program = musicxml_note.midi_program
+          note.start_time = musicxml_note.note_duration.time_position
+
+          # Fix negative time errors from incorrect MusicXML
+          note.start_time = max(note.start_time, 0)
+
+          note.end_time = note.start_time + musicxml_note.note_duration.seconds
+          note.pitch = musicxml_note.pitch[1]  # Index 1 = MIDI pitch number
+          note.velocity = musicxml_note.velocity
+
+          durationratio = musicxml_note.note_duration.duration_ratio()
+          note.numerator = durationratio.numerator
+          note.denominator = durationratio.denominator
+
+  musicxml_chord_symbols = musicxml_document.get_chord_symbols()
+  for musicxml_chord_symbol in musicxml_chord_symbols:
+    text_annotation = sequence.text_annotations.add()
+    text_annotation.time = musicxml_chord_symbol.time_position
+    text_annotation.text = musicxml_chord_symbol.get_figure_string()
+    text_annotation.annotation_type = CHORD_SYMBOL
+
+  return sequence
+
+
+def musicxml_file_to_sequence_proto(musicxml_file):
+  &#34;&#34;&#34;Converts a MusicXML file to a NoteSequence proto.
+
+  Args:
+    musicxml_file: A string path to a MusicXML file.
+
+  Returns:
+    A NoteSequence proto.
+
+  Raises:
+    MusicXMLConversionError: Invalid musicxml_file.
+  &#34;&#34;&#34;
+  try:
+    musicxml_document = musicxml_parser.MusicXMLDocument(musicxml_file)
+  except musicxml_parser.MusicXMLParseError as e:
+    raise MusicXMLConversionError(e)
+  return musicxml_to_sequence_proto(musicxml_document)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.musicxml_reader.musicxml_file_to_sequence_proto"><code class="name flex">
+<span>def <span class="ident">musicxml_file_to_sequence_proto</span></span>(<span>musicxml_file)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts a MusicXML file to a NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>musicxml_file</code></strong></dt>
+<dd>A string path to a MusicXML file.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.musicxml_reader.MusicXMLConversionError" href="#note_seq.musicxml_reader.MusicXMLConversionError">MusicXMLConversionError</a></code></dt>
+<dd>Invalid musicxml_file.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def musicxml_file_to_sequence_proto(musicxml_file):
+  &#34;&#34;&#34;Converts a MusicXML file to a NoteSequence proto.
+
+  Args:
+    musicxml_file: A string path to a MusicXML file.
+
+  Returns:
+    A NoteSequence proto.
+
+  Raises:
+    MusicXMLConversionError: Invalid musicxml_file.
+  &#34;&#34;&#34;
+  try:
+    musicxml_document = musicxml_parser.MusicXMLDocument(musicxml_file)
+  except musicxml_parser.MusicXMLParseError as e:
+    raise MusicXMLConversionError(e)
+  return musicxml_to_sequence_proto(musicxml_document)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.musicxml_reader.musicxml_to_sequence_proto"><code class="name flex">
+<span>def <span class="ident">musicxml_to_sequence_proto</span></span>(<span>musicxml_document)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert MusicXML file contents to a NoteSequence proto.</p>
+<p>Converts a MusicXML file encoded as a string into a NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>musicxml_document</code></strong></dt>
+<dd>A parsed MusicXML file. This file has been parsed by
+class MusicXMLDocument</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.musicxml_reader.MusicXMLConversionError" href="#note_seq.musicxml_reader.MusicXMLConversionError">MusicXMLConversionError</a></code></dt>
+<dd>An error occurred when parsing the MusicXML file.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def musicxml_to_sequence_proto(musicxml_document):
+  &#34;&#34;&#34;Convert MusicXML file contents to a NoteSequence proto.
+
+  Converts a MusicXML file encoded as a string into a NoteSequence proto.
+
+  Args:
+    musicxml_document: A parsed MusicXML file. This file has been parsed by
+      class MusicXMLDocument
+
+  Returns:
+    A NoteSequence proto.
+
+  Raises:
+    MusicXMLConversionError: An error occurred when parsing the MusicXML file.
+  &#34;&#34;&#34;
+  sequence = music_pb2.NoteSequence()
+
+  # Standard MusicXML fields.
+  sequence.source_info.source_type = (
+      music_pb2.NoteSequence.SourceInfo.SCORE_BASED)
+  sequence.source_info.encoding_type = (
+      music_pb2.NoteSequence.SourceInfo.MUSIC_XML)
+  sequence.source_info.parser = (
+      music_pb2.NoteSequence.SourceInfo.MAGENTA_MUSIC_XML)
+
+  # Populate header.
+  sequence.ticks_per_quarter = musicxml_document.midi_resolution
+
+  # Populate time signatures.
+  musicxml_time_signatures = musicxml_document.get_time_signatures()
+  for musicxml_time_signature in musicxml_time_signatures:
+    time_signature = sequence.time_signatures.add()
+    time_signature.time = musicxml_time_signature.time_position
+    time_signature.numerator = musicxml_time_signature.numerator
+    time_signature.denominator = musicxml_time_signature.denominator
+
+  # Populate key signatures.
+  musicxml_key_signatures = musicxml_document.get_key_signatures()
+  for musicxml_key in musicxml_key_signatures:
+    key_signature = sequence.key_signatures.add()
+    key_signature.time = musicxml_key.time_position
+    # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
+    # Convert from MIDI / MusicXML key to music.proto key
+    music_proto_keys = [11, 6, 1, 8, 3, 10, 5, 0, 7, 2, 9, 4, 11, 6, 1]
+    key_signature.key = music_proto_keys[musicxml_key.key + 7]
+    if musicxml_key.mode == &#34;major&#34;:
+      key_signature.mode = key_signature.MAJOR
+    elif musicxml_key.mode == &#34;minor&#34;:
+      key_signature.mode = key_signature.MINOR
+
+  # Populate tempo changes.
+  musicxml_tempos = musicxml_document.get_tempos()
+  for musicxml_tempo in musicxml_tempos:
+    tempo = sequence.tempos.add()
+    tempo.time = musicxml_tempo.time_position
+    tempo.qpm = musicxml_tempo.qpm
+
+  # Populate notes from each MusicXML part across all voices
+  # Unlike MIDI import, notes are not sorted
+  sequence.total_time = musicxml_document.total_time_secs
+  for part_index, musicxml_part in enumerate(musicxml_document.parts):
+    part_info = sequence.part_infos.add()
+    part_info.part = part_index
+    part_info.name = musicxml_part.score_part.part_name
+
+    for musicxml_measure in musicxml_part.measures:
+      for musicxml_note in musicxml_measure.notes:
+        if not musicxml_note.is_rest:
+          note = sequence.notes.add()
+          note.part = part_index
+          note.voice = musicxml_note.voice
+          note.instrument = musicxml_note.midi_channel
+          note.program = musicxml_note.midi_program
+          note.start_time = musicxml_note.note_duration.time_position
+
+          # Fix negative time errors from incorrect MusicXML
+          note.start_time = max(note.start_time, 0)
+
+          note.end_time = note.start_time + musicxml_note.note_duration.seconds
+          note.pitch = musicxml_note.pitch[1]  # Index 1 = MIDI pitch number
+          note.velocity = musicxml_note.velocity
+
+          durationratio = musicxml_note.note_duration.duration_ratio()
+          note.numerator = durationratio.numerator
+          note.denominator = durationratio.denominator
+
+  musicxml_chord_symbols = musicxml_document.get_chord_symbols()
+  for musicxml_chord_symbol in musicxml_chord_symbols:
+    text_annotation = sequence.text_annotations.add()
+    text_annotation.time = musicxml_chord_symbol.time_position
+    text_annotation.text = musicxml_chord_symbol.get_figure_string()
+    text_annotation.annotation_type = CHORD_SYMBOL
+
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.musicxml_reader.MusicXMLConversionError"><code class="flex name class">
+<span>class <span class="ident">MusicXMLConversionError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>MusicXML conversion error handler.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MusicXMLConversionError(Exception):
+  &#34;&#34;&#34;MusicXML conversion error handler.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.musicxml_reader.musicxml_file_to_sequence_proto" href="#note_seq.musicxml_reader.musicxml_file_to_sequence_proto">musicxml_file_to_sequence_proto</a></code></li>
+<li><code><a title="note_seq.musicxml_reader.musicxml_to_sequence_proto" href="#note_seq.musicxml_reader.musicxml_to_sequence_proto">musicxml_to_sequence_proto</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.musicxml_reader.MusicXMLConversionError" href="#note_seq.musicxml_reader.MusicXMLConversionError">MusicXMLConversionError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/notebook_utils.html
+++ b/docs/notebook_utils.html
@@ -1,0 +1,528 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.notebook_utils API documentation</title>
+<meta name="description" content="Python functions which run only within a Jupyter or Colab notebook." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.notebook_utils</code></h1>
+</header>
+<section id="section-intro">
+<p>Python functions which run only within a Jupyter or Colab notebook.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+&#34;&#34;&#34;Python functions which run only within a Jupyter or Colab notebook.&#34;&#34;&#34;
+
+import base64
+import collections
+import functools
+import io
+import os
+import urllib
+
+import bokeh
+import bokeh.plotting
+from IPython import display
+from note_seq import midi_synth
+import numpy as np
+import pandas as pd
+from scipy.io import wavfile
+
+makedirs = functools.partial(os.makedirs, exist_ok=True)
+
+
+_DEFAULT_SAMPLE_RATE = 44100
+_play_id = 0  # Used for ephemeral colab_play.
+
+
+def colab_play(array_of_floats, sample_rate, ephemeral=True, autoplay=False):
+  &#34;&#34;&#34;Creates an HTML5 audio widget to play a sound in Colab.
+
+  This function should only be called from a Colab notebook.
+
+  Args:
+    array_of_floats: A 1D or 2D array-like container of float sound
+      samples. Values outside of the range [-1, 1] will be clipped.
+    sample_rate: Sample rate in samples per second.
+    ephemeral: If set to True, the widget will be ephemeral, and disappear
+      on reload (and it won&#39;t be counted against realtime document size).
+    autoplay: If True, automatically start playing the sound when the
+      widget is rendered.
+  &#34;&#34;&#34;
+  from google.colab.output import _js_builder as js  # pylint:disable=import-outside-toplevel,g-import-not-at-top,protected-access
+
+  normalizer = float(np.iinfo(np.int16).max)
+  array_of_ints = np.array(
+      np.asarray(array_of_floats) * normalizer, dtype=np.int16)
+  memfile = io.BytesIO()
+  wavfile.write(memfile, sample_rate, array_of_ints)
+  html = &#34;&#34;&#34;&lt;audio controls {autoplay}&gt;
+              &lt;source controls src=&#34;data:audio/wav;base64,{base64_wavfile}&#34;
+              type=&#34;audio/wav&#34; /&gt;
+              Your browser does not support the audio element.
+            &lt;/audio&gt;&#34;&#34;&#34;
+  html = html.format(
+      autoplay=&#39;autoplay&#39; if autoplay else &#39;&#39;,
+      base64_wavfile=base64.b64encode(memfile.getvalue()).decode(&#39;ascii&#39;))
+  memfile.close()
+  global _play_id
+  _play_id += 1
+  if ephemeral:
+    element = &#39;id_%s&#39; % _play_id
+    display.display(display.HTML(&#39;&lt;div id=&#34;%s&#34;&gt; &lt;/div&gt;&#39; % element))
+    js.Js(&#39;document&#39;, mode=js.EVAL).getElementById(element).innerHTML = html
+  else:
+    display.display(display.HTML(html))
+
+
+def play_sequence(sequence,
+                  synth=midi_synth.synthesize,
+                  sample_rate=_DEFAULT_SAMPLE_RATE,
+                  colab_ephemeral=True,
+                  **synth_args):
+  &#34;&#34;&#34;Creates an interactive player for a synthesized note sequence.
+
+  This function should only be called from a Jupyter or Colab notebook.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize and play.
+    synth: A synthesis function that takes a sequence and sample rate as input.
+    sample_rate: The sample rate at which to synthesize.
+    colab_ephemeral: If set to True, the widget will be ephemeral in Colab, and
+      disappear on reload (and it won&#39;t be counted against realtime document
+      size).
+    **synth_args: Additional keyword arguments to pass to the synth function.
+  &#34;&#34;&#34;
+  array_of_floats = synth(sequence, sample_rate=sample_rate, **synth_args)
+
+  try:
+    import google.colab  # pylint:disable=import-outside-toplevel,g-import-not-at-top,unused-import
+    colab_play(array_of_floats, sample_rate, colab_ephemeral)
+  except ImportError:
+    display.display(display.Audio(array_of_floats, rate=sample_rate))
+
+
+def plot_sequence(sequence, show_figure=True):
+  &#34;&#34;&#34;Creates an interactive pianoroll for a NoteSequence.
+
+  Example usage: plot a random melody.
+    sequence = mm.Melody(np.random.randint(36, 72, 30)).to_sequence()
+    bokeh_pianoroll(sequence)
+
+  Args:
+     sequence: A NoteSequence.
+     show_figure: A boolean indicating whether or not to show the figure.
+
+  Returns:
+     If show_figure is False, a Bokeh figure; otherwise None.
+  &#34;&#34;&#34;
+
+  def _sequence_to_pandas_dataframe(sequence):
+    &#34;&#34;&#34;Generates a pandas dataframe from a sequence.&#34;&#34;&#34;
+    pd_dict = collections.defaultdict(list)
+    for note in sequence.notes:
+      pd_dict[&#39;start_time&#39;].append(note.start_time)
+      pd_dict[&#39;end_time&#39;].append(note.end_time)
+      pd_dict[&#39;duration&#39;].append(note.end_time - note.start_time)
+      pd_dict[&#39;pitch&#39;].append(note.pitch)
+      pd_dict[&#39;bottom&#39;].append(note.pitch - 0.4)
+      pd_dict[&#39;top&#39;].append(note.pitch + 0.4)
+      pd_dict[&#39;velocity&#39;].append(note.velocity)
+      pd_dict[&#39;fill_alpha&#39;].append(note.velocity / 128.0)
+      pd_dict[&#39;instrument&#39;].append(note.instrument)
+      pd_dict[&#39;program&#39;].append(note.program)
+
+    # If no velocity differences are found, set alpha to 1.0.
+    if np.max(pd_dict[&#39;velocity&#39;]) == np.min(pd_dict[&#39;velocity&#39;]):
+      pd_dict[&#39;fill_alpha&#39;] = [1.0] * len(pd_dict[&#39;fill_alpha&#39;])
+
+    return pd.DataFrame(pd_dict)
+
+  # These are hard-coded reasonable values, but the user can override them
+  # by updating the figure if need be.
+  fig = bokeh.plotting.figure(
+      tools=&#39;hover,pan,box_zoom,reset,save&#39;)
+  fig.plot_width = 500
+  fig.plot_height = 200
+  fig.xaxis.axis_label = &#39;time (sec)&#39;
+  fig.yaxis.axis_label = &#39;pitch (MIDI)&#39;
+  fig.yaxis.ticker = bokeh.models.SingleIntervalTicker(interval=12)
+  fig.ygrid.ticker = bokeh.models.SingleIntervalTicker(interval=12)
+  # Pick indexes that are maximally different in Spectral8 colormap.
+  spectral_color_indexes = [7, 0, 6, 1, 5, 2, 3]
+
+  # Create a Pandas dataframe and group it by instrument.
+  dataframe = _sequence_to_pandas_dataframe(sequence)
+  instruments = sorted(set(dataframe[&#39;instrument&#39;]))
+  grouped_dataframe = dataframe.groupby(&#39;instrument&#39;)
+  for counter, instrument in enumerate(instruments):
+    instrument_df = grouped_dataframe.get_group(instrument)
+    color_idx = spectral_color_indexes[counter % len(spectral_color_indexes)]
+    color = bokeh.palettes.Spectral8[color_idx]
+    source = bokeh.plotting.ColumnDataSource(instrument_df)
+    fig.quad(top=&#39;top&#39;, bottom=&#39;bottom&#39;, left=&#39;start_time&#39;, right=&#39;end_time&#39;,
+             line_color=&#39;black&#39;, fill_color=color,
+             fill_alpha=&#39;fill_alpha&#39;, source=source)
+  fig.select(dict(type=bokeh.models.HoverTool)).tooltips = (
+      {&#39;pitch&#39;: &#39;@pitch&#39;,
+       &#39;program&#39;: &#39;@program&#39;,
+       &#39;velo&#39;: &#39;@velocity&#39;,
+       &#39;duration&#39;: &#39;@duration&#39;,
+       &#39;start_time&#39;: &#39;@start_time&#39;,
+       &#39;end_time&#39;: &#39;@end_time&#39;,
+       &#39;velocity&#39;: &#39;@velocity&#39;,
+       &#39;fill_alpha&#39;: &#39;@fill_alpha&#39;})
+
+  if show_figure:
+    bokeh.plotting.output_notebook()
+    bokeh.plotting.show(fig)
+    return None
+  return fig
+
+
+def download_bundle(bundle_name, target_dir, force_reload=False):
+  &#34;&#34;&#34;Downloads a Magenta bundle to target directory.
+
+  Target directory target_dir will be created if it does not already exist.
+
+  Args:
+     bundle_name: A string Magenta bundle name to download.
+     target_dir: A string local directory in which to write the bundle.
+     force_reload: A boolean that when True, reloads the bundle even if present.
+  &#34;&#34;&#34;
+  makedirs(target_dir)
+  bundle_target = os.path.join(target_dir, bundle_name)
+  if not os.path.exists(bundle_target) or force_reload:
+    response = urllib.request.urlopen(
+        &#39;http://download.magenta.tensorflow.org/models/%s&#39; % bundle_name)
+    data = response.read()
+    local_file = open(bundle_target, &#39;wb&#39;)
+    local_file.write(data)
+    local_file.close()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.notebook_utils.colab_play"><code class="name flex">
+<span>def <span class="ident">colab_play</span></span>(<span>array_of_floats, sample_rate, ephemeral=True, autoplay=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates an HTML5 audio widget to play a sound in Colab.</p>
+<p>This function should only be called from a Colab notebook.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>array_of_floats</code></strong></dt>
+<dd>A 1D or 2D array-like container of float sound
+samples. Values outside of the range [-1, 1] will be clipped.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>Sample rate in samples per second.</dd>
+<dt><strong><code>ephemeral</code></strong></dt>
+<dd>If set to True, the widget will be ephemeral, and disappear
+on reload (and it won't be counted against realtime document size).</dd>
+<dt><strong><code>autoplay</code></strong></dt>
+<dd>If True, automatically start playing the sound when the
+widget is rendered.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def colab_play(array_of_floats, sample_rate, ephemeral=True, autoplay=False):
+  &#34;&#34;&#34;Creates an HTML5 audio widget to play a sound in Colab.
+
+  This function should only be called from a Colab notebook.
+
+  Args:
+    array_of_floats: A 1D or 2D array-like container of float sound
+      samples. Values outside of the range [-1, 1] will be clipped.
+    sample_rate: Sample rate in samples per second.
+    ephemeral: If set to True, the widget will be ephemeral, and disappear
+      on reload (and it won&#39;t be counted against realtime document size).
+    autoplay: If True, automatically start playing the sound when the
+      widget is rendered.
+  &#34;&#34;&#34;
+  from google.colab.output import _js_builder as js  # pylint:disable=import-outside-toplevel,g-import-not-at-top,protected-access
+
+  normalizer = float(np.iinfo(np.int16).max)
+  array_of_ints = np.array(
+      np.asarray(array_of_floats) * normalizer, dtype=np.int16)
+  memfile = io.BytesIO()
+  wavfile.write(memfile, sample_rate, array_of_ints)
+  html = &#34;&#34;&#34;&lt;audio controls {autoplay}&gt;
+              &lt;source controls src=&#34;data:audio/wav;base64,{base64_wavfile}&#34;
+              type=&#34;audio/wav&#34; /&gt;
+              Your browser does not support the audio element.
+            &lt;/audio&gt;&#34;&#34;&#34;
+  html = html.format(
+      autoplay=&#39;autoplay&#39; if autoplay else &#39;&#39;,
+      base64_wavfile=base64.b64encode(memfile.getvalue()).decode(&#39;ascii&#39;))
+  memfile.close()
+  global _play_id
+  _play_id += 1
+  if ephemeral:
+    element = &#39;id_%s&#39; % _play_id
+    display.display(display.HTML(&#39;&lt;div id=&#34;%s&#34;&gt; &lt;/div&gt;&#39; % element))
+    js.Js(&#39;document&#39;, mode=js.EVAL).getElementById(element).innerHTML = html
+  else:
+    display.display(display.HTML(html))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.notebook_utils.download_bundle"><code class="name flex">
+<span>def <span class="ident">download_bundle</span></span>(<span>bundle_name, target_dir, force_reload=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Downloads a Magenta bundle to target directory.</p>
+<p>Target directory target_dir will be created if it does not already exist.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>bundle_name</code></strong></dt>
+<dd>A string Magenta bundle name to download.</dd>
+<dt><strong><code>target_dir</code></strong></dt>
+<dd>A string local directory in which to write the bundle.</dd>
+<dt><strong><code>force_reload</code></strong></dt>
+<dd>A boolean that when True, reloads the bundle even if present.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def download_bundle(bundle_name, target_dir, force_reload=False):
+  &#34;&#34;&#34;Downloads a Magenta bundle to target directory.
+
+  Target directory target_dir will be created if it does not already exist.
+
+  Args:
+     bundle_name: A string Magenta bundle name to download.
+     target_dir: A string local directory in which to write the bundle.
+     force_reload: A boolean that when True, reloads the bundle even if present.
+  &#34;&#34;&#34;
+  makedirs(target_dir)
+  bundle_target = os.path.join(target_dir, bundle_name)
+  if not os.path.exists(bundle_target) or force_reload:
+    response = urllib.request.urlopen(
+        &#39;http://download.magenta.tensorflow.org/models/%s&#39; % bundle_name)
+    data = response.read()
+    local_file = open(bundle_target, &#39;wb&#39;)
+    local_file.write(data)
+    local_file.close()</code></pre>
+</details>
+</dd>
+<dt id="note_seq.notebook_utils.play_sequence"><code class="name flex">
+<span>def <span class="ident">play_sequence</span></span>(<span>sequence, synth=&lt;function synthesize&gt;, sample_rate=44100, colab_ephemeral=True, **synth_args)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates an interactive player for a synthesized note sequence.</p>
+<p>This function should only be called from a Jupyter or Colab notebook.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence to synthesize and play.</dd>
+<dt><strong><code>synth</code></strong></dt>
+<dd>A synthesis function that takes a sequence and sample rate as input.</dd>
+<dt><strong><code>sample_rate</code></strong></dt>
+<dd>The sample rate at which to synthesize.</dd>
+<dt><strong><code>colab_ephemeral</code></strong></dt>
+<dd>If set to True, the widget will be ephemeral in Colab, and
+disappear on reload (and it won't be counted against realtime document
+size).</dd>
+<dt><strong><code>**synth_args</code></strong></dt>
+<dd>Additional keyword arguments to pass to the synth function.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def play_sequence(sequence,
+                  synth=midi_synth.synthesize,
+                  sample_rate=_DEFAULT_SAMPLE_RATE,
+                  colab_ephemeral=True,
+                  **synth_args):
+  &#34;&#34;&#34;Creates an interactive player for a synthesized note sequence.
+
+  This function should only be called from a Jupyter or Colab notebook.
+
+  Args:
+    sequence: A music_pb2.NoteSequence to synthesize and play.
+    synth: A synthesis function that takes a sequence and sample rate as input.
+    sample_rate: The sample rate at which to synthesize.
+    colab_ephemeral: If set to True, the widget will be ephemeral in Colab, and
+      disappear on reload (and it won&#39;t be counted against realtime document
+      size).
+    **synth_args: Additional keyword arguments to pass to the synth function.
+  &#34;&#34;&#34;
+  array_of_floats = synth(sequence, sample_rate=sample_rate, **synth_args)
+
+  try:
+    import google.colab  # pylint:disable=import-outside-toplevel,g-import-not-at-top,unused-import
+    colab_play(array_of_floats, sample_rate, colab_ephemeral)
+  except ImportError:
+    display.display(display.Audio(array_of_floats, rate=sample_rate))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.notebook_utils.plot_sequence"><code class="name flex">
+<span>def <span class="ident">plot_sequence</span></span>(<span>sequence, show_figure=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates an interactive pianoroll for a NoteSequence.</p>
+<p>Example usage: plot a random melody.
+sequence = mm.Melody(np.random.randint(36, 72, 30)).to_sequence()
+bokeh_pianoroll(sequence)</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>A NoteSequence.</dd>
+<dt><strong><code>show_figure</code></strong></dt>
+<dd>A boolean indicating whether or not to show the figure.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>If show_figure is False, a Bokeh figure; otherwise None.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def plot_sequence(sequence, show_figure=True):
+  &#34;&#34;&#34;Creates an interactive pianoroll for a NoteSequence.
+
+  Example usage: plot a random melody.
+    sequence = mm.Melody(np.random.randint(36, 72, 30)).to_sequence()
+    bokeh_pianoroll(sequence)
+
+  Args:
+     sequence: A NoteSequence.
+     show_figure: A boolean indicating whether or not to show the figure.
+
+  Returns:
+     If show_figure is False, a Bokeh figure; otherwise None.
+  &#34;&#34;&#34;
+
+  def _sequence_to_pandas_dataframe(sequence):
+    &#34;&#34;&#34;Generates a pandas dataframe from a sequence.&#34;&#34;&#34;
+    pd_dict = collections.defaultdict(list)
+    for note in sequence.notes:
+      pd_dict[&#39;start_time&#39;].append(note.start_time)
+      pd_dict[&#39;end_time&#39;].append(note.end_time)
+      pd_dict[&#39;duration&#39;].append(note.end_time - note.start_time)
+      pd_dict[&#39;pitch&#39;].append(note.pitch)
+      pd_dict[&#39;bottom&#39;].append(note.pitch - 0.4)
+      pd_dict[&#39;top&#39;].append(note.pitch + 0.4)
+      pd_dict[&#39;velocity&#39;].append(note.velocity)
+      pd_dict[&#39;fill_alpha&#39;].append(note.velocity / 128.0)
+      pd_dict[&#39;instrument&#39;].append(note.instrument)
+      pd_dict[&#39;program&#39;].append(note.program)
+
+    # If no velocity differences are found, set alpha to 1.0.
+    if np.max(pd_dict[&#39;velocity&#39;]) == np.min(pd_dict[&#39;velocity&#39;]):
+      pd_dict[&#39;fill_alpha&#39;] = [1.0] * len(pd_dict[&#39;fill_alpha&#39;])
+
+    return pd.DataFrame(pd_dict)
+
+  # These are hard-coded reasonable values, but the user can override them
+  # by updating the figure if need be.
+  fig = bokeh.plotting.figure(
+      tools=&#39;hover,pan,box_zoom,reset,save&#39;)
+  fig.plot_width = 500
+  fig.plot_height = 200
+  fig.xaxis.axis_label = &#39;time (sec)&#39;
+  fig.yaxis.axis_label = &#39;pitch (MIDI)&#39;
+  fig.yaxis.ticker = bokeh.models.SingleIntervalTicker(interval=12)
+  fig.ygrid.ticker = bokeh.models.SingleIntervalTicker(interval=12)
+  # Pick indexes that are maximally different in Spectral8 colormap.
+  spectral_color_indexes = [7, 0, 6, 1, 5, 2, 3]
+
+  # Create a Pandas dataframe and group it by instrument.
+  dataframe = _sequence_to_pandas_dataframe(sequence)
+  instruments = sorted(set(dataframe[&#39;instrument&#39;]))
+  grouped_dataframe = dataframe.groupby(&#39;instrument&#39;)
+  for counter, instrument in enumerate(instruments):
+    instrument_df = grouped_dataframe.get_group(instrument)
+    color_idx = spectral_color_indexes[counter % len(spectral_color_indexes)]
+    color = bokeh.palettes.Spectral8[color_idx]
+    source = bokeh.plotting.ColumnDataSource(instrument_df)
+    fig.quad(top=&#39;top&#39;, bottom=&#39;bottom&#39;, left=&#39;start_time&#39;, right=&#39;end_time&#39;,
+             line_color=&#39;black&#39;, fill_color=color,
+             fill_alpha=&#39;fill_alpha&#39;, source=source)
+  fig.select(dict(type=bokeh.models.HoverTool)).tooltips = (
+      {&#39;pitch&#39;: &#39;@pitch&#39;,
+       &#39;program&#39;: &#39;@program&#39;,
+       &#39;velo&#39;: &#39;@velocity&#39;,
+       &#39;duration&#39;: &#39;@duration&#39;,
+       &#39;start_time&#39;: &#39;@start_time&#39;,
+       &#39;end_time&#39;: &#39;@end_time&#39;,
+       &#39;velocity&#39;: &#39;@velocity&#39;,
+       &#39;fill_alpha&#39;: &#39;@fill_alpha&#39;})
+
+  if show_figure:
+    bokeh.plotting.output_notebook()
+    bokeh.plotting.show(fig)
+    return None
+  return fig</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.notebook_utils.colab_play" href="#note_seq.notebook_utils.colab_play">colab_play</a></code></li>
+<li><code><a title="note_seq.notebook_utils.download_bundle" href="#note_seq.notebook_utils.download_bundle">download_bundle</a></code></li>
+<li><code><a title="note_seq.notebook_utils.play_sequence" href="#note_seq.notebook_utils.play_sequence">play_sequence</a></code></li>
+<li><code><a title="note_seq.notebook_utils.plot_sequence" href="#note_seq.notebook_utils.plot_sequence">plot_sequence</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_controls.html
+++ b/docs/performance_controls.html
@@ -1,0 +1,1117 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_controls API documentation</title>
+<meta name="description" content="Classes for computing performance control signals." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_controls</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for computing performance control signals.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for computing performance control signals.&#34;&#34;&#34;
+
+import abc
+import copy
+import numbers
+
+from note_seq import constants
+from note_seq import encoder_decoder
+from note_seq.performance_lib import PerformanceEvent
+
+NOTES_PER_OCTAVE = constants.NOTES_PER_OCTAVE
+DEFAULT_NOTE_DENSITY = 15.0
+DEFAULT_PITCH_HISTOGRAM = [1.0] * NOTES_PER_OCTAVE
+
+
+class PerformanceControlSignal(object):
+  &#34;&#34;&#34;Control signal used for conditional generation of performances.
+
+  The two main components of the control signal (that must be implemented in
+  subclasses) are the `extract` method that extracts the control signal values
+  from a Performance object, and the `encoder` class that transforms these
+  control signal values into model inputs.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def name(self):
+    &#34;&#34;&#34;Name of the control signal.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def description(self):
+    &#34;&#34;&#34;Description of the control signal.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def validate(self, value):
+    &#34;&#34;&#34;Validate a control signal value.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_value(self):
+    &#34;&#34;&#34;Default value of the (unencoded) control signal.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def encoder(self):
+    &#34;&#34;&#34;Instantiated encoder object for the control signal.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def extract(self, performance):
+    &#34;&#34;&#34;Extract a sequence of control values from a Performance object.
+
+    Args:
+      performance: The Performance object from which to extract control signal
+          values.
+
+    Returns:
+      A sequence of control signal values the same length as `performance`.
+    &#34;&#34;&#34;
+    pass
+
+
+class NoteDensityPerformanceControlSignal(PerformanceControlSignal):
+  &#34;&#34;&#34;Note density (notes per second) performance control signal.&#34;&#34;&#34;
+
+  name = &#39;notes_per_second&#39;
+  description = &#39;Desired number of notes per second.&#39;
+
+  def __init__(self, window_size_seconds, density_bin_ranges):
+    &#34;&#34;&#34;Initialize a NoteDensityPerformanceControlSignal.
+
+    Args:
+      window_size_seconds: The size of the window, in seconds, used to compute
+          note density (notes per second).
+      density_bin_ranges: List of note density (notes per second) bin boundaries
+          to use when quantizing. The number of bins will be one larger than the
+          list length.
+    &#34;&#34;&#34;
+    self._window_size_seconds = window_size_seconds
+    self._density_bin_ranges = density_bin_ranges
+    self._encoder = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        self.NoteDensityOneHotEncoding(density_bin_ranges))
+
+  def validate(self, value):
+    return isinstance(value, numbers.Number) and value &gt;= 0.0
+
+  @property
+  def default_value(self):
+    return DEFAULT_NOTE_DENSITY
+
+  @property
+  def encoder(self):
+    return self._encoder
+
+  def extract(self, performance):
+    &#34;&#34;&#34;Computes note density at every event in a performance.
+
+    Args:
+      performance: A Performance object for which to compute a note density
+          sequence.
+
+    Returns:
+      A list of note densities of the same length as `performance`, with each
+      entry equal to the note density in the window starting at the
+      corresponding performance event time.
+    &#34;&#34;&#34;
+    window_size_steps = int(round(
+        self._window_size_seconds * performance.steps_per_second))
+
+    prev_event_type = None
+    prev_density = 0.0
+
+    density_sequence = []
+
+    for i, event in enumerate(performance):
+      if (prev_event_type is not None and
+          prev_event_type != PerformanceEvent.TIME_SHIFT):
+        # The previous event didn&#39;t move us forward in time, so the note density
+        # here should be the same.
+        density_sequence.append(prev_density)
+        prev_event_type = event.event_type
+        continue
+
+      j = i
+      step_offset = 0
+      note_count = 0
+
+      # Count the number of note-on events within the window.
+      while step_offset &lt; window_size_steps and j &lt; len(performance):
+        if performance[j].event_type == PerformanceEvent.NOTE_ON:
+          note_count += 1
+        elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+          step_offset += performance[j].event_value
+        j += 1
+
+      # If we&#39;re near the end of the performance, part of the window will
+      # necessarily be empty; we don&#39;t include this part of the window when
+      # calculating note density.
+      actual_window_size_steps = min(step_offset, window_size_steps)
+      if actual_window_size_steps &gt; 0:
+        density = (
+            note_count * performance.steps_per_second /
+            actual_window_size_steps)
+      else:
+        density = 0.0
+
+      density_sequence.append(density)
+
+      prev_event_type = event.event_type
+      prev_density = density
+
+    return density_sequence
+
+  class NoteDensityOneHotEncoding(encoder_decoder.OneHotEncoding):
+    &#34;&#34;&#34;One-hot encoding for performance note density events.
+
+    Encodes by quantizing note density events. When decoding, always decodes to
+    the minimum value for each bin. The first bin starts at zero note density.
+    &#34;&#34;&#34;
+
+    def __init__(self, density_bin_ranges):
+      &#34;&#34;&#34;Initialize a NoteDensityOneHotEncoding.
+
+      Args:
+        density_bin_ranges: List of note density (notes per second) bin
+            boundaries to use when quantizing. The number of bins will be one
+            larger than the list length.
+      &#34;&#34;&#34;
+      self._density_bin_ranges = density_bin_ranges
+
+    @property
+    def num_classes(self):
+      return len(self._density_bin_ranges) + 1
+
+    @property
+    def default_event(self):
+      return 0.0
+
+    def encode_event(self, event):
+      for idx, density in enumerate(self._density_bin_ranges):
+        if event &lt; density:
+          return idx
+      return len(self._density_bin_ranges)
+
+    def decode_event(self, index):
+      if index == 0:
+        return 0.0
+      else:
+        return self._density_bin_ranges[index - 1]
+
+
+class PitchHistogramPerformanceControlSignal(PerformanceControlSignal):
+  &#34;&#34;&#34;Pitch class histogram performance control signal.&#34;&#34;&#34;
+
+  name = &#39;pitch_class_histogram&#39;
+  description = &#39;Desired weight for each for each of the 12 pitch classes.&#39;
+
+  def __init__(self, window_size_seconds, prior_count=0.01):
+    &#34;&#34;&#34;Initializes a PitchHistogramPerformanceControlSignal.
+
+    Args:
+      window_size_seconds: The size of the window, in seconds, used to compute
+          each histogram.
+      prior_count: A prior count to smooth the resulting histograms. This value
+          will be added to the actual pitch class counts.
+    &#34;&#34;&#34;
+    self._window_size_seconds = window_size_seconds
+    self._prior_count = prior_count
+    self._encoder = self.PitchHistogramEncoder()
+
+  @property
+  def default_value(self):
+    return DEFAULT_PITCH_HISTOGRAM
+
+  def validate(self, value):
+    return (isinstance(value, list) and len(value) == NOTES_PER_OCTAVE and
+            all(isinstance(a, numbers.Number) for a in value))
+
+  @property
+  def encoder(self):
+    return self._encoder
+
+  def extract(self, performance):
+    &#34;&#34;&#34;Computes local pitch class histogram at every event in a performance.
+
+    Args:
+      performance: A Performance object for which to compute a pitch class
+          histogram sequence.
+
+    Returns:
+      A list of pitch class histograms the same length as `performance`, where
+      each pitch class histogram is a length-12 list of float values summing to
+      one.
+    &#34;&#34;&#34;
+    window_size_steps = int(round(
+        self._window_size_seconds * performance.steps_per_second))
+
+    prev_event_type = None
+    prev_histogram = self.default_value
+
+    base_active_pitches = set()
+    histogram_sequence = []
+
+    for i, event in enumerate(performance):
+      # Maintain the base set of active pitches.
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        base_active_pitches.add(event.event_value)
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        base_active_pitches.discard(event.event_value)
+
+      if (prev_event_type is not None and
+          prev_event_type != PerformanceEvent.TIME_SHIFT):
+        # The previous event didn&#39;t move us forward in time, so the histogram
+        # here should be the same.
+        histogram_sequence.append(prev_histogram)
+        prev_event_type = event.event_type
+        continue
+
+      j = i
+      step_offset = 0
+
+      active_pitches = copy.deepcopy(base_active_pitches)
+      histogram = [self._prior_count] * NOTES_PER_OCTAVE
+
+      # Count the total duration of each pitch class within the window.
+      while step_offset &lt; window_size_steps and j &lt; len(performance):
+        if performance[j].event_type == PerformanceEvent.NOTE_ON:
+          active_pitches.add(performance[j].event_value)
+        elif performance[j].event_type == PerformanceEvent.NOTE_OFF:
+          active_pitches.discard(performance[j].event_value)
+        elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+          for pitch in active_pitches:
+            histogram[pitch % NOTES_PER_OCTAVE] += (
+                performance[j].event_value / performance.steps_per_second)
+          step_offset += performance[j].event_value
+        j += 1
+
+      histogram_sequence.append(histogram)
+
+      prev_event_type = event.event_type
+      prev_histogram = histogram
+
+    return histogram_sequence
+
+  class PitchHistogramEncoder(encoder_decoder.EventSequenceEncoderDecoder):
+    &#34;&#34;&#34;An encoder for pitch class histogram sequences.&#34;&#34;&#34;
+
+    @property
+    def input_size(self):
+      return NOTES_PER_OCTAVE
+
+    @property
+    def num_classes(self):
+      raise NotImplementedError
+
+    @property
+    def default_event_label(self):
+      raise NotImplementedError
+
+    def events_to_input(self, events, position):
+      # Normalize by the total weight.
+      total = sum(events[position])
+      if total &gt; 0:
+        return [count / total for count in events[position]]
+      else:
+        return [1.0 / NOTES_PER_OCTAVE] * NOTES_PER_OCTAVE
+
+    def events_to_label(self, events, position):
+      raise NotImplementedError
+
+    def class_index_to_event(self, class_index, events):
+      raise NotImplementedError
+
+
+# List of performance control signal classes.
+all_performance_control_signals = [
+    NoteDensityPerformanceControlSignal,
+    PitchHistogramPerformanceControlSignal
+]</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_controls.NoteDensityPerformanceControlSignal"><code class="flex name class">
+<span>class <span class="ident">NoteDensityPerformanceControlSignal</span></span>
+<span>(</span><span>window_size_seconds, density_bin_ranges)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Note density (notes per second) performance control signal.</p>
+<p>Initialize a NoteDensityPerformanceControlSignal.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>window_size_seconds</code></strong></dt>
+<dd>The size of the window, in seconds, used to compute
+note density (notes per second).</dd>
+<dt><strong><code>density_bin_ranges</code></strong></dt>
+<dd>List of note density (notes per second) bin boundaries
+to use when quantizing. The number of bins will be one larger than the
+list length.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NoteDensityPerformanceControlSignal(PerformanceControlSignal):
+  &#34;&#34;&#34;Note density (notes per second) performance control signal.&#34;&#34;&#34;
+
+  name = &#39;notes_per_second&#39;
+  description = &#39;Desired number of notes per second.&#39;
+
+  def __init__(self, window_size_seconds, density_bin_ranges):
+    &#34;&#34;&#34;Initialize a NoteDensityPerformanceControlSignal.
+
+    Args:
+      window_size_seconds: The size of the window, in seconds, used to compute
+          note density (notes per second).
+      density_bin_ranges: List of note density (notes per second) bin boundaries
+          to use when quantizing. The number of bins will be one larger than the
+          list length.
+    &#34;&#34;&#34;
+    self._window_size_seconds = window_size_seconds
+    self._density_bin_ranges = density_bin_ranges
+    self._encoder = encoder_decoder.OneHotEventSequenceEncoderDecoder(
+        self.NoteDensityOneHotEncoding(density_bin_ranges))
+
+  def validate(self, value):
+    return isinstance(value, numbers.Number) and value &gt;= 0.0
+
+  @property
+  def default_value(self):
+    return DEFAULT_NOTE_DENSITY
+
+  @property
+  def encoder(self):
+    return self._encoder
+
+  def extract(self, performance):
+    &#34;&#34;&#34;Computes note density at every event in a performance.
+
+    Args:
+      performance: A Performance object for which to compute a note density
+          sequence.
+
+    Returns:
+      A list of note densities of the same length as `performance`, with each
+      entry equal to the note density in the window starting at the
+      corresponding performance event time.
+    &#34;&#34;&#34;
+    window_size_steps = int(round(
+        self._window_size_seconds * performance.steps_per_second))
+
+    prev_event_type = None
+    prev_density = 0.0
+
+    density_sequence = []
+
+    for i, event in enumerate(performance):
+      if (prev_event_type is not None and
+          prev_event_type != PerformanceEvent.TIME_SHIFT):
+        # The previous event didn&#39;t move us forward in time, so the note density
+        # here should be the same.
+        density_sequence.append(prev_density)
+        prev_event_type = event.event_type
+        continue
+
+      j = i
+      step_offset = 0
+      note_count = 0
+
+      # Count the number of note-on events within the window.
+      while step_offset &lt; window_size_steps and j &lt; len(performance):
+        if performance[j].event_type == PerformanceEvent.NOTE_ON:
+          note_count += 1
+        elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+          step_offset += performance[j].event_value
+        j += 1
+
+      # If we&#39;re near the end of the performance, part of the window will
+      # necessarily be empty; we don&#39;t include this part of the window when
+      # calculating note density.
+      actual_window_size_steps = min(step_offset, window_size_steps)
+      if actual_window_size_steps &gt; 0:
+        density = (
+            note_count * performance.steps_per_second /
+            actual_window_size_steps)
+      else:
+        density = 0.0
+
+      density_sequence.append(density)
+
+      prev_event_type = event.event_type
+      prev_density = density
+
+    return density_sequence
+
+  class NoteDensityOneHotEncoding(encoder_decoder.OneHotEncoding):
+    &#34;&#34;&#34;One-hot encoding for performance note density events.
+
+    Encodes by quantizing note density events. When decoding, always decodes to
+    the minimum value for each bin. The first bin starts at zero note density.
+    &#34;&#34;&#34;
+
+    def __init__(self, density_bin_ranges):
+      &#34;&#34;&#34;Initialize a NoteDensityOneHotEncoding.
+
+      Args:
+        density_bin_ranges: List of note density (notes per second) bin
+            boundaries to use when quantizing. The number of bins will be one
+            larger than the list length.
+      &#34;&#34;&#34;
+      self._density_bin_ranges = density_bin_ranges
+
+    @property
+    def num_classes(self):
+      return len(self._density_bin_ranges) + 1
+
+    @property
+    def default_event(self):
+      return 0.0
+
+    def encode_event(self, event):
+      for idx, density in enumerate(self._density_bin_ranges):
+        if event &lt; density:
+          return idx
+      return len(self._density_bin_ranges)
+
+    def decode_event(self, index):
+      if index == 0:
+        return 0.0
+      else:
+        return self._density_bin_ranges[index - 1]</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_controls.PerformanceControlSignal" href="#note_seq.performance_controls.PerformanceControlSignal">PerformanceControlSignal</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.performance_controls.NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding"><code class="name">var <span class="ident">NoteDensityOneHotEncoding</span></code></dt>
+<dd>
+<div class="desc"><p>One-hot encoding for performance note density events.</p>
+<p>Encodes by quantizing note density events. When decoding, always decodes to
+the minimum value for each bin. The first bin starts at zero note density.</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_controls.NoteDensityPerformanceControlSignal.extract"><code class="name flex">
+<span>def <span class="ident">extract</span></span>(<span>self, performance)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Computes note density at every event in a performance.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>performance</code></strong></dt>
+<dd>A Performance object for which to compute a note density
+sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A list of note densities of the same length as <code>performance</code>, with each
+entry equal to the note density in the window starting at the
+corresponding performance event time.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extract(self, performance):
+  &#34;&#34;&#34;Computes note density at every event in a performance.
+
+  Args:
+    performance: A Performance object for which to compute a note density
+        sequence.
+
+  Returns:
+    A list of note densities of the same length as `performance`, with each
+    entry equal to the note density in the window starting at the
+    corresponding performance event time.
+  &#34;&#34;&#34;
+  window_size_steps = int(round(
+      self._window_size_seconds * performance.steps_per_second))
+
+  prev_event_type = None
+  prev_density = 0.0
+
+  density_sequence = []
+
+  for i, event in enumerate(performance):
+    if (prev_event_type is not None and
+        prev_event_type != PerformanceEvent.TIME_SHIFT):
+      # The previous event didn&#39;t move us forward in time, so the note density
+      # here should be the same.
+      density_sequence.append(prev_density)
+      prev_event_type = event.event_type
+      continue
+
+    j = i
+    step_offset = 0
+    note_count = 0
+
+    # Count the number of note-on events within the window.
+    while step_offset &lt; window_size_steps and j &lt; len(performance):
+      if performance[j].event_type == PerformanceEvent.NOTE_ON:
+        note_count += 1
+      elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+        step_offset += performance[j].event_value
+      j += 1
+
+    # If we&#39;re near the end of the performance, part of the window will
+    # necessarily be empty; we don&#39;t include this part of the window when
+    # calculating note density.
+    actual_window_size_steps = min(step_offset, window_size_steps)
+    if actual_window_size_steps &gt; 0:
+      density = (
+          note_count * performance.steps_per_second /
+          actual_window_size_steps)
+    else:
+      density = 0.0
+
+    density_sequence.append(density)
+
+    prev_event_type = event.event_type
+    prev_density = density
+
+  return density_sequence</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.performance_controls.PerformanceControlSignal" href="#note_seq.performance_controls.PerformanceControlSignal">PerformanceControlSignal</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.default_value" href="#note_seq.performance_controls.PerformanceControlSignal.default_value">default_value</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.description" href="#note_seq.performance_controls.PerformanceControlSignal.description">description</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.encoder" href="#note_seq.performance_controls.PerformanceControlSignal.encoder">encoder</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.name" href="#note_seq.performance_controls.PerformanceControlSignal.name">name</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.validate" href="#note_seq.performance_controls.PerformanceControlSignal.validate">validate</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_controls.PerformanceControlSignal"><code class="flex name class">
+<span>class <span class="ident">PerformanceControlSignal</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Control signal used for conditional generation of performances.</p>
+<p>The two main components of the control signal (that must be implemented in
+subclasses) are the <code>extract</code> method that extracts the control signal values
+from a Performance object, and the <code>encoder</code> class that transforms these
+control signal values into model inputs.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceControlSignal(object):
+  &#34;&#34;&#34;Control signal used for conditional generation of performances.
+
+  The two main components of the control signal (that must be implemented in
+  subclasses) are the `extract` method that extracts the control signal values
+  from a Performance object, and the `encoder` class that transforms these
+  control signal values into model inputs.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  @property
+  @abc.abstractmethod
+  def name(self):
+    &#34;&#34;&#34;Name of the control signal.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def description(self):
+    &#34;&#34;&#34;Description of the control signal.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def validate(self, value):
+    &#34;&#34;&#34;Validate a control signal value.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def default_value(self):
+    &#34;&#34;&#34;Default value of the (unencoded) control signal.&#34;&#34;&#34;
+    pass
+
+  @property
+  @abc.abstractmethod
+  def encoder(self):
+    &#34;&#34;&#34;Instantiated encoder object for the control signal.&#34;&#34;&#34;
+    pass
+
+  @abc.abstractmethod
+  def extract(self, performance):
+    &#34;&#34;&#34;Extract a sequence of control values from a Performance object.
+
+    Args:
+      performance: The Performance object from which to extract control signal
+          values.
+
+    Returns:
+      A sequence of control signal values the same length as `performance`.
+    &#34;&#34;&#34;
+    pass</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_controls.NoteDensityPerformanceControlSignal" href="#note_seq.performance_controls.NoteDensityPerformanceControlSignal">NoteDensityPerformanceControlSignal</a></li>
+<li><a title="note_seq.performance_controls.PitchHistogramPerformanceControlSignal" href="#note_seq.performance_controls.PitchHistogramPerformanceControlSignal">PitchHistogramPerformanceControlSignal</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.default_value"><code class="name">var <span class="ident">default_value</span></code></dt>
+<dd>
+<div class="desc"><p>Default value of the (unencoded) control signal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def default_value(self):
+  &#34;&#34;&#34;Default value of the (unencoded) control signal.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.description"><code class="name">var <span class="ident">description</span></code></dt>
+<dd>
+<div class="desc"><p>Description of the control signal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def description(self):
+  &#34;&#34;&#34;Description of the control signal.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.encoder"><code class="name">var <span class="ident">encoder</span></code></dt>
+<dd>
+<div class="desc"><p>Instantiated encoder object for the control signal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def encoder(self):
+  &#34;&#34;&#34;Instantiated encoder object for the control signal.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.name"><code class="name">var <span class="ident">name</span></code></dt>
+<dd>
+<div class="desc"><p>Name of the control signal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+@abc.abstractmethod
+def name(self):
+  &#34;&#34;&#34;Name of the control signal.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.extract"><code class="name flex">
+<span>def <span class="ident">extract</span></span>(<span>self, performance)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extract a sequence of control values from a Performance object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>performance</code></strong></dt>
+<dd>The Performance object from which to extract control signal
+values.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A sequence of control signal values the same length as <code>performance</code>.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def extract(self, performance):
+  &#34;&#34;&#34;Extract a sequence of control values from a Performance object.
+
+  Args:
+    performance: The Performance object from which to extract control signal
+        values.
+
+  Returns:
+    A sequence of control signal values the same length as `performance`.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls.PerformanceControlSignal.validate"><code class="name flex">
+<span>def <span class="ident">validate</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Validate a control signal value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def validate(self, value):
+  &#34;&#34;&#34;Validate a control signal value.&#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_controls.PitchHistogramPerformanceControlSignal"><code class="flex name class">
+<span>class <span class="ident">PitchHistogramPerformanceControlSignal</span></span>
+<span>(</span><span>window_size_seconds, prior_count=0.01)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Pitch class histogram performance control signal.</p>
+<p>Initializes a PitchHistogramPerformanceControlSignal.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>window_size_seconds</code></strong></dt>
+<dd>The size of the window, in seconds, used to compute
+each histogram.</dd>
+<dt><strong><code>prior_count</code></strong></dt>
+<dd>A prior count to smooth the resulting histograms. This value
+will be added to the actual pitch class counts.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PitchHistogramPerformanceControlSignal(PerformanceControlSignal):
+  &#34;&#34;&#34;Pitch class histogram performance control signal.&#34;&#34;&#34;
+
+  name = &#39;pitch_class_histogram&#39;
+  description = &#39;Desired weight for each for each of the 12 pitch classes.&#39;
+
+  def __init__(self, window_size_seconds, prior_count=0.01):
+    &#34;&#34;&#34;Initializes a PitchHistogramPerformanceControlSignal.
+
+    Args:
+      window_size_seconds: The size of the window, in seconds, used to compute
+          each histogram.
+      prior_count: A prior count to smooth the resulting histograms. This value
+          will be added to the actual pitch class counts.
+    &#34;&#34;&#34;
+    self._window_size_seconds = window_size_seconds
+    self._prior_count = prior_count
+    self._encoder = self.PitchHistogramEncoder()
+
+  @property
+  def default_value(self):
+    return DEFAULT_PITCH_HISTOGRAM
+
+  def validate(self, value):
+    return (isinstance(value, list) and len(value) == NOTES_PER_OCTAVE and
+            all(isinstance(a, numbers.Number) for a in value))
+
+  @property
+  def encoder(self):
+    return self._encoder
+
+  def extract(self, performance):
+    &#34;&#34;&#34;Computes local pitch class histogram at every event in a performance.
+
+    Args:
+      performance: A Performance object for which to compute a pitch class
+          histogram sequence.
+
+    Returns:
+      A list of pitch class histograms the same length as `performance`, where
+      each pitch class histogram is a length-12 list of float values summing to
+      one.
+    &#34;&#34;&#34;
+    window_size_steps = int(round(
+        self._window_size_seconds * performance.steps_per_second))
+
+    prev_event_type = None
+    prev_histogram = self.default_value
+
+    base_active_pitches = set()
+    histogram_sequence = []
+
+    for i, event in enumerate(performance):
+      # Maintain the base set of active pitches.
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        base_active_pitches.add(event.event_value)
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        base_active_pitches.discard(event.event_value)
+
+      if (prev_event_type is not None and
+          prev_event_type != PerformanceEvent.TIME_SHIFT):
+        # The previous event didn&#39;t move us forward in time, so the histogram
+        # here should be the same.
+        histogram_sequence.append(prev_histogram)
+        prev_event_type = event.event_type
+        continue
+
+      j = i
+      step_offset = 0
+
+      active_pitches = copy.deepcopy(base_active_pitches)
+      histogram = [self._prior_count] * NOTES_PER_OCTAVE
+
+      # Count the total duration of each pitch class within the window.
+      while step_offset &lt; window_size_steps and j &lt; len(performance):
+        if performance[j].event_type == PerformanceEvent.NOTE_ON:
+          active_pitches.add(performance[j].event_value)
+        elif performance[j].event_type == PerformanceEvent.NOTE_OFF:
+          active_pitches.discard(performance[j].event_value)
+        elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+          for pitch in active_pitches:
+            histogram[pitch % NOTES_PER_OCTAVE] += (
+                performance[j].event_value / performance.steps_per_second)
+          step_offset += performance[j].event_value
+        j += 1
+
+      histogram_sequence.append(histogram)
+
+      prev_event_type = event.event_type
+      prev_histogram = histogram
+
+    return histogram_sequence
+
+  class PitchHistogramEncoder(encoder_decoder.EventSequenceEncoderDecoder):
+    &#34;&#34;&#34;An encoder for pitch class histogram sequences.&#34;&#34;&#34;
+
+    @property
+    def input_size(self):
+      return NOTES_PER_OCTAVE
+
+    @property
+    def num_classes(self):
+      raise NotImplementedError
+
+    @property
+    def default_event_label(self):
+      raise NotImplementedError
+
+    def events_to_input(self, events, position):
+      # Normalize by the total weight.
+      total = sum(events[position])
+      if total &gt; 0:
+        return [count / total for count in events[position]]
+      else:
+        return [1.0 / NOTES_PER_OCTAVE] * NOTES_PER_OCTAVE
+
+    def events_to_label(self, events, position):
+      raise NotImplementedError
+
+    def class_index_to_event(self, class_index, events):
+      raise NotImplementedError</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_controls.PerformanceControlSignal" href="#note_seq.performance_controls.PerformanceControlSignal">PerformanceControlSignal</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.performance_controls.PitchHistogramPerformanceControlSignal.PitchHistogramEncoder"><code class="name">var <span class="ident">PitchHistogramEncoder</span></code></dt>
+<dd>
+<div class="desc"><p>An encoder for pitch class histogram sequences.</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_controls.PitchHistogramPerformanceControlSignal.extract"><code class="name flex">
+<span>def <span class="ident">extract</span></span>(<span>self, performance)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Computes local pitch class histogram at every event in a performance.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>performance</code></strong></dt>
+<dd>A Performance object for which to compute a pitch class
+histogram sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A list of pitch class histograms the same length as <code>performance</code>, where
+each pitch class histogram is a length-12 list of float values summing to
+one.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extract(self, performance):
+  &#34;&#34;&#34;Computes local pitch class histogram at every event in a performance.
+
+  Args:
+    performance: A Performance object for which to compute a pitch class
+        histogram sequence.
+
+  Returns:
+    A list of pitch class histograms the same length as `performance`, where
+    each pitch class histogram is a length-12 list of float values summing to
+    one.
+  &#34;&#34;&#34;
+  window_size_steps = int(round(
+      self._window_size_seconds * performance.steps_per_second))
+
+  prev_event_type = None
+  prev_histogram = self.default_value
+
+  base_active_pitches = set()
+  histogram_sequence = []
+
+  for i, event in enumerate(performance):
+    # Maintain the base set of active pitches.
+    if event.event_type == PerformanceEvent.NOTE_ON:
+      base_active_pitches.add(event.event_value)
+    elif event.event_type == PerformanceEvent.NOTE_OFF:
+      base_active_pitches.discard(event.event_value)
+
+    if (prev_event_type is not None and
+        prev_event_type != PerformanceEvent.TIME_SHIFT):
+      # The previous event didn&#39;t move us forward in time, so the histogram
+      # here should be the same.
+      histogram_sequence.append(prev_histogram)
+      prev_event_type = event.event_type
+      continue
+
+    j = i
+    step_offset = 0
+
+    active_pitches = copy.deepcopy(base_active_pitches)
+    histogram = [self._prior_count] * NOTES_PER_OCTAVE
+
+    # Count the total duration of each pitch class within the window.
+    while step_offset &lt; window_size_steps and j &lt; len(performance):
+      if performance[j].event_type == PerformanceEvent.NOTE_ON:
+        active_pitches.add(performance[j].event_value)
+      elif performance[j].event_type == PerformanceEvent.NOTE_OFF:
+        active_pitches.discard(performance[j].event_value)
+      elif performance[j].event_type == PerformanceEvent.TIME_SHIFT:
+        for pitch in active_pitches:
+          histogram[pitch % NOTES_PER_OCTAVE] += (
+              performance[j].event_value / performance.steps_per_second)
+        step_offset += performance[j].event_value
+      j += 1
+
+    histogram_sequence.append(histogram)
+
+    prev_event_type = event.event_type
+    prev_histogram = histogram
+
+  return histogram_sequence</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.performance_controls.PerformanceControlSignal" href="#note_seq.performance_controls.PerformanceControlSignal">PerformanceControlSignal</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.default_value" href="#note_seq.performance_controls.PerformanceControlSignal.default_value">default_value</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.description" href="#note_seq.performance_controls.PerformanceControlSignal.description">description</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.encoder" href="#note_seq.performance_controls.PerformanceControlSignal.encoder">encoder</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.name" href="#note_seq.performance_controls.PerformanceControlSignal.name">name</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.validate" href="#note_seq.performance_controls.PerformanceControlSignal.validate">validate</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_controls.NoteDensityPerformanceControlSignal" href="#note_seq.performance_controls.NoteDensityPerformanceControlSignal">NoteDensityPerformanceControlSignal</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_controls.NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding" href="#note_seq.performance_controls.NoteDensityPerformanceControlSignal.NoteDensityOneHotEncoding">NoteDensityOneHotEncoding</a></code></li>
+<li><code><a title="note_seq.performance_controls.NoteDensityPerformanceControlSignal.extract" href="#note_seq.performance_controls.NoteDensityPerformanceControlSignal.extract">extract</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_controls.PerformanceControlSignal" href="#note_seq.performance_controls.PerformanceControlSignal">PerformanceControlSignal</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.default_value" href="#note_seq.performance_controls.PerformanceControlSignal.default_value">default_value</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.description" href="#note_seq.performance_controls.PerformanceControlSignal.description">description</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.encoder" href="#note_seq.performance_controls.PerformanceControlSignal.encoder">encoder</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.extract" href="#note_seq.performance_controls.PerformanceControlSignal.extract">extract</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.name" href="#note_seq.performance_controls.PerformanceControlSignal.name">name</a></code></li>
+<li><code><a title="note_seq.performance_controls.PerformanceControlSignal.validate" href="#note_seq.performance_controls.PerformanceControlSignal.validate">validate</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_controls.PitchHistogramPerformanceControlSignal" href="#note_seq.performance_controls.PitchHistogramPerformanceControlSignal">PitchHistogramPerformanceControlSignal</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_controls.PitchHistogramPerformanceControlSignal.PitchHistogramEncoder" href="#note_seq.performance_controls.PitchHistogramPerformanceControlSignal.PitchHistogramEncoder">PitchHistogramEncoder</a></code></li>
+<li><code><a title="note_seq.performance_controls.PitchHistogramPerformanceControlSignal.extract" href="#note_seq.performance_controls.PitchHistogramPerformanceControlSignal.extract">extract</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_controls_test.html
+++ b/docs/performance_controls_test.html
@@ -1,0 +1,593 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_controls_test API documentation</title>
+<meta name="description" content="Tests for performance controls." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_controls_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for performance controls.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for performance controls.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import performance_controls
+from note_seq import performance_lib
+
+
+class NoteDensityPerformanceControlSignalTest(absltest.TestCase):
+
+  def setUp(self):
+    self.control = performance_controls.NoteDensityPerformanceControlSignal(
+        window_size_seconds=1.0, density_bin_ranges=[1.0, 5.0])
+
+  def testExtract(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 64)
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    expected_density_sequence = [
+        4.0, 4.0, 4.0, 4.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0, 0.0]
+
+    density_sequence = self.control.extract(performance)
+    self.assertEqual(expected_density_sequence, density_sequence)
+
+  def testEncoder(self):
+    density_sequence = [0.0, 0.5, 1.0, 2.0, 5.0, 10.0]
+
+    expected_inputs = [
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+    ]
+
+    self.assertEqual(expected_inputs[0],
+                     self.control.encoder.events_to_input(density_sequence, 0))
+    self.assertEqual(expected_inputs[1],
+                     self.control.encoder.events_to_input(density_sequence, 1))
+    self.assertEqual(expected_inputs[2],
+                     self.control.encoder.events_to_input(density_sequence, 2))
+    self.assertEqual(expected_inputs[3],
+                     self.control.encoder.events_to_input(density_sequence, 3))
+    self.assertEqual(expected_inputs[4],
+                     self.control.encoder.events_to_input(density_sequence, 4))
+    self.assertEqual(expected_inputs[5],
+                     self.control.encoder.events_to_input(density_sequence, 5))
+
+
+class PitchHistogramPerformanceControlSignalTest(absltest.TestCase):
+
+  def setUp(self):
+    self.control = performance_controls.PitchHistogramPerformanceControlSignal(
+        window_size_seconds=1.0, prior_count=0)
+
+  def testExtract(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 64)
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    expected_histogram_sequence = [
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]
+
+    histogram_sequence = self.control.extract(performance)
+    self.assertEqual(expected_histogram_sequence, histogram_sequence)
+
+  def testEncoder(self):
+    histogram_sequence = [
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]
+
+    expected_inputs = [
+        [0.25, 0, 0, 0, 0.375, 0, 0, 0.375, 0, 0, 0, 0],
+        [0.0, 0, 0, 0, 0.5, 0, 0, 0.5, 0, 0, 0, 0],
+        [0.0, 0, 0, 0, 1.0, 0, 0, 0.0, 0, 0, 0, 0],
+        [1.0 / 12.0] * 12
+    ]
+
+    self.assertEqual(
+        expected_inputs[0],
+        self.control.encoder.events_to_input(histogram_sequence, 0))
+    self.assertEqual(
+        expected_inputs[1],
+        self.control.encoder.events_to_input(histogram_sequence, 1))
+    self.assertEqual(
+        expected_inputs[2],
+        self.control.encoder.events_to_input(histogram_sequence, 2))
+    self.assertEqual(
+        expected_inputs[3],
+        self.control.encoder.events_to_input(histogram_sequence, 3))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest"><code class="flex name class">
+<span>class <span class="ident">NoteDensityPerformanceControlSignalTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NoteDensityPerformanceControlSignalTest(absltest.TestCase):
+
+  def setUp(self):
+    self.control = performance_controls.NoteDensityPerformanceControlSignal(
+        window_size_seconds=1.0, density_bin_ranges=[1.0, 5.0])
+
+  def testExtract(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 64)
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    expected_density_sequence = [
+        4.0, 4.0, 4.0, 4.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0, 0.0]
+
+    density_sequence = self.control.extract(performance)
+    self.assertEqual(expected_density_sequence, density_sequence)
+
+  def testEncoder(self):
+    density_sequence = [0.0, 0.5, 1.0, 2.0, 5.0, 10.0]
+
+    expected_inputs = [
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+    ]
+
+    self.assertEqual(expected_inputs[0],
+                     self.control.encoder.events_to_input(density_sequence, 0))
+    self.assertEqual(expected_inputs[1],
+                     self.control.encoder.events_to_input(density_sequence, 1))
+    self.assertEqual(expected_inputs[2],
+                     self.control.encoder.events_to_input(density_sequence, 2))
+    self.assertEqual(expected_inputs[3],
+                     self.control.encoder.events_to_input(density_sequence, 3))
+    self.assertEqual(expected_inputs[4],
+                     self.control.encoder.events_to_input(density_sequence, 4))
+    self.assertEqual(expected_inputs[5],
+                     self.control.encoder.events_to_input(density_sequence, 5))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.control = performance_controls.NoteDensityPerformanceControlSignal(
+      window_size_seconds=1.0, density_bin_ranges=[1.0, 5.0])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testEncoder"><code class="name flex">
+<span>def <span class="ident">testEncoder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncoder(self):
+  density_sequence = [0.0, 0.5, 1.0, 2.0, 5.0, 10.0]
+
+  expected_inputs = [
+      [1.0, 0.0, 0.0],
+      [1.0, 0.0, 0.0],
+      [0.0, 1.0, 0.0],
+      [0.0, 1.0, 0.0],
+      [0.0, 0.0, 1.0],
+      [0.0, 0.0, 1.0],
+  ]
+
+  self.assertEqual(expected_inputs[0],
+                   self.control.encoder.events_to_input(density_sequence, 0))
+  self.assertEqual(expected_inputs[1],
+                   self.control.encoder.events_to_input(density_sequence, 1))
+  self.assertEqual(expected_inputs[2],
+                   self.control.encoder.events_to_input(density_sequence, 2))
+  self.assertEqual(expected_inputs[3],
+                   self.control.encoder.events_to_input(density_sequence, 3))
+  self.assertEqual(expected_inputs[4],
+                   self.control.encoder.events_to_input(density_sequence, 4))
+  self.assertEqual(expected_inputs[5],
+                   self.control.encoder.events_to_input(density_sequence, 5))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testExtract"><code class="name flex">
+<span>def <span class="ident">testExtract</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtract(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 50),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 25),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 25),
+      pe(pe.NOTE_OFF, 64)
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  expected_density_sequence = [
+      4.0, 4.0, 4.0, 4.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0, 0.0]
+
+  density_sequence = self.control.extract(performance)
+  self.assertEqual(expected_density_sequence, density_sequence)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest"><code class="flex name class">
+<span>class <span class="ident">PitchHistogramPerformanceControlSignalTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PitchHistogramPerformanceControlSignalTest(absltest.TestCase):
+
+  def setUp(self):
+    self.control = performance_controls.PitchHistogramPerformanceControlSignal(
+        window_size_seconds=1.0, prior_count=0)
+
+  def testExtract(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 25),
+        pe(pe.NOTE_OFF, 64)
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    expected_histogram_sequence = [
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]
+
+    histogram_sequence = self.control.extract(performance)
+    self.assertEqual(expected_histogram_sequence, histogram_sequence)
+
+  def testEncoder(self):
+    histogram_sequence = [
+        [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]
+
+    expected_inputs = [
+        [0.25, 0, 0, 0, 0.375, 0, 0, 0.375, 0, 0, 0, 0],
+        [0.0, 0, 0, 0, 0.5, 0, 0, 0.5, 0, 0, 0, 0],
+        [0.0, 0, 0, 0, 1.0, 0, 0, 0.0, 0, 0, 0, 0],
+        [1.0 / 12.0] * 12
+    ]
+
+    self.assertEqual(
+        expected_inputs[0],
+        self.control.encoder.events_to_input(histogram_sequence, 0))
+    self.assertEqual(
+        expected_inputs[1],
+        self.control.encoder.events_to_input(histogram_sequence, 1))
+    self.assertEqual(
+        expected_inputs[2],
+        self.control.encoder.events_to_input(histogram_sequence, 2))
+    self.assertEqual(
+        expected_inputs[3],
+        self.control.encoder.events_to_input(histogram_sequence, 3))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.control = performance_controls.PitchHistogramPerformanceControlSignal(
+      window_size_seconds=1.0, prior_count=0)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testEncoder"><code class="name flex">
+<span>def <span class="ident">testEncoder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncoder(self):
+  histogram_sequence = [
+      [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  ]
+
+  expected_inputs = [
+      [0.25, 0, 0, 0, 0.375, 0, 0, 0.375, 0, 0, 0, 0],
+      [0.0, 0, 0, 0, 0.5, 0, 0, 0.5, 0, 0, 0, 0],
+      [0.0, 0, 0, 0, 1.0, 0, 0, 0.0, 0, 0, 0, 0],
+      [1.0 / 12.0] * 12
+  ]
+
+  self.assertEqual(
+      expected_inputs[0],
+      self.control.encoder.events_to_input(histogram_sequence, 0))
+  self.assertEqual(
+      expected_inputs[1],
+      self.control.encoder.events_to_input(histogram_sequence, 1))
+  self.assertEqual(
+      expected_inputs[2],
+      self.control.encoder.events_to_input(histogram_sequence, 2))
+  self.assertEqual(
+      expected_inputs[3],
+      self.control.encoder.events_to_input(histogram_sequence, 3))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testExtract"><code class="name flex">
+<span>def <span class="ident">testExtract</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtract(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 50),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 25),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 25),
+      pe(pe.NOTE_OFF, 64)
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  expected_histogram_sequence = [
+      [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+      [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+      [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+      [0.5, 0, 0, 0, 0.75, 0, 0, 0.75, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.25, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0.25, 0, 0, 0.0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  ]
+
+  histogram_sequence = self.control.extract(performance)
+  self.assertEqual(expected_histogram_sequence, histogram_sequence)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest" href="#note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest">NoteDensityPerformanceControlSignalTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.setUp" href="#note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testEncoder" href="#note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testEncoder">testEncoder</a></code></li>
+<li><code><a title="note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testExtract" href="#note_seq.performance_controls_test.NoteDensityPerformanceControlSignalTest.testExtract">testExtract</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest" href="#note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest">PitchHistogramPerformanceControlSignalTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.setUp" href="#note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testEncoder" href="#note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testEncoder">testEncoder</a></code></li>
+<li><code><a title="note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testExtract" href="#note_seq.performance_controls_test.PitchHistogramPerformanceControlSignalTest.testExtract">testExtract</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_encoder_decoder.html
+++ b/docs/performance_encoder_decoder.html
@@ -1,0 +1,1397 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between performance input and model input/output." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between performance input and model input/output.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between performance input and model input/output.&#34;&#34;&#34;
+
+import math
+
+from note_seq import encoder_decoder
+from note_seq import performance_lib
+from note_seq.encoder_decoder import EventSequenceEncoderDecoder
+from note_seq.performance_lib import PerformanceEvent
+import numpy as np
+
+# Number of floats used to encode NOTE_ON and NOTE_OFF events, using modulo-12
+# encoding. 5 floats for: valid, octave_cos, octave_sin, note_cos, note_sin.
+MODULO_PITCH_ENCODER_WIDTH = 5
+
+# Number of floats used to encode TIME_SHIFT and VELOCITY events using
+# module-bins encoding. 3 floats for: valid, event_cos, event_sin.
+MODULO_VELOCITY_ENCODER_WIDTH = 3
+MODULO_TIME_SHIFT_ENCODER_WIDTH = 3
+
+MODULO_EVENT_RANGES = [
+    (PerformanceEvent.NOTE_ON, performance_lib.MIN_MIDI_PITCH,
+     performance_lib.MAX_MIDI_PITCH, MODULO_PITCH_ENCODER_WIDTH),
+    (PerformanceEvent.NOTE_OFF, performance_lib.MIN_MIDI_PITCH,
+     performance_lib.MAX_MIDI_PITCH, MODULO_PITCH_ENCODER_WIDTH),
+]
+
+
+class PerformanceModuloEncoding(object):
+  &#34;&#34;&#34;Modulo encoding for performance events.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS):
+    &#34;&#34;&#34;Initiaizer for PerformanceModuloEncoding.
+
+    Args:
+      num_velocity_bins: Number of velocity bins.
+      max_shift_steps: Maximum number of shift steps supported.
+    &#34;&#34;&#34;
+
+    self._event_ranges = MODULO_EVENT_RANGES + [
+        (PerformanceEvent.TIME_SHIFT, 1, max_shift_steps,
+         MODULO_TIME_SHIFT_ENCODER_WIDTH)
+    ]
+    if num_velocity_bins &gt; 0:
+      self._event_ranges.append(
+          (PerformanceEvent.VELOCITY, 1, num_velocity_bins,
+           MODULO_VELOCITY_ENCODER_WIDTH))
+    self._max_shift_steps = max_shift_steps
+    self._num_velocity_bins = num_velocity_bins
+
+    # Create a lookup table for modulo-12 encoding of pitch classes.
+    # Possible values for semitone_steps are 1 and 7. A value of 1 corresponds
+    # to placing notes consecutively on the unit circle. A value of 7
+    # corresponds to following each note with one that is 7 semitones above it.
+    # semitone_steps = 1 seems to produce better results, and is the recommended
+    # value. Moreover, unit tests are provided only for semitone_steps = 1. If
+    # in the future you plan to enable support for semitone_steps = 7, then
+    # please make semitone_steps a parameter of this method, and add unit tests
+    # for it.
+    semitone_steps = 1
+    self._pitch_class_table = np.zeros((12, 2))
+    for i in range(12):
+      row = (i * semitone_steps) % 12
+      angle = (float(row) * math.pi) / 6.0
+      self._pitch_class_table[row] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-144 encoding of notes. Encode each note
+    # on a unit circle of 144 notes, spanning 12 octaves. Since there are only
+    # 128 midi notes, the last 16 positions on the unit circle will not be used.
+    self._note_table = np.zeros((144, 2))
+    for i in range(144):
+      angle = (float(i) * math.pi) / 72.0
+      self._note_table[i] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-bins encoding of time_shifts.
+    self._time_shift_table = np.zeros((max_shift_steps, 2))
+    for i in range(max_shift_steps):
+      angle = (float(i) * 2.0 * math.pi) / float(max_shift_steps)
+      self._time_shift_table[i] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-bins encoding of velocities.
+    if num_velocity_bins &gt; 0:
+      self._velocity_table = np.zeros((num_velocity_bins, 2))
+      for i in range(num_velocity_bins):
+        angle = (float(i) * 2.0 * math.pi) / float(num_velocity_bins)
+        self._velocity_table[i] = [math.cos(angle), math.sin(angle)]
+
+  @property
+  def input_size(self):
+    total = 0
+    for _, _, _, encoder_width in self._event_ranges:
+      total += encoder_width
+    return total
+
+  def encode_modulo_event(self, event):
+    offset = 0
+    for event_type, min_value, _, encoder_width in self._event_ranges:
+      if event.event_type == event_type:
+        value = event.event_value - min_value
+        return offset, event_type, value
+      offset += encoder_width
+
+    raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+  def embed_pitch_class(self, value):
+    if value &lt; 0 or value &gt;= 12:
+      raise ValueError(&#39;Unexpected pitch class value: %s&#39; % value)
+    return self._pitch_class_table[value]
+
+  def embed_note(self, value):
+    if value &lt; 0 or value &gt;= 144:
+      raise ValueError(&#39;Unexpected note value: %s&#39; % value)
+    return self._note_table[value]
+
+  def embed_time_shift(self, value):
+    if value &lt; 0 or value &gt;= self._max_shift_steps:
+      raise ValueError(&#39;Unexpected time shift value: %s&#39; % value)
+    return self._time_shift_table[value]
+
+  def embed_velocity(self, value):
+    if value &lt; 0 or value &gt;= self._num_velocity_bins:
+      raise ValueError(&#39;Unexpected velocity value: %s&#39; % value)
+    return self._velocity_table[value]
+
+
+class ModuloPerformanceEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder for modulo encoding performance events.
+
+  ModuloPerformanceEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder
+  that uses modulo/circular encoding for encoding performance input events, and
+  otherwise uses one hot encoding for encoding and decoding of labels.
+  &#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS):
+    &#34;&#34;&#34;Initialize a ModuloPerformanceEventSequenceEncoderDecoder object.
+
+    Args:
+      num_velocity_bins: Number of velocity bins.
+      max_shift_steps: Maximum number of shift steps supported.
+    &#34;&#34;&#34;
+
+    self._modulo_encoding = PerformanceModuloEncoding(
+        num_velocity_bins=num_velocity_bins, max_shift_steps=max_shift_steps)
+    self._one_hot_encoding = PerformanceOneHotEncoding(
+        num_velocity_bins=num_velocity_bins, max_shift_steps=max_shift_steps)
+
+  @property
+  def input_size(self):
+    return self._modulo_encoding.input_size
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a modulo/circular encoding for the given position in the performance
+      event sequence.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    offset, event_type, value = (self._modulo_encoding
+                                 .encode_modulo_event(events[position]))
+    input_[offset] = 1.0  # valid bit for the event
+    offset += 1
+    if event_type in (performance_lib.PerformanceEvent.NOTE_ON,
+                      performance_lib.PerformanceEvent.NOTE_OFF):
+
+      # Encode the note on a circle of 144 notes, covering 12 octaves.
+      cosine_sine_pair = self._modulo_encoding.embed_note(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+      offset += 2
+
+      # Encode the note&#39;s pitch class, using the encoder&#39;s lookup table.
+      value %= 12
+      cosine_sine_pair = self._modulo_encoding.embed_pitch_class(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+    else:
+      # This must be a velocity, or a time-shift event. Encode it using
+      # modulo-bins embedding.
+      if event_type == performance_lib.PerformanceEvent.TIME_SHIFT:
+        cosine_sine_pair = self._modulo_encoding.embed_time_shift(value)
+      else:
+        cosine_sine_pair = self._modulo_encoding.embed_velocity(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns the zero-based index value for the given position in the event
+    sequence, as determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)
+
+
+class PerformanceOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;One-hot encoding for performance events.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS,
+               min_pitch=performance_lib.MIN_MIDI_PITCH,
+               max_pitch=performance_lib.MAX_MIDI_PITCH):
+    self._event_ranges = [
+        (PerformanceEvent.NOTE_ON, min_pitch, max_pitch),
+        (PerformanceEvent.NOTE_OFF, min_pitch, max_pitch),
+        (PerformanceEvent.TIME_SHIFT, 1, max_shift_steps)
+    ]
+    if num_velocity_bins &gt; 0:
+      self._event_ranges.append(
+          (PerformanceEvent.VELOCITY, 1, num_velocity_bins))
+    self._max_shift_steps = max_shift_steps
+
+  @property
+  def num_classes(self):
+    return sum(max_value - min_value + 1
+               for event_type, min_value, max_value in self._event_ranges)
+
+  @property
+  def default_event(self):
+    return PerformanceEvent(
+        event_type=PerformanceEvent.TIME_SHIFT,
+        event_value=self._max_shift_steps)
+
+  def encode_event(self, event):
+    offset = 0
+    for event_type, min_value, max_value in self._event_ranges:
+      if event.event_type == event_type:
+        return offset + event.event_value - min_value
+      offset += max_value - min_value + 1
+
+    raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+  def decode_event(self, index):
+    offset = 0
+    for event_type, min_value, max_value in self._event_ranges:
+      if offset &lt;= index &lt;= offset + max_value - min_value:
+        return PerformanceEvent(
+            event_type=event_type, event_value=min_value + index - offset)
+      offset += max_value - min_value + 1
+
+    raise ValueError(&#39;Unknown event index: %s&#39; % index)
+
+  def event_to_num_steps(self, event):
+    if event.event_type == PerformanceEvent.TIME_SHIFT:
+      return event.event_value
+    else:
+      return 0
+
+
+class NotePerformanceEventSequenceEncoderDecoder(
+    EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;Multiple one-hot encoding for event tuples.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins, max_shift_steps=1000,
+               max_duration_steps=1000,
+               min_pitch=performance_lib.MIN_MIDI_PITCH,
+               max_pitch=performance_lib.MAX_MIDI_PITCH):
+    self._min_pitch = min_pitch
+
+    def optimal_num_segments(steps):
+      segments_indices = [(i, i + steps / i) for i in range(1, steps)
+                          if steps % i == 0]
+      return min(segments_indices, key=lambda v: v[1])[0]
+
+    # Add 1 because we need to represent 0 time shifts.
+    self._shift_steps_segments = optimal_num_segments(max_shift_steps + 1)
+    assert self._shift_steps_segments &gt; 1
+    self._shift_steps_per_segment = (
+        (max_shift_steps + 1) // self._shift_steps_segments)
+
+    self._max_duration_steps = max_duration_steps
+    self._duration_steps_segments = optimal_num_segments(max_duration_steps)
+    assert self._duration_steps_segments &gt; 1
+    self._duration_steps_per_segment = (
+        max_duration_steps // self._duration_steps_segments)
+
+    self._num_classes = [
+        # TIME_SHIFT major
+        self._shift_steps_segments,
+        # TIME_SHIFT minor
+        self._shift_steps_per_segment,
+        # NOTE_ON
+        max_pitch - min_pitch + 1,
+        # VELOCITY
+        num_velocity_bins,
+        # DURATION major
+        self._duration_steps_segments,
+        # DURATION minor
+        self._duration_steps_per_segment,
+    ]
+
+  @property
+  def input_size(self):
+    return sum(self._num_classes)
+
+  @property
+  def num_classes(self):
+    return self._num_classes
+
+  @property
+  def shift_steps_segments(self):
+    return self._shift_steps_segments
+
+  @property
+  def duration_steps_segments(self):
+    return self._duration_steps_segments
+
+  @property
+  def shift_steps_per_segment(self):
+    return self._shift_steps_per_segment
+
+  @property
+  def duration_steps_per_segment(self):
+    return self._duration_steps_per_segment
+
+  @property
+  def default_event_label(self):
+    return self._encode_event(
+        (PerformanceEvent(PerformanceEvent.TIME_SHIFT, 0),
+         PerformanceEvent(PerformanceEvent.NOTE_ON, 60),
+         PerformanceEvent(PerformanceEvent.VELOCITY, 1),
+         PerformanceEvent(PerformanceEvent.DURATION, 1)))
+
+  def _encode_event(self, event):
+    time_shift_major = event[0].event_value // self._shift_steps_per_segment
+    time_shift_minor = event[0].event_value % self._shift_steps_per_segment
+
+    note_on = event[1].event_value - self._min_pitch
+
+    velocity = event[2].event_value - 1
+
+    # Don&#39;t need to represent 0 duration, so subtract 1.
+    duration_value = event[3].event_value - 1
+    duration_major = duration_value // self._duration_steps_per_segment
+    duration_minor = duration_value % self._duration_steps_per_segment
+
+    return (time_shift_major, time_shift_minor, note_on, velocity,
+            duration_major, duration_minor)
+
+  def events_to_input(self, events, position):
+    event = events[position]
+    encoded = self._encode_event(event)
+
+    one_hots = []
+    for i, encoded_sub_event in enumerate(encoded):
+      one_hot = [0.0] * self._num_classes[i]
+      one_hot[encoded_sub_event] = 1.0
+      one_hots.append(one_hot)
+
+    return np.hstack(one_hots)
+
+  def events_to_label(self, events, position):
+    event = events[position]
+
+    return self._encode_event(event)
+
+  def class_index_to_event(self, class_index, events):
+    class_indices = class_index
+    time_shift = (class_indices[0] * self._shift_steps_per_segment +
+                  class_indices[1])
+    pitch = class_indices[2] + self._min_pitch
+    velocity = class_indices[3] + 1
+    duration = (class_indices[4] * self._duration_steps_per_segment +
+                class_indices[5]) + 1
+
+    return (PerformanceEvent(PerformanceEvent.TIME_SHIFT, time_shift),
+            PerformanceEvent(PerformanceEvent.NOTE_ON, pitch),
+            PerformanceEvent(PerformanceEvent.VELOCITY, velocity),
+            PerformanceEvent(PerformanceEvent.DURATION, duration))
+
+  def labels_to_num_steps(self, labels):
+    steps = 0
+    for label in labels:
+      event = self.class_index_to_event(label, None)
+      steps += event[0].event_value
+    if event:
+      steps += event[3].event_value
+    return steps</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">ModuloPerformanceEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>num_velocity_bins=0, max_shift_steps=100)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An EventSequenceEncoderDecoder for modulo encoding performance events.</p>
+<p>ModuloPerformanceEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder
+that uses modulo/circular encoding for encoding performance input events, and
+otherwise uses one hot encoding for encoding and decoding of labels.</p>
+<p>Initialize a ModuloPerformanceEventSequenceEncoderDecoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins.</dd>
+<dt><strong><code>max_shift_steps</code></strong></dt>
+<dd>Maximum number of shift steps supported.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ModuloPerformanceEventSequenceEncoderDecoder(EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder for modulo encoding performance events.
+
+  ModuloPerformanceEventSequenceEncoderDecoder is an EventSequenceEncoderDecoder
+  that uses modulo/circular encoding for encoding performance input events, and
+  otherwise uses one hot encoding for encoding and decoding of labels.
+  &#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS):
+    &#34;&#34;&#34;Initialize a ModuloPerformanceEventSequenceEncoderDecoder object.
+
+    Args:
+      num_velocity_bins: Number of velocity bins.
+      max_shift_steps: Maximum number of shift steps supported.
+    &#34;&#34;&#34;
+
+    self._modulo_encoding = PerformanceModuloEncoding(
+        num_velocity_bins=num_velocity_bins, max_shift_steps=max_shift_steps)
+    self._one_hot_encoding = PerformanceOneHotEncoding(
+        num_velocity_bins=num_velocity_bins, max_shift_steps=max_shift_steps)
+
+  @property
+  def input_size(self):
+    return self._modulo_encoding.input_size
+
+  @property
+  def num_classes(self):
+    return self._one_hot_encoding.num_classes
+
+  @property
+  def default_event_label(self):
+    return self._one_hot_encoding.encode_event(
+        self._one_hot_encoding.default_event)
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Returns a modulo/circular encoding for the given position in the performance
+      event sequence.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    input_ = [0.0] * self.input_size
+    offset, event_type, value = (self._modulo_encoding
+                                 .encode_modulo_event(events[position]))
+    input_[offset] = 1.0  # valid bit for the event
+    offset += 1
+    if event_type in (performance_lib.PerformanceEvent.NOTE_ON,
+                      performance_lib.PerformanceEvent.NOTE_OFF):
+
+      # Encode the note on a circle of 144 notes, covering 12 octaves.
+      cosine_sine_pair = self._modulo_encoding.embed_note(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+      offset += 2
+
+      # Encode the note&#39;s pitch class, using the encoder&#39;s lookup table.
+      value %= 12
+      cosine_sine_pair = self._modulo_encoding.embed_pitch_class(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+    else:
+      # This must be a velocity, or a time-shift event. Encode it using
+      # modulo-bins embedding.
+      if event_type == performance_lib.PerformanceEvent.TIME_SHIFT:
+        cosine_sine_pair = self._modulo_encoding.embed_time_shift(value)
+      else:
+        cosine_sine_pair = self._modulo_encoding.embed_velocity(value)
+      input_[offset] = cosine_sine_pair[0]
+      input_[offset + 1] = cosine_sine_pair[1]
+    return input_
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Returns the zero-based index value for the given position in the event
+    sequence, as determined by the one hot encoding.
+
+    Args:
+      events: A list-like sequence of events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.encode_event(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An event value.
+    &#34;&#34;&#34;
+    return self._one_hot_encoding.decode_event(class_index)
+
+  def labels_to_num_steps(self, labels):
+    &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+    Args:
+      labels: A list-like sequence of integers in the range
+          [0, self.num_classes).
+
+    Returns:
+      The total number of time steps for the label sequence, as determined by
+      the one-hot encoding.
+    &#34;&#34;&#34;
+    events = []
+    for label in labels:
+      events.append(self.class_index_to_event(label, events))
+    return sum(self._one_hot_encoding.event_to_num_steps(event)
+               for event in events)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An integer in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events. This object is not used in this
+implementation.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An integer in the range [0, self.num_classes).
+    events: A list-like sequence of events. This object is not used in this
+        implementation.
+
+  Returns:
+    An event value.
+  &#34;&#34;&#34;
+  return self._one_hot_encoding.decode_event(class_index)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the event sequence.</p>
+<p>Returns a modulo/circular encoding for the given position in the performance
+event sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, a list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+  Returns a modulo/circular encoding for the given position in the performance
+    event sequence.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    An input vector, a list of floats.
+  &#34;&#34;&#34;
+  input_ = [0.0] * self.input_size
+  offset, event_type, value = (self._modulo_encoding
+                               .encode_modulo_event(events[position]))
+  input_[offset] = 1.0  # valid bit for the event
+  offset += 1
+  if event_type in (performance_lib.PerformanceEvent.NOTE_ON,
+                    performance_lib.PerformanceEvent.NOTE_OFF):
+
+    # Encode the note on a circle of 144 notes, covering 12 octaves.
+    cosine_sine_pair = self._modulo_encoding.embed_note(value)
+    input_[offset] = cosine_sine_pair[0]
+    input_[offset + 1] = cosine_sine_pair[1]
+    offset += 2
+
+    # Encode the note&#39;s pitch class, using the encoder&#39;s lookup table.
+    value %= 12
+    cosine_sine_pair = self._modulo_encoding.embed_pitch_class(value)
+    input_[offset] = cosine_sine_pair[0]
+    input_[offset + 1] = cosine_sine_pair[1]
+  else:
+    # This must be a velocity, or a time-shift event. Encode it using
+    # modulo-bins embedding.
+    if event_type == performance_lib.PerformanceEvent.TIME_SHIFT:
+      cosine_sine_pair = self._modulo_encoding.embed_time_shift(value)
+    else:
+      cosine_sine_pair = self._modulo_encoding.embed_velocity(value)
+    input_[offset] = cosine_sine_pair[0]
+    input_[offset + 1] = cosine_sine_pair[1]
+  return input_</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the event sequence.</p>
+<p>Returns the zero-based index value for the given position in the event
+sequence, as determined by the one hot encoding.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+  Returns the zero-based index value for the given position in the event
+  sequence, as determined by the one hot encoding.
+
+  Args:
+    events: A list-like sequence of events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  return self._one_hot_encoding.encode_event(events[position])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.labels_to_num_steps"><code class="name flex">
+<span>def <span class="ident">labels_to_num_steps</span></span>(<span>self, labels)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the total number of time steps for a sequence of class labels.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>labels</code></strong></dt>
+<dd>A list-like sequence of integers in the range
+[0, self.num_classes).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The total number of time steps for the label sequence, as determined by
+the one-hot encoding.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def labels_to_num_steps(self, labels):
+  &#34;&#34;&#34;Returns the total number of time steps for a sequence of class labels.
+
+  Args:
+    labels: A list-like sequence of integers in the range
+        [0, self.num_classes).
+
+  Returns:
+    The total number of time steps for the label sequence, as determined by
+    the one-hot encoding.
+  &#34;&#34;&#34;
+  events = []
+  for label in labels:
+    events.append(self.class_index_to_event(label, events))
+  return sum(self._one_hot_encoding.event_to_num_steps(event)
+             for event in events)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">NotePerformanceEventSequenceEncoderDecoder</span></span>
+<span>(</span><span>num_velocity_bins, max_shift_steps=1000, max_duration_steps=1000, min_pitch=0, max_pitch=127)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Multiple one-hot encoding for event tuples.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NotePerformanceEventSequenceEncoderDecoder(
+    EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;Multiple one-hot encoding for event tuples.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins, max_shift_steps=1000,
+               max_duration_steps=1000,
+               min_pitch=performance_lib.MIN_MIDI_PITCH,
+               max_pitch=performance_lib.MAX_MIDI_PITCH):
+    self._min_pitch = min_pitch
+
+    def optimal_num_segments(steps):
+      segments_indices = [(i, i + steps / i) for i in range(1, steps)
+                          if steps % i == 0]
+      return min(segments_indices, key=lambda v: v[1])[0]
+
+    # Add 1 because we need to represent 0 time shifts.
+    self._shift_steps_segments = optimal_num_segments(max_shift_steps + 1)
+    assert self._shift_steps_segments &gt; 1
+    self._shift_steps_per_segment = (
+        (max_shift_steps + 1) // self._shift_steps_segments)
+
+    self._max_duration_steps = max_duration_steps
+    self._duration_steps_segments = optimal_num_segments(max_duration_steps)
+    assert self._duration_steps_segments &gt; 1
+    self._duration_steps_per_segment = (
+        max_duration_steps // self._duration_steps_segments)
+
+    self._num_classes = [
+        # TIME_SHIFT major
+        self._shift_steps_segments,
+        # TIME_SHIFT minor
+        self._shift_steps_per_segment,
+        # NOTE_ON
+        max_pitch - min_pitch + 1,
+        # VELOCITY
+        num_velocity_bins,
+        # DURATION major
+        self._duration_steps_segments,
+        # DURATION minor
+        self._duration_steps_per_segment,
+    ]
+
+  @property
+  def input_size(self):
+    return sum(self._num_classes)
+
+  @property
+  def num_classes(self):
+    return self._num_classes
+
+  @property
+  def shift_steps_segments(self):
+    return self._shift_steps_segments
+
+  @property
+  def duration_steps_segments(self):
+    return self._duration_steps_segments
+
+  @property
+  def shift_steps_per_segment(self):
+    return self._shift_steps_per_segment
+
+  @property
+  def duration_steps_per_segment(self):
+    return self._duration_steps_per_segment
+
+  @property
+  def default_event_label(self):
+    return self._encode_event(
+        (PerformanceEvent(PerformanceEvent.TIME_SHIFT, 0),
+         PerformanceEvent(PerformanceEvent.NOTE_ON, 60),
+         PerformanceEvent(PerformanceEvent.VELOCITY, 1),
+         PerformanceEvent(PerformanceEvent.DURATION, 1)))
+
+  def _encode_event(self, event):
+    time_shift_major = event[0].event_value // self._shift_steps_per_segment
+    time_shift_minor = event[0].event_value % self._shift_steps_per_segment
+
+    note_on = event[1].event_value - self._min_pitch
+
+    velocity = event[2].event_value - 1
+
+    # Don&#39;t need to represent 0 duration, so subtract 1.
+    duration_value = event[3].event_value - 1
+    duration_major = duration_value // self._duration_steps_per_segment
+    duration_minor = duration_value % self._duration_steps_per_segment
+
+    return (time_shift_major, time_shift_minor, note_on, velocity,
+            duration_major, duration_minor)
+
+  def events_to_input(self, events, position):
+    event = events[position]
+    encoded = self._encode_event(event)
+
+    one_hots = []
+    for i, encoded_sub_event in enumerate(encoded):
+      one_hot = [0.0] * self._num_classes[i]
+      one_hot[encoded_sub_event] = 1.0
+      one_hots.append(one_hot)
+
+    return np.hstack(one_hots)
+
+  def events_to_label(self, events, position):
+    event = events[position]
+
+    return self._encode_event(event)
+
+  def class_index_to_event(self, class_index, events):
+    class_indices = class_index
+    time_shift = (class_indices[0] * self._shift_steps_per_segment +
+                  class_indices[1])
+    pitch = class_indices[2] + self._min_pitch
+    velocity = class_indices[3] + 1
+    duration = (class_indices[4] * self._duration_steps_per_segment +
+                class_indices[5]) + 1
+
+    return (PerformanceEvent(PerformanceEvent.TIME_SHIFT, time_shift),
+            PerformanceEvent(PerformanceEvent.NOTE_ON, pitch),
+            PerformanceEvent(PerformanceEvent.VELOCITY, velocity),
+            PerformanceEvent(PerformanceEvent.DURATION, duration))
+
+  def labels_to_num_steps(self, labels):
+    steps = 0
+    for label in labels:
+      event = self.class_index_to_event(label, None)
+      steps += event[0].event_value
+    if event:
+      steps += event[3].event_value
+    return steps</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_per_segment"><code class="name">var <span class="ident">duration_steps_per_segment</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def duration_steps_per_segment(self):
+  return self._duration_steps_per_segment</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_segments"><code class="name">var <span class="ident">duration_steps_segments</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def duration_steps_segments(self):
+  return self._duration_steps_segments</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_per_segment"><code class="name">var <span class="ident">shift_steps_per_segment</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def shift_steps_per_segment(self):
+  return self._shift_steps_per_segment</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_segments"><code class="name">var <span class="ident">shift_steps_segments</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def shift_steps_segments(self):
+  return self._shift_steps_segments</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding"><code class="flex name class">
+<span>class <span class="ident">PerformanceModuloEncoding</span></span>
+<span>(</span><span>num_velocity_bins=0, max_shift_steps=100)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Modulo encoding for performance events.</p>
+<p>Initiaizer for PerformanceModuloEncoding.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins.</dd>
+<dt><strong><code>max_shift_steps</code></strong></dt>
+<dd>Maximum number of shift steps supported.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceModuloEncoding(object):
+  &#34;&#34;&#34;Modulo encoding for performance events.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS):
+    &#34;&#34;&#34;Initiaizer for PerformanceModuloEncoding.
+
+    Args:
+      num_velocity_bins: Number of velocity bins.
+      max_shift_steps: Maximum number of shift steps supported.
+    &#34;&#34;&#34;
+
+    self._event_ranges = MODULO_EVENT_RANGES + [
+        (PerformanceEvent.TIME_SHIFT, 1, max_shift_steps,
+         MODULO_TIME_SHIFT_ENCODER_WIDTH)
+    ]
+    if num_velocity_bins &gt; 0:
+      self._event_ranges.append(
+          (PerformanceEvent.VELOCITY, 1, num_velocity_bins,
+           MODULO_VELOCITY_ENCODER_WIDTH))
+    self._max_shift_steps = max_shift_steps
+    self._num_velocity_bins = num_velocity_bins
+
+    # Create a lookup table for modulo-12 encoding of pitch classes.
+    # Possible values for semitone_steps are 1 and 7. A value of 1 corresponds
+    # to placing notes consecutively on the unit circle. A value of 7
+    # corresponds to following each note with one that is 7 semitones above it.
+    # semitone_steps = 1 seems to produce better results, and is the recommended
+    # value. Moreover, unit tests are provided only for semitone_steps = 1. If
+    # in the future you plan to enable support for semitone_steps = 7, then
+    # please make semitone_steps a parameter of this method, and add unit tests
+    # for it.
+    semitone_steps = 1
+    self._pitch_class_table = np.zeros((12, 2))
+    for i in range(12):
+      row = (i * semitone_steps) % 12
+      angle = (float(row) * math.pi) / 6.0
+      self._pitch_class_table[row] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-144 encoding of notes. Encode each note
+    # on a unit circle of 144 notes, spanning 12 octaves. Since there are only
+    # 128 midi notes, the last 16 positions on the unit circle will not be used.
+    self._note_table = np.zeros((144, 2))
+    for i in range(144):
+      angle = (float(i) * math.pi) / 72.0
+      self._note_table[i] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-bins encoding of time_shifts.
+    self._time_shift_table = np.zeros((max_shift_steps, 2))
+    for i in range(max_shift_steps):
+      angle = (float(i) * 2.0 * math.pi) / float(max_shift_steps)
+      self._time_shift_table[i] = [math.cos(angle), math.sin(angle)]
+
+    # Create a lookup table for modulo-bins encoding of velocities.
+    if num_velocity_bins &gt; 0:
+      self._velocity_table = np.zeros((num_velocity_bins, 2))
+      for i in range(num_velocity_bins):
+        angle = (float(i) * 2.0 * math.pi) / float(num_velocity_bins)
+        self._velocity_table[i] = [math.cos(angle), math.sin(angle)]
+
+  @property
+  def input_size(self):
+    total = 0
+    for _, _, _, encoder_width in self._event_ranges:
+      total += encoder_width
+    return total
+
+  def encode_modulo_event(self, event):
+    offset = 0
+    for event_type, min_value, _, encoder_width in self._event_ranges:
+      if event.event_type == event_type:
+        value = event.event_value - min_value
+        return offset, event_type, value
+      offset += encoder_width
+
+    raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+  def embed_pitch_class(self, value):
+    if value &lt; 0 or value &gt;= 12:
+      raise ValueError(&#39;Unexpected pitch class value: %s&#39; % value)
+    return self._pitch_class_table[value]
+
+  def embed_note(self, value):
+    if value &lt; 0 or value &gt;= 144:
+      raise ValueError(&#39;Unexpected note value: %s&#39; % value)
+    return self._note_table[value]
+
+  def embed_time_shift(self, value):
+    if value &lt; 0 or value &gt;= self._max_shift_steps:
+      raise ValueError(&#39;Unexpected time shift value: %s&#39; % value)
+    return self._time_shift_table[value]
+
+  def embed_velocity(self, value):
+    if value &lt; 0 or value &gt;= self._num_velocity_bins:
+      raise ValueError(&#39;Unexpected velocity value: %s&#39; % value)
+    return self._velocity_table[value]</code></pre>
+</details>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.input_size"><code class="name">var <span class="ident">input_size</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def input_size(self):
+  total = 0
+  for _, _, _, encoder_width in self._event_ranges:
+    total += encoder_width
+  return total</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_note"><code class="name flex">
+<span>def <span class="ident">embed_note</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def embed_note(self, value):
+  if value &lt; 0 or value &gt;= 144:
+    raise ValueError(&#39;Unexpected note value: %s&#39; % value)
+  return self._note_table[value]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_pitch_class"><code class="name flex">
+<span>def <span class="ident">embed_pitch_class</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def embed_pitch_class(self, value):
+  if value &lt; 0 or value &gt;= 12:
+    raise ValueError(&#39;Unexpected pitch class value: %s&#39; % value)
+  return self._pitch_class_table[value]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_time_shift"><code class="name flex">
+<span>def <span class="ident">embed_time_shift</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def embed_time_shift(self, value):
+  if value &lt; 0 or value &gt;= self._max_shift_steps:
+    raise ValueError(&#39;Unexpected time shift value: %s&#39; % value)
+  return self._time_shift_table[value]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_velocity"><code class="name flex">
+<span>def <span class="ident">embed_velocity</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def embed_velocity(self, value):
+  if value &lt; 0 or value &gt;= self._num_velocity_bins:
+    raise ValueError(&#39;Unexpected velocity value: %s&#39; % value)
+  return self._velocity_table[value]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.encode_modulo_event"><code class="name flex">
+<span>def <span class="ident">encode_modulo_event</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def encode_modulo_event(self, event):
+  offset = 0
+  for event_type, min_value, _, encoder_width in self._event_ranges:
+    if event.event_type == event_type:
+      value = event.event_value - min_value
+      return offset, event_type, value
+    offset += encoder_width
+
+  raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_encoder_decoder.PerformanceOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">PerformanceOneHotEncoding</span></span>
+<span>(</span><span>num_velocity_bins=0, max_shift_steps=100, min_pitch=0, max_pitch=127)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>One-hot encoding for performance events.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;One-hot encoding for performance events.&#34;&#34;&#34;
+
+  def __init__(self, num_velocity_bins=0,
+               max_shift_steps=performance_lib.DEFAULT_MAX_SHIFT_STEPS,
+               min_pitch=performance_lib.MIN_MIDI_PITCH,
+               max_pitch=performance_lib.MAX_MIDI_PITCH):
+    self._event_ranges = [
+        (PerformanceEvent.NOTE_ON, min_pitch, max_pitch),
+        (PerformanceEvent.NOTE_OFF, min_pitch, max_pitch),
+        (PerformanceEvent.TIME_SHIFT, 1, max_shift_steps)
+    ]
+    if num_velocity_bins &gt; 0:
+      self._event_ranges.append(
+          (PerformanceEvent.VELOCITY, 1, num_velocity_bins))
+    self._max_shift_steps = max_shift_steps
+
+  @property
+  def num_classes(self):
+    return sum(max_value - min_value + 1
+               for event_type, min_value, max_value in self._event_ranges)
+
+  @property
+  def default_event(self):
+    return PerformanceEvent(
+        event_type=PerformanceEvent.TIME_SHIFT,
+        event_value=self._max_shift_steps)
+
+  def encode_event(self, event):
+    offset = 0
+    for event_type, min_value, max_value in self._event_ranges:
+      if event.event_type == event_type:
+        return offset + event.event_value - min_value
+      offset += max_value - min_value + 1
+
+    raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+  def decode_event(self, index):
+    offset = 0
+    for event_type, min_value, max_value in self._event_ranges:
+      if offset &lt;= index &lt;= offset + max_value - min_value:
+        return PerformanceEvent(
+            event_type=event_type, event_value=min_value + index - offset)
+      offset += max_value - min_value + 1
+
+    raise ValueError(&#39;Unknown event index: %s&#39; % index)
+
+  def event_to_num_steps(self, event):
+    if event.event_type == PerformanceEvent.TIME_SHIFT:
+      return event.event_value
+    else:
+      return 0</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder" href="#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder">ModuloPerformanceEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.class_index_to_event" href="#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_input" href="#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_label" href="#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.labels_to_num_steps" href="#note_seq.performance_encoder_decoder.ModuloPerformanceEventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder" href="#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder">NotePerformanceEventSequenceEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_per_segment" href="#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_per_segment">duration_steps_per_segment</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_segments" href="#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.duration_steps_segments">duration_steps_segments</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_per_segment" href="#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_per_segment">shift_steps_per_segment</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_segments" href="#note_seq.performance_encoder_decoder.NotePerformanceEventSequenceEncoderDecoder.shift_steps_segments">shift_steps_segments</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding">PerformanceModuloEncoding</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_note" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_note">embed_note</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_pitch_class" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_pitch_class">embed_pitch_class</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_time_shift" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_time_shift">embed_time_shift</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_velocity" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.embed_velocity">embed_velocity</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.encode_modulo_event" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.encode_modulo_event">encode_modulo_event</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder.PerformanceModuloEncoding.input_size" href="#note_seq.performance_encoder_decoder.PerformanceModuloEncoding.input_size">input_size</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder.PerformanceOneHotEncoding" href="#note_seq.performance_encoder_decoder.PerformanceOneHotEncoding">PerformanceOneHotEncoding</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_encoder_decoder_test.html
+++ b/docs/performance_encoder_decoder_test.html
@@ -1,0 +1,1473 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for performance_encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for performance_encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for performance_encoder_decoder.&#34;&#34;&#34;
+
+import math
+
+from absl.testing import absltest
+from note_seq import performance_encoder_decoder
+from note_seq import performance_lib
+from note_seq.performance_encoder_decoder import ModuloPerformanceEventSequenceEncoderDecoder
+from note_seq.performance_encoder_decoder import NotePerformanceEventSequenceEncoderDecoder
+from note_seq.performance_encoder_decoder import PerformanceModuloEncoding
+from note_seq.performance_lib import PerformanceEvent
+
+cos = math.cos
+sin = math.sin
+pi = math.pi
+
+
+class PerformanceOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = performance_encoder_decoder.PerformanceOneHotEncoding(
+        num_velocity_bins=16)
+
+  def testEncodeDecode(self):
+    expected_pairs = [
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=60), 60),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=0), 0),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=127), 127),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=72), 200),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=0), 128),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127), 255),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10), 265),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1), 256),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100), 355),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=5), 360),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=1), 356),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=16), 371)
+    ]
+
+    for expected_event, expected_index in expected_pairs:
+      index = self.enc.encode_event(expected_event)
+      self.assertEqual(expected_index, index)
+      event = self.enc.decode_event(expected_index)
+      self.assertEqual(expected_event, event)
+
+  def testEventToNumSteps(self):
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60)))
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=67)))
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=10)))
+
+    self.assertEqual(1, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1)))
+    self.assertEqual(45, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=45)))
+    self.assertEqual(100, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100)))
+
+
+class PerformanceModuloEncodingTest(absltest.TestCase):
+  &#34;&#34;&#34;Test class for PerformanceModuloEncoding.&#34;&#34;&#34;
+
+  def setUp(self):
+    self._num_velocity_bins = 16
+    self._max_shift_steps = performance_lib.DEFAULT_MAX_SHIFT_STEPS
+    self.enc = PerformanceModuloEncoding(
+        num_velocity_bins=self._num_velocity_bins,
+        max_shift_steps=self._max_shift_steps)
+
+    self._expected_input_size = (
+        2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+    self._expected_num_classes = (self._num_velocity_bins +
+                                  self._max_shift_steps +
+                                  (performance_lib.MAX_MIDI_PITCH -
+                                   performance_lib.MIN_MIDI_PITCH + 1) * 2)
+
+  def testInputSize(self):
+    self.assertEqual(self._expected_input_size, self.enc.input_size)
+
+  def testEmbedPitchClass(self):
+    # The following are true only for semitone_steps = 1.
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (1, (cos(pi / 6.0), sin(pi / 6.0))),
+        (2, (cos(pi / 3.0), sin(pi / 3.0))),
+        (3, (cos(pi / 2.0), sin(pi / 2.0))),
+        (4, (cos(2.0 * pi / 3.0), sin(2.0 * pi / 3.0))),
+        (5, (cos(5.0 * pi / 6.0), sin(5.0 * pi / 6.0))),
+        (6, (cos(pi), sin(pi))),
+        (7, (cos(7.0 * pi / 6.0), sin(7.0 * pi / 6.0))),
+        (8, (cos(4.0 * pi / 3.0), sin(4.0 * pi / 3.0))),
+        (9, (cos(3.0 * pi / 2.0), sin(3.0 * pi / 2.0))),
+        (10, (cos(5.0 * pi / 3.0), sin(5.0 * pi / 3.0))),
+        (11, (cos(11.0 * pi / 6.0), sin(11.0 * pi / 6.0)))]
+
+    for note, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_pitch_class(note)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedNote(self):
+    # The following are true only for semitone_steps = 1.
+    base = 72.0
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (13, (cos(pi * 13.0 / base), sin(pi * 13.0 / base))),
+        (26, (cos(pi * 26.0 / base), sin(pi * 26.0 / base))),
+        (39, (cos(pi * 39.0 / base), sin(pi * 39.0 / base))),
+        (52, (cos(pi * 52.0 / base), sin(pi * 52.0 / base))),
+        (65, (cos(pi * 65.0 / base), sin(pi * 65.0 / base))),
+        (78, (cos(pi * 78.0 / base), sin(pi * 78.0 / base))),
+        (91, (cos(pi * 91.0 / base), sin(pi * 91.0 / base))),
+        (104, (cos(pi * 104.0 / base), sin(pi * 104.0 / base))),
+        (117, (cos(pi * 117.0 / base), sin(pi * 117.0 / base))),
+        (130, (cos(pi * 130.0 / base), sin(pi * 130.0 / base))),
+        (143, (cos(pi * 143.0 / base), sin(pi * 143.0 / base)))]
+
+    for note, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_note(note)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedTimeShift(self):
+    # The following are true only for semitone_steps = 1.
+    base = self._max_shift_steps  # 100
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+        (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+        (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+        (20, (cos(2.0 * pi * 20.0 / base), sin(2.0 * pi * 20.0 / base))),
+        (45, (cos(2.0 * pi * 45.0 / base), sin(2.0 * pi * 45.0 / base))),
+        (70, (cos(2.0 * pi * 70.0 / base), sin(2.0 * pi * 70.0 / base))),
+        (99, (cos(2.0 * pi * 99.0 / base), sin(2.0 * pi * 99.0 / base)))]
+
+    for time_shift, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_time_shift(time_shift)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedVelocity(self):
+    # The following are true only for semitone_steps = 1.
+    base = self._num_velocity_bins  # 16
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+        (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+        (7, (cos(2.0 * pi * 7.0 / base), sin(2.0 * pi * 7.0 / base))),
+        (10, (cos(2.0 * pi * 10.0 / base), sin(2.0 * pi * 10.0 / base))),
+        (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+        (15, (cos(2.0 * pi * 15.0 / base), sin(2.0 * pi * 15.0 / base)))]
+
+    for velocity, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_velocity(velocity)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEncodeModuloEvent(self):
+    expected_pairs = [
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+         (0, PerformanceEvent.NOTE_ON, 60)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+         (0, PerformanceEvent.NOTE_ON, 0)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+         (0, PerformanceEvent.NOTE_ON, 127)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+         (5, PerformanceEvent.NOTE_OFF, 72)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+         (5, PerformanceEvent.NOTE_OFF, 0)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+         (5, PerformanceEvent.NOTE_OFF, 127)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+         (10, PerformanceEvent.TIME_SHIFT, 9)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+         (10, PerformanceEvent.TIME_SHIFT, 0)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+         (10, PerformanceEvent.TIME_SHIFT, 99)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+         (13, PerformanceEvent.VELOCITY, 4)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+         (13, PerformanceEvent.VELOCITY, 0)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+         (13, PerformanceEvent.VELOCITY, 15)),
+    ]
+
+    # expected_encoded_modulo_event is of the following form:
+    # (offset, encoder_width, event_type, value, bins)
+    for event, expected_encoded_modulo_event in expected_pairs:
+      actual_encoded_modulo_event = self.enc.encode_modulo_event(event)
+      self.assertEqual(actual_encoded_modulo_event,
+                       expected_encoded_modulo_event)
+
+
+class ModuloPerformanceEventSequenceEncoderTest(absltest.TestCase):
+  &#34;&#34;&#34;Test class for ModuloPerformanceEventSequenceEncoder.
+
+  ModuloPerformanceEventSequenceEncoderDecoder is tightly coupled with the
+  PerformanceModuloEncoding, and PerformanceOneHotEncoding classes. As a result,
+  in the test set up, the test object is initialized with one of each objects
+  and tested accordingly. Since this class only modifies the input encoding
+  of performance events, and otherwise its treatment of labels is the same as
+  OneHotEventSequenceEncoderDecoder, the events_to_labels(), and
+  class_index_to_event() methods of the class are not tested.
+  &#34;&#34;&#34;
+
+  def setUp(self):
+    self._num_velocity_bins = 32
+    self._max_shift_steps = 100
+    self.enc = ModuloPerformanceEventSequenceEncoderDecoder(
+        num_velocity_bins=self._num_velocity_bins,
+        max_shift_steps=self._max_shift_steps)
+
+    self._expected_input_size = (
+        2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+    self._expected_num_classes = (self._num_velocity_bins +
+                                  self._max_shift_steps +
+                                  2 * (performance_lib.MAX_MIDI_PITCH -
+                                       performance_lib.MIN_MIDI_PITCH + 1))
+
+  def testInputSize(self):
+    self.assertEqual(self._expected_input_size, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(self._expected_num_classes, self.enc.num_classes)
+
+  def testDefaultEventLabel(self):
+    label = self._expected_num_classes - self._num_velocity_bins - 1
+    self.assertEqual(label, self.enc.default_event_label)
+
+  def testEventsToInput(self):
+    num_shift_bins = self._max_shift_steps
+    num_velocity_bins = self._num_velocity_bins
+    slow_base = 2.0 * pi / 144.0
+    fast_base = 2.0 * pi / 12.0
+    shift_base = 2.0 * pi / num_shift_bins
+    velocity_base = 2.0 * pi / num_velocity_bins
+
+    expected_pairs = [
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+         [1.0, cos(60.0 * slow_base), sin(60.0 * slow_base),
+          cos(60.0 * fast_base), sin(60.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+         [1.0, cos(0.0 * slow_base), sin(0.0 * slow_base),
+          cos(0.0 * fast_base), sin(0.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+         [1.0, cos(127.0 * slow_base), sin(127.0 * slow_base),
+          cos(127.0 * fast_base), sin(127.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(72.0 * slow_base), sin(72.0 * slow_base),
+          cos(72.0 * fast_base), sin(72.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(0.0 * slow_base), sin(0.0 * slow_base),
+          cos(0.0 * fast_base), sin(0.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(127.0 * slow_base), sin(127.0 * slow_base),
+          cos(127.0 * fast_base), sin(127.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(9.0 * shift_base), sin(9.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(0.0 * shift_base), sin(0.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(99.0 * shift_base), sin(99.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(4.0 * velocity_base), sin(4.0 * velocity_base)]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(0.0 * velocity_base), sin(0.0 * velocity_base)]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(15.0 * velocity_base), sin(15.0 * velocity_base)]),
+    ]
+
+    events = []
+    position = 0
+    for event, expected_encoded_modulo_event in expected_pairs:
+      events += [event]
+      actual_encoded_modulo_event = self.enc.events_to_input(events, position)
+      position += 1
+      for i in range(self._expected_input_size):
+        self.assertAlmostEqual(expected_encoded_modulo_event[i],
+                               actual_encoded_modulo_event[i])
+
+
+class NotePerformanceEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = NotePerformanceEventSequenceEncoderDecoder(
+        num_velocity_bins=16, max_shift_steps=99, max_duration_steps=500)
+
+    self.assertEqual(10, self.enc.shift_steps_segments)
+    self.assertEqual(20, self.enc.duration_steps_segments)
+
+  def testEncodeDecode(self):
+    pe = PerformanceEvent
+    performance = [
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 401)),
+        (pe(pe.TIME_SHIFT, 55), pe(pe.NOTE_ON, 64),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 310)),
+        (pe(pe.TIME_SHIFT, 99), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 1)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 500)),
+    ]
+
+    labels = [self.enc.events_to_label(performance, i)
+              for i in range(len(performance))]
+
+    expected_labels = [
+        (0, 0, 60, 12, 16, 0),
+        (5, 5, 64, 12, 12, 9),
+        (9, 9, 67, 15, 3, 24),
+        (0, 0, 67, 15, 0, 0),
+        (0, 0, 67, 15, 19, 24),
+    ]
+
+    self.assertEqual(expected_labels, labels)
+
+    inputs = [self.enc.events_to_input(performance, i)
+              for i in range(len(performance))]
+
+    for input_ in inputs:
+      self.assertEqual(6, input_.nonzero()[0].shape[0])
+
+    decoded_performance = [self.enc.class_index_to_event(label, None)
+                           for label in labels]
+
+    self.assertEqual(performance, decoded_performance)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest"><code class="flex name class">
+<span>class <span class="ident">ModuloPerformanceEventSequenceEncoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test class for ModuloPerformanceEventSequenceEncoder.</p>
+<p>ModuloPerformanceEventSequenceEncoderDecoder is tightly coupled with the
+PerformanceModuloEncoding, and PerformanceOneHotEncoding classes. As a result,
+in the test set up, the test object is initialized with one of each objects
+and tested accordingly. Since this class only modifies the input encoding
+of performance events, and otherwise its treatment of labels is the same as
+OneHotEventSequenceEncoderDecoder, the events_to_labels(), and
+class_index_to_event() methods of the class are not tested.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ModuloPerformanceEventSequenceEncoderTest(absltest.TestCase):
+  &#34;&#34;&#34;Test class for ModuloPerformanceEventSequenceEncoder.
+
+  ModuloPerformanceEventSequenceEncoderDecoder is tightly coupled with the
+  PerformanceModuloEncoding, and PerformanceOneHotEncoding classes. As a result,
+  in the test set up, the test object is initialized with one of each objects
+  and tested accordingly. Since this class only modifies the input encoding
+  of performance events, and otherwise its treatment of labels is the same as
+  OneHotEventSequenceEncoderDecoder, the events_to_labels(), and
+  class_index_to_event() methods of the class are not tested.
+  &#34;&#34;&#34;
+
+  def setUp(self):
+    self._num_velocity_bins = 32
+    self._max_shift_steps = 100
+    self.enc = ModuloPerformanceEventSequenceEncoderDecoder(
+        num_velocity_bins=self._num_velocity_bins,
+        max_shift_steps=self._max_shift_steps)
+
+    self._expected_input_size = (
+        2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+    self._expected_num_classes = (self._num_velocity_bins +
+                                  self._max_shift_steps +
+                                  2 * (performance_lib.MAX_MIDI_PITCH -
+                                       performance_lib.MIN_MIDI_PITCH + 1))
+
+  def testInputSize(self):
+    self.assertEqual(self._expected_input_size, self.enc.input_size)
+
+  def testNumClasses(self):
+    self.assertEqual(self._expected_num_classes, self.enc.num_classes)
+
+  def testDefaultEventLabel(self):
+    label = self._expected_num_classes - self._num_velocity_bins - 1
+    self.assertEqual(label, self.enc.default_event_label)
+
+  def testEventsToInput(self):
+    num_shift_bins = self._max_shift_steps
+    num_velocity_bins = self._num_velocity_bins
+    slow_base = 2.0 * pi / 144.0
+    fast_base = 2.0 * pi / 12.0
+    shift_base = 2.0 * pi / num_shift_bins
+    velocity_base = 2.0 * pi / num_velocity_bins
+
+    expected_pairs = [
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+         [1.0, cos(60.0 * slow_base), sin(60.0 * slow_base),
+          cos(60.0 * fast_base), sin(60.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+         [1.0, cos(0.0 * slow_base), sin(0.0 * slow_base),
+          cos(0.0 * fast_base), sin(0.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+         [1.0, cos(127.0 * slow_base), sin(127.0 * slow_base),
+          cos(127.0 * fast_base), sin(127.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(72.0 * slow_base), sin(72.0 * slow_base),
+          cos(72.0 * fast_base), sin(72.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(0.0 * slow_base), sin(0.0 * slow_base),
+          cos(0.0 * fast_base), sin(0.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+          cos(127.0 * slow_base), sin(127.0 * slow_base),
+          cos(127.0 * fast_base), sin(127.0 * fast_base),
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(9.0 * shift_base), sin(9.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(0.0 * shift_base), sin(0.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          1.0, cos(99.0 * shift_base), sin(99.0 * shift_base),
+          0.0, 0.0, 0.0]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(4.0 * velocity_base), sin(4.0 * velocity_base)]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(0.0 * velocity_base), sin(0.0 * velocity_base)]),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0,
+          1.0, cos(15.0 * velocity_base), sin(15.0 * velocity_base)]),
+    ]
+
+    events = []
+    position = 0
+    for event, expected_encoded_modulo_event in expected_pairs:
+      events += [event]
+      actual_encoded_modulo_event = self.enc.events_to_input(events, position)
+      position += 1
+      for i in range(self._expected_input_size):
+        self.assertAlmostEqual(expected_encoded_modulo_event[i],
+                               actual_encoded_modulo_event[i])</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self._num_velocity_bins = 32
+  self._max_shift_steps = 100
+  self.enc = ModuloPerformanceEventSequenceEncoderDecoder(
+      num_velocity_bins=self._num_velocity_bins,
+      max_shift_steps=self._max_shift_steps)
+
+  self._expected_input_size = (
+      2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+      performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+      performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+  self._expected_num_classes = (self._num_velocity_bins +
+                                self._max_shift_steps +
+                                2 * (performance_lib.MAX_MIDI_PITCH -
+                                     performance_lib.MIN_MIDI_PITCH + 1))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testDefaultEventLabel"><code class="name flex">
+<span>def <span class="ident">testDefaultEventLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDefaultEventLabel(self):
+  label = self._expected_num_classes - self._num_velocity_bins - 1
+  self.assertEqual(label, self.enc.default_event_label)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testEventsToInput"><code class="name flex">
+<span>def <span class="ident">testEventsToInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventsToInput(self):
+  num_shift_bins = self._max_shift_steps
+  num_velocity_bins = self._num_velocity_bins
+  slow_base = 2.0 * pi / 144.0
+  fast_base = 2.0 * pi / 12.0
+  shift_base = 2.0 * pi / num_shift_bins
+  velocity_base = 2.0 * pi / num_velocity_bins
+
+  expected_pairs = [
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+       [1.0, cos(60.0 * slow_base), sin(60.0 * slow_base),
+        cos(60.0 * fast_base), sin(60.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+       [1.0, cos(0.0 * slow_base), sin(0.0 * slow_base),
+        cos(0.0 * fast_base), sin(0.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+       [1.0, cos(127.0 * slow_base), sin(127.0 * slow_base),
+        cos(127.0 * fast_base), sin(127.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        cos(72.0 * slow_base), sin(72.0 * slow_base),
+        cos(72.0 * fast_base), sin(72.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        cos(0.0 * slow_base), sin(0.0 * slow_base),
+        cos(0.0 * fast_base), sin(0.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        cos(127.0 * slow_base), sin(127.0 * slow_base),
+        cos(127.0 * fast_base), sin(127.0 * fast_base),
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        1.0, cos(9.0 * shift_base), sin(9.0 * shift_base),
+        0.0, 0.0, 0.0]),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        1.0, cos(0.0 * shift_base), sin(0.0 * shift_base),
+        0.0, 0.0, 0.0]),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        1.0, cos(99.0 * shift_base), sin(99.0 * shift_base),
+        0.0, 0.0, 0.0]),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0,
+        1.0, cos(4.0 * velocity_base), sin(4.0 * velocity_base)]),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0,
+        1.0, cos(0.0 * velocity_base), sin(0.0 * velocity_base)]),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0,
+        1.0, cos(15.0 * velocity_base), sin(15.0 * velocity_base)]),
+  ]
+
+  events = []
+  position = 0
+  for event, expected_encoded_modulo_event in expected_pairs:
+    events += [event]
+    actual_encoded_modulo_event = self.enc.events_to_input(events, position)
+    position += 1
+    for i in range(self._expected_input_size):
+      self.assertAlmostEqual(expected_encoded_modulo_event[i],
+                             actual_encoded_modulo_event[i])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(self._expected_input_size, self.enc.input_size)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testNumClasses"><code class="name flex">
+<span>def <span class="ident">testNumClasses</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumClasses(self):
+  self.assertEqual(self._expected_num_classes, self.enc.num_classes)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest"><code class="flex name class">
+<span>class <span class="ident">NotePerformanceEventSequenceEncoderDecoderTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NotePerformanceEventSequenceEncoderDecoderTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = NotePerformanceEventSequenceEncoderDecoder(
+        num_velocity_bins=16, max_shift_steps=99, max_duration_steps=500)
+
+    self.assertEqual(10, self.enc.shift_steps_segments)
+    self.assertEqual(20, self.enc.duration_steps_segments)
+
+  def testEncodeDecode(self):
+    pe = PerformanceEvent
+    performance = [
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 401)),
+        (pe(pe.TIME_SHIFT, 55), pe(pe.NOTE_ON, 64),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 310)),
+        (pe(pe.TIME_SHIFT, 99), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 1)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 500)),
+    ]
+
+    labels = [self.enc.events_to_label(performance, i)
+              for i in range(len(performance))]
+
+    expected_labels = [
+        (0, 0, 60, 12, 16, 0),
+        (5, 5, 64, 12, 12, 9),
+        (9, 9, 67, 15, 3, 24),
+        (0, 0, 67, 15, 0, 0),
+        (0, 0, 67, 15, 19, 24),
+    ]
+
+    self.assertEqual(expected_labels, labels)
+
+    inputs = [self.enc.events_to_input(performance, i)
+              for i in range(len(performance))]
+
+    for input_ in inputs:
+      self.assertEqual(6, input_.nonzero()[0].shape[0])
+
+    decoded_performance = [self.enc.class_index_to_event(label, None)
+                           for label in labels]
+
+    self.assertEqual(performance, decoded_performance)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = NotePerformanceEventSequenceEncoderDecoder(
+      num_velocity_bins=16, max_shift_steps=99, max_duration_steps=500)
+
+  self.assertEqual(10, self.enc.shift_steps_segments)
+  self.assertEqual(20, self.enc.duration_steps_segments)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.testEncodeDecode"><code class="name flex">
+<span>def <span class="ident">testEncodeDecode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeDecode(self):
+  pe = PerformanceEvent
+  performance = [
+      (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+       pe(pe.VELOCITY, 13), pe(pe.DURATION, 401)),
+      (pe(pe.TIME_SHIFT, 55), pe(pe.NOTE_ON, 64),
+       pe(pe.VELOCITY, 13), pe(pe.DURATION, 310)),
+      (pe(pe.TIME_SHIFT, 99), pe(pe.NOTE_ON, 67),
+       pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+      (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+       pe(pe.VELOCITY, 16), pe(pe.DURATION, 1)),
+      (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 67),
+       pe(pe.VELOCITY, 16), pe(pe.DURATION, 500)),
+  ]
+
+  labels = [self.enc.events_to_label(performance, i)
+            for i in range(len(performance))]
+
+  expected_labels = [
+      (0, 0, 60, 12, 16, 0),
+      (5, 5, 64, 12, 12, 9),
+      (9, 9, 67, 15, 3, 24),
+      (0, 0, 67, 15, 0, 0),
+      (0, 0, 67, 15, 19, 24),
+  ]
+
+  self.assertEqual(expected_labels, labels)
+
+  inputs = [self.enc.events_to_input(performance, i)
+            for i in range(len(performance))]
+
+  for input_ in inputs:
+    self.assertEqual(6, input_.nonzero()[0].shape[0])
+
+  decoded_performance = [self.enc.class_index_to_event(label, None)
+                         for label in labels]
+
+  self.assertEqual(performance, decoded_performance)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest"><code class="flex name class">
+<span>class <span class="ident">PerformanceModuloEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test class for PerformanceModuloEncoding.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceModuloEncodingTest(absltest.TestCase):
+  &#34;&#34;&#34;Test class for PerformanceModuloEncoding.&#34;&#34;&#34;
+
+  def setUp(self):
+    self._num_velocity_bins = 16
+    self._max_shift_steps = performance_lib.DEFAULT_MAX_SHIFT_STEPS
+    self.enc = PerformanceModuloEncoding(
+        num_velocity_bins=self._num_velocity_bins,
+        max_shift_steps=self._max_shift_steps)
+
+    self._expected_input_size = (
+        2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+        performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+    self._expected_num_classes = (self._num_velocity_bins +
+                                  self._max_shift_steps +
+                                  (performance_lib.MAX_MIDI_PITCH -
+                                   performance_lib.MIN_MIDI_PITCH + 1) * 2)
+
+  def testInputSize(self):
+    self.assertEqual(self._expected_input_size, self.enc.input_size)
+
+  def testEmbedPitchClass(self):
+    # The following are true only for semitone_steps = 1.
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (1, (cos(pi / 6.0), sin(pi / 6.0))),
+        (2, (cos(pi / 3.0), sin(pi / 3.0))),
+        (3, (cos(pi / 2.0), sin(pi / 2.0))),
+        (4, (cos(2.0 * pi / 3.0), sin(2.0 * pi / 3.0))),
+        (5, (cos(5.0 * pi / 6.0), sin(5.0 * pi / 6.0))),
+        (6, (cos(pi), sin(pi))),
+        (7, (cos(7.0 * pi / 6.0), sin(7.0 * pi / 6.0))),
+        (8, (cos(4.0 * pi / 3.0), sin(4.0 * pi / 3.0))),
+        (9, (cos(3.0 * pi / 2.0), sin(3.0 * pi / 2.0))),
+        (10, (cos(5.0 * pi / 3.0), sin(5.0 * pi / 3.0))),
+        (11, (cos(11.0 * pi / 6.0), sin(11.0 * pi / 6.0)))]
+
+    for note, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_pitch_class(note)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedNote(self):
+    # The following are true only for semitone_steps = 1.
+    base = 72.0
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (13, (cos(pi * 13.0 / base), sin(pi * 13.0 / base))),
+        (26, (cos(pi * 26.0 / base), sin(pi * 26.0 / base))),
+        (39, (cos(pi * 39.0 / base), sin(pi * 39.0 / base))),
+        (52, (cos(pi * 52.0 / base), sin(pi * 52.0 / base))),
+        (65, (cos(pi * 65.0 / base), sin(pi * 65.0 / base))),
+        (78, (cos(pi * 78.0 / base), sin(pi * 78.0 / base))),
+        (91, (cos(pi * 91.0 / base), sin(pi * 91.0 / base))),
+        (104, (cos(pi * 104.0 / base), sin(pi * 104.0 / base))),
+        (117, (cos(pi * 117.0 / base), sin(pi * 117.0 / base))),
+        (130, (cos(pi * 130.0 / base), sin(pi * 130.0 / base))),
+        (143, (cos(pi * 143.0 / base), sin(pi * 143.0 / base)))]
+
+    for note, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_note(note)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedTimeShift(self):
+    # The following are true only for semitone_steps = 1.
+    base = self._max_shift_steps  # 100
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+        (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+        (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+        (20, (cos(2.0 * pi * 20.0 / base), sin(2.0 * pi * 20.0 / base))),
+        (45, (cos(2.0 * pi * 45.0 / base), sin(2.0 * pi * 45.0 / base))),
+        (70, (cos(2.0 * pi * 70.0 / base), sin(2.0 * pi * 70.0 / base))),
+        (99, (cos(2.0 * pi * 99.0 / base), sin(2.0 * pi * 99.0 / base)))]
+
+    for time_shift, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_time_shift(time_shift)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEmbedVelocity(self):
+    # The following are true only for semitone_steps = 1.
+    base = self._num_velocity_bins  # 16
+    expected_pairs = [
+        (0, (cos(0.0), sin(0.0))),
+        (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+        (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+        (7, (cos(2.0 * pi * 7.0 / base), sin(2.0 * pi * 7.0 / base))),
+        (10, (cos(2.0 * pi * 10.0 / base), sin(2.0 * pi * 10.0 / base))),
+        (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+        (15, (cos(2.0 * pi * 15.0 / base), sin(2.0 * pi * 15.0 / base)))]
+
+    for velocity, expected_embedding in expected_pairs:
+      actual_embedding = self.enc.embed_velocity(velocity)
+      self.assertEqual(actual_embedding[0], expected_embedding[0])
+      self.assertEqual(actual_embedding[1], expected_embedding[1])
+
+  def testEncodeModuloEvent(self):
+    expected_pairs = [
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+         (0, PerformanceEvent.NOTE_ON, 60)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+         (0, PerformanceEvent.NOTE_ON, 0)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+         (0, PerformanceEvent.NOTE_ON, 127)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+         (5, PerformanceEvent.NOTE_OFF, 72)),
+        (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+         (5, PerformanceEvent.NOTE_OFF, 0)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+         (5, PerformanceEvent.NOTE_OFF, 127)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+         (10, PerformanceEvent.TIME_SHIFT, 9)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+         (10, PerformanceEvent.TIME_SHIFT, 0)),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+         (10, PerformanceEvent.TIME_SHIFT, 99)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+         (13, PerformanceEvent.VELOCITY, 4)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+         (13, PerformanceEvent.VELOCITY, 0)),
+        (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+         (13, PerformanceEvent.VELOCITY, 15)),
+    ]
+
+    # expected_encoded_modulo_event is of the following form:
+    # (offset, encoder_width, event_type, value, bins)
+    for event, expected_encoded_modulo_event in expected_pairs:
+      actual_encoded_modulo_event = self.enc.encode_modulo_event(event)
+      self.assertEqual(actual_encoded_modulo_event,
+                       expected_encoded_modulo_event)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self._num_velocity_bins = 16
+  self._max_shift_steps = performance_lib.DEFAULT_MAX_SHIFT_STEPS
+  self.enc = PerformanceModuloEncoding(
+      num_velocity_bins=self._num_velocity_bins,
+      max_shift_steps=self._max_shift_steps)
+
+  self._expected_input_size = (
+      2 * performance_encoder_decoder.MODULO_PITCH_ENCODER_WIDTH +
+      performance_encoder_decoder.MODULO_VELOCITY_ENCODER_WIDTH +
+      performance_encoder_decoder.MODULO_TIME_SHIFT_ENCODER_WIDTH)
+
+  self._expected_num_classes = (self._num_velocity_bins +
+                                self._max_shift_steps +
+                                (performance_lib.MAX_MIDI_PITCH -
+                                 performance_lib.MIN_MIDI_PITCH + 1) * 2)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedNote"><code class="name flex">
+<span>def <span class="ident">testEmbedNote</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmbedNote(self):
+  # The following are true only for semitone_steps = 1.
+  base = 72.0
+  expected_pairs = [
+      (0, (cos(0.0), sin(0.0))),
+      (13, (cos(pi * 13.0 / base), sin(pi * 13.0 / base))),
+      (26, (cos(pi * 26.0 / base), sin(pi * 26.0 / base))),
+      (39, (cos(pi * 39.0 / base), sin(pi * 39.0 / base))),
+      (52, (cos(pi * 52.0 / base), sin(pi * 52.0 / base))),
+      (65, (cos(pi * 65.0 / base), sin(pi * 65.0 / base))),
+      (78, (cos(pi * 78.0 / base), sin(pi * 78.0 / base))),
+      (91, (cos(pi * 91.0 / base), sin(pi * 91.0 / base))),
+      (104, (cos(pi * 104.0 / base), sin(pi * 104.0 / base))),
+      (117, (cos(pi * 117.0 / base), sin(pi * 117.0 / base))),
+      (130, (cos(pi * 130.0 / base), sin(pi * 130.0 / base))),
+      (143, (cos(pi * 143.0 / base), sin(pi * 143.0 / base)))]
+
+  for note, expected_embedding in expected_pairs:
+    actual_embedding = self.enc.embed_note(note)
+    self.assertEqual(actual_embedding[0], expected_embedding[0])
+    self.assertEqual(actual_embedding[1], expected_embedding[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedPitchClass"><code class="name flex">
+<span>def <span class="ident">testEmbedPitchClass</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmbedPitchClass(self):
+  # The following are true only for semitone_steps = 1.
+  expected_pairs = [
+      (0, (cos(0.0), sin(0.0))),
+      (1, (cos(pi / 6.0), sin(pi / 6.0))),
+      (2, (cos(pi / 3.0), sin(pi / 3.0))),
+      (3, (cos(pi / 2.0), sin(pi / 2.0))),
+      (4, (cos(2.0 * pi / 3.0), sin(2.0 * pi / 3.0))),
+      (5, (cos(5.0 * pi / 6.0), sin(5.0 * pi / 6.0))),
+      (6, (cos(pi), sin(pi))),
+      (7, (cos(7.0 * pi / 6.0), sin(7.0 * pi / 6.0))),
+      (8, (cos(4.0 * pi / 3.0), sin(4.0 * pi / 3.0))),
+      (9, (cos(3.0 * pi / 2.0), sin(3.0 * pi / 2.0))),
+      (10, (cos(5.0 * pi / 3.0), sin(5.0 * pi / 3.0))),
+      (11, (cos(11.0 * pi / 6.0), sin(11.0 * pi / 6.0)))]
+
+  for note, expected_embedding in expected_pairs:
+    actual_embedding = self.enc.embed_pitch_class(note)
+    self.assertEqual(actual_embedding[0], expected_embedding[0])
+    self.assertEqual(actual_embedding[1], expected_embedding[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedTimeShift"><code class="name flex">
+<span>def <span class="ident">testEmbedTimeShift</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmbedTimeShift(self):
+  # The following are true only for semitone_steps = 1.
+  base = self._max_shift_steps  # 100
+  expected_pairs = [
+      (0, (cos(0.0), sin(0.0))),
+      (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+      (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+      (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+      (20, (cos(2.0 * pi * 20.0 / base), sin(2.0 * pi * 20.0 / base))),
+      (45, (cos(2.0 * pi * 45.0 / base), sin(2.0 * pi * 45.0 / base))),
+      (70, (cos(2.0 * pi * 70.0 / base), sin(2.0 * pi * 70.0 / base))),
+      (99, (cos(2.0 * pi * 99.0 / base), sin(2.0 * pi * 99.0 / base)))]
+
+  for time_shift, expected_embedding in expected_pairs:
+    actual_embedding = self.enc.embed_time_shift(time_shift)
+    self.assertEqual(actual_embedding[0], expected_embedding[0])
+    self.assertEqual(actual_embedding[1], expected_embedding[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedVelocity"><code class="name flex">
+<span>def <span class="ident">testEmbedVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEmbedVelocity(self):
+  # The following are true only for semitone_steps = 1.
+  base = self._num_velocity_bins  # 16
+  expected_pairs = [
+      (0, (cos(0.0), sin(0.0))),
+      (2, (cos(2.0 * pi * 2.0 / base), sin(2.0 * pi * 2.0 / base))),
+      (5, (cos(2.0 * pi * 5.0 / base), sin(2.0 * pi * 5.0 / base))),
+      (7, (cos(2.0 * pi * 7.0 / base), sin(2.0 * pi * 7.0 / base))),
+      (10, (cos(2.0 * pi * 10.0 / base), sin(2.0 * pi * 10.0 / base))),
+      (13, (cos(2.0 * pi * 13.0 / base), sin(2.0 * pi * 13.0 / base))),
+      (15, (cos(2.0 * pi * 15.0 / base), sin(2.0 * pi * 15.0 / base)))]
+
+  for velocity, expected_embedding in expected_pairs:
+    actual_embedding = self.enc.embed_velocity(velocity)
+    self.assertEqual(actual_embedding[0], expected_embedding[0])
+    self.assertEqual(actual_embedding[1], expected_embedding[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEncodeModuloEvent"><code class="name flex">
+<span>def <span class="ident">testEncodeModuloEvent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeModuloEvent(self):
+  expected_pairs = [
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60),
+       (0, PerformanceEvent.NOTE_ON, 60)),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=0),
+       (0, PerformanceEvent.NOTE_ON, 0)),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=127),
+       (0, PerformanceEvent.NOTE_ON, 127)),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=72),
+       (5, PerformanceEvent.NOTE_OFF, 72)),
+      (PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=0),
+       (5, PerformanceEvent.NOTE_OFF, 0)),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_OFF, event_value=127),
+       (5, PerformanceEvent.NOTE_OFF, 127)),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=10),
+       (10, PerformanceEvent.TIME_SHIFT, 9)),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=1),
+       (10, PerformanceEvent.TIME_SHIFT, 0)),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=100),
+       (10, PerformanceEvent.TIME_SHIFT, 99)),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=5),
+       (13, PerformanceEvent.VELOCITY, 4)),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=1),
+       (13, PerformanceEvent.VELOCITY, 0)),
+      (PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=16),
+       (13, PerformanceEvent.VELOCITY, 15)),
+  ]
+
+  # expected_encoded_modulo_event is of the following form:
+  # (offset, encoder_width, event_type, value, bins)
+  for event, expected_encoded_modulo_event in expected_pairs:
+    actual_encoded_modulo_event = self.enc.encode_modulo_event(event)
+    self.assertEqual(actual_encoded_modulo_event,
+                     expected_encoded_modulo_event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testInputSize"><code class="name flex">
+<span>def <span class="ident">testInputSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInputSize(self):
+  self.assertEqual(self._expected_input_size, self.enc.input_size)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest"><code class="flex name class">
+<span>class <span class="ident">PerformanceOneHotEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceOneHotEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = performance_encoder_decoder.PerformanceOneHotEncoding(
+        num_velocity_bins=16)
+
+  def testEncodeDecode(self):
+    expected_pairs = [
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=60), 60),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=0), 0),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_ON, event_value=127), 127),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=72), 200),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=0), 128),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.NOTE_OFF, event_value=127), 255),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=10), 265),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1), 256),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100), 355),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=5), 360),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=1), 356),
+        (PerformanceEvent(
+            event_type=PerformanceEvent.VELOCITY, event_value=16), 371)
+    ]
+
+    for expected_event, expected_index in expected_pairs:
+      index = self.enc.encode_event(expected_event)
+      self.assertEqual(expected_index, index)
+      event = self.enc.decode_event(expected_index)
+      self.assertEqual(expected_event, event)
+
+  def testEventToNumSteps(self):
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60)))
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=67)))
+    self.assertEqual(0, self.enc.event_to_num_steps(
+        PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=10)))
+
+    self.assertEqual(1, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=1)))
+    self.assertEqual(45, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=45)))
+    self.assertEqual(100, self.enc.event_to_num_steps(
+        PerformanceEvent(
+            event_type=PerformanceEvent.TIME_SHIFT, event_value=100)))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = performance_encoder_decoder.PerformanceOneHotEncoding(
+      num_velocity_bins=16)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEncodeDecode"><code class="name flex">
+<span>def <span class="ident">testEncodeDecode</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeDecode(self):
+  expected_pairs = [
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_ON, event_value=60), 60),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_ON, event_value=0), 0),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_ON, event_value=127), 127),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_OFF, event_value=72), 200),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_OFF, event_value=0), 128),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.NOTE_OFF, event_value=127), 255),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=10), 265),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=1), 256),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=100), 355),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.VELOCITY, event_value=5), 360),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.VELOCITY, event_value=1), 356),
+      (PerformanceEvent(
+          event_type=PerformanceEvent.VELOCITY, event_value=16), 371)
+  ]
+
+  for expected_event, expected_index in expected_pairs:
+    index = self.enc.encode_event(expected_event)
+    self.assertEqual(expected_index, index)
+    event = self.enc.decode_event(expected_index)
+    self.assertEqual(expected_event, event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEventToNumSteps"><code class="name flex">
+<span>def <span class="ident">testEventToNumSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEventToNumSteps(self):
+  self.assertEqual(0, self.enc.event_to_num_steps(
+      PerformanceEvent(event_type=PerformanceEvent.NOTE_ON, event_value=60)))
+  self.assertEqual(0, self.enc.event_to_num_steps(
+      PerformanceEvent(event_type=PerformanceEvent.NOTE_OFF, event_value=67)))
+  self.assertEqual(0, self.enc.event_to_num_steps(
+      PerformanceEvent(event_type=PerformanceEvent.VELOCITY, event_value=10)))
+
+  self.assertEqual(1, self.enc.event_to_num_steps(
+      PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=1)))
+  self.assertEqual(45, self.enc.event_to_num_steps(
+      PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=45)))
+  self.assertEqual(100, self.enc.event_to_num_steps(
+      PerformanceEvent(
+          event_type=PerformanceEvent.TIME_SHIFT, event_value=100)))</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest">ModuloPerformanceEventSequenceEncoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.setUp" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testDefaultEventLabel" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testDefaultEventLabel">testDefaultEventLabel</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testEventsToInput" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testEventsToInput">testEventsToInput</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testInputSize" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testInputSize">testInputSize</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testNumClasses" href="#note_seq.performance_encoder_decoder_test.ModuloPerformanceEventSequenceEncoderTest.testNumClasses">testNumClasses</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest" href="#note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest">NotePerformanceEventSequenceEncoderDecoderTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.setUp" href="#note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.testEncodeDecode" href="#note_seq.performance_encoder_decoder_test.NotePerformanceEventSequenceEncoderDecoderTest.testEncodeDecode">testEncodeDecode</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest">PerformanceModuloEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.setUp" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedNote" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedNote">testEmbedNote</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedPitchClass" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedPitchClass">testEmbedPitchClass</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedTimeShift" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedTimeShift">testEmbedTimeShift</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedVelocity" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEmbedVelocity">testEmbedVelocity</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEncodeModuloEvent" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testEncodeModuloEvent">testEncodeModuloEvent</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testInputSize" href="#note_seq.performance_encoder_decoder_test.PerformanceModuloEncodingTest.testInputSize">testInputSize</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest" href="#note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest">PerformanceOneHotEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.setUp" href="#note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEncodeDecode" href="#note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEncodeDecode">testEncodeDecode</a></code></li>
+<li><code><a title="note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEventToNumSteps" href="#note_seq.performance_encoder_decoder_test.PerformanceOneHotEncodingTest.testEventToNumSteps">testEventToNumSteps</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_lib.html
+++ b/docs/performance_lib.html
@@ -1,0 +1,2662 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_lib API documentation</title>
+<meta name="description" content="Utility functions for working with polyphonic performances." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with polyphonic performances.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with polyphonic performances.&#34;&#34;&#34;
+
+import abc
+import collections
+import math
+
+from absl import logging
+import attr
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+
+MAX_MIDI_PITCH = constants.MAX_MIDI_PITCH
+MIN_MIDI_PITCH = constants.MIN_MIDI_PITCH
+
+MAX_MIDI_VELOCITY = constants.MAX_MIDI_VELOCITY
+MIN_MIDI_VELOCITY = constants.MIN_MIDI_VELOCITY
+MAX_NUM_VELOCITY_BINS = MAX_MIDI_VELOCITY - MIN_MIDI_VELOCITY + 1
+
+STANDARD_PPQ = constants.STANDARD_PPQ
+
+DEFAULT_MAX_SHIFT_STEPS = 100
+DEFAULT_MAX_SHIFT_QUARTERS = 4
+
+DEFAULT_PROGRAM = 0
+
+
+@attr.s(frozen=True)
+class PerformanceEvent(object):
+  &#34;&#34;&#34;Class for storing events in a performance.&#34;&#34;&#34;
+  event_type = attr.ib()
+  event_value = attr.ib()
+
+  # Start of a new note.
+  NOTE_ON = 1
+  # End of a note.
+  NOTE_OFF = 2
+  # Shift time forward.
+  TIME_SHIFT = 3
+  # Change current velocity.
+  VELOCITY = 4
+  # Duration of preceding NOTE_ON.
+  # For Note-based encoding, used instead of NOTE_OFF events.
+  DURATION = 5
+
+  @event_type.validator
+  def _check_event(self, attribute, value):
+    &#34;&#34;&#34;Validate event contents.&#34;&#34;&#34;
+    del attribute, value  # This checks the whole object.
+    if self.event_type in (PerformanceEvent.NOTE_ON, PerformanceEvent.NOTE_OFF):
+      if not MIN_MIDI_PITCH &lt;= self.event_value &lt;= MAX_MIDI_PITCH:
+        raise ValueError(&#39;Invalid pitch value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.TIME_SHIFT:
+      if not 0 &lt;= self.event_value:
+        raise ValueError(&#39;Invalid time shift value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.DURATION:
+      if not 1 &lt;= self.event_value:
+        raise ValueError(&#39;Invalid duration value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.VELOCITY:
+      if not 1 &lt;= self.event_value &lt;= MAX_NUM_VELOCITY_BINS:
+        raise ValueError(&#39;Invalid velocity value: %s&#39; % self.event_value)
+    else:
+      raise ValueError(&#39;Invalid event type: %s&#39; % self.event_type)
+
+
+def _velocity_bin_size(num_velocity_bins):
+  return int(math.ceil(
+      (MAX_MIDI_VELOCITY - MIN_MIDI_VELOCITY + 1) / num_velocity_bins))
+
+
+def velocity_to_bin(velocity, num_velocity_bins):
+  return ((velocity - MIN_MIDI_VELOCITY) //
+          _velocity_bin_size(num_velocity_bins) + 1)
+
+
+def velocity_bin_to_velocity(velocity_bin, num_velocity_bins):
+  return (
+      MIN_MIDI_VELOCITY + (velocity_bin - 1) *
+      _velocity_bin_size(num_velocity_bins))
+
+
+def _program_and_is_drum_from_sequence(sequence, instrument=None):
+  &#34;&#34;&#34;Get MIDI program and is_drum from sequence and (optional) instrument.
+
+  Args:
+    sequence: The NoteSequence from which MIDI program and is_drum will be
+        extracted.
+    instrument: The instrument in `sequence` from which MIDI program and
+        is_drum will be extracted, or None to consider all instruments.
+
+  Returns:
+    A tuple containing program and is_drum for the sequence and optional
+    instrument. If multiple programs are found (or if is_drum is True),
+    program will be None. If multiple values of is_drum are found, is_drum
+    will be None.
+  &#34;&#34;&#34;
+  notes = [note for note in sequence.notes
+           if instrument is None or note.instrument == instrument]
+  # Only set program for non-drum tracks.
+  if all(note.is_drum for note in notes):
+    is_drum = True
+    program = None
+  elif all(not note.is_drum for note in notes):
+    is_drum = False
+    programs = set(note.program for note in notes)
+    program = programs.pop() if len(programs) == 1 else None
+  else:
+    is_drum = None
+    program = None
+  return program, is_drum
+
+
+class BasePerformance(events_lib.EventSequence):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a stream of performance events.
+
+  Events are PerformanceEvent objects that encode event type and value.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  def __init__(self, start_step, num_velocity_bins, max_shift_steps,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a BasePerformance.
+
+    Args:
+      start_step: The offset of this sequence relative to the beginning of the
+          source sequence.
+      num_velocity_bins: Number of velocity bins to use.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      program: MIDI program used for this performance, or None if not specified.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified.
+
+    Raises:
+      ValueError: If `num_velocity_bins` is larger than the number of MIDI
+          velocity values.
+    &#34;&#34;&#34;
+    if num_velocity_bins &gt; MAX_MIDI_VELOCITY - MIN_MIDI_VELOCITY + 1:
+      raise ValueError(
+          &#39;Number of velocity bins is too large: %d&#39; % num_velocity_bins)
+
+    self._start_step = start_step
+    self._num_velocity_bins = num_velocity_bins
+    self._max_shift_steps = max_shift_steps
+    self._program = program
+    self._is_drum = is_drum
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def max_shift_steps(self):
+    return self._max_shift_steps
+
+  @property
+  def program(self):
+    return self._program
+
+  @property
+  def is_drum(self):
+    return self._is_drum
+
+  def _append_steps(self, num_steps):
+    &#34;&#34;&#34;Adds steps to the end of the sequence.&#34;&#34;&#34;
+    if (self._events and
+        self._events[-1].event_type == PerformanceEvent.TIME_SHIFT and
+        self._events[-1].event_value &lt; self._max_shift_steps):
+      # Last event is already non-maximal time shift. Increase its duration.
+      added_steps = min(num_steps,
+                        self._max_shift_steps - self._events[-1].event_value)
+      self._events[-1] = PerformanceEvent(
+          PerformanceEvent.TIME_SHIFT,
+          self._events[-1].event_value + added_steps)
+      num_steps -= added_steps
+
+    while num_steps &gt;= self._max_shift_steps:
+      self._events.append(
+          PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                           event_value=self._max_shift_steps))
+      num_steps -= self._max_shift_steps
+
+    if num_steps &gt; 0:
+      self._events.append(
+          PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                           event_value=num_steps))
+
+  def _trim_steps(self, num_steps):
+    &#34;&#34;&#34;Trims a given number of steps from the end of the sequence.&#34;&#34;&#34;
+    steps_trimmed = 0
+    while self._events and steps_trimmed &lt; num_steps:
+      if self._events[-1].event_type == PerformanceEvent.TIME_SHIFT:
+        if steps_trimmed + self._events[-1].event_value &gt; num_steps:
+          self._events[-1] = PerformanceEvent(
+              event_type=PerformanceEvent.TIME_SHIFT,
+              event_value=(self._events[-1].event_value -
+                           num_steps + steps_trimmed))
+          steps_trimmed = num_steps
+        else:
+          steps_trimmed += self._events[-1].event_value
+          self._events.pop()
+      else:
+        self._events.pop()
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads with time shifts to make the
+    sequence the specified length. If it is too long, it will be truncated to
+    the requested length.
+
+    Args:
+      steps: How many quantized steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if from_left:
+      raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+    if self.num_steps &lt; steps:
+      self._append_steps(steps - self.num_steps)
+    elif self.num_steps &gt; steps:
+      self._trim_steps(self.num_steps - steps)
+
+    assert self.num_steps == steps
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The performance event to append to the end.
+
+    Raises:
+      ValueError: If `event` is not a valid performance event.
+    &#34;&#34;&#34;
+    if not isinstance(event, PerformanceEvent):
+      raise ValueError(&#39;Invalid performance event: %s&#39; % event)
+    self._events.append(event)
+
+  def truncate(self, num_events):
+    &#34;&#34;&#34;Truncates this Performance to the specified number of events.
+
+    Args:
+      num_events: The number of events to which this performance will be
+          truncated.
+    &#34;&#34;&#34;
+    self._events = self._events[:num_events]
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this sequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    return self._events[i]
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this sequence.&#34;&#34;&#34;
+    return iter(self._events)
+
+  def __str__(self):
+    strs = []
+    for event in self:
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        strs.append(&#39;(%s, ON)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        strs.append(&#39;(%s, OFF)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.TIME_SHIFT:
+        strs.append(&#39;(%s, SHIFT)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.VELOCITY:
+        strs.append(&#39;(%s, VELOCITY)&#39; % event.event_value)
+      else:
+        raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+    return &#39;\n&#39;.join(strs)
+
+  @property
+  def end_step(self):
+    return self.start_step + self.num_steps
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    steps = 0
+    for event in self:
+      if event.event_type == PerformanceEvent.TIME_SHIFT:
+        steps += event.event_value
+    return steps
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Return a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    step = self.start_step
+    result = []
+    for event in self:
+      result.append(step)
+      if event.event_type == PerformanceEvent.TIME_SHIFT:
+        step += event.event_value
+    return result
+
+  @staticmethod
+  def _from_quantized_sequence(quantized_sequence, start_step,
+                               num_velocity_bins, max_shift_steps,
+                               instrument=None):
+    &#34;&#34;&#34;Extract a list of events from the given quantized NoteSequence object.
+
+    Within a step, new pitches are started with NOTE_ON and existing pitches are
+    ended with NOTE_OFF. TIME_SHIFT shifts the current step forward in time.
+    VELOCITY changes the current velocity value that will be applied to all
+    NOTE_ON events.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start converting the sequence at this time step.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      instrument: If not None, extract only the specified instrument. Otherwise,
+          extract all instruments into a single event list.
+
+    Returns:
+      A list of events.
+    &#34;&#34;&#34;
+    notes = [note for note in quantized_sequence.notes
+             if note.quantized_start_step &gt;= start_step
+             and (instrument is None or note.instrument == instrument)]
+    sorted_notes = sorted(notes, key=lambda note: (note.start_time, note.pitch))
+
+    # Sort all note start and end events.
+    onsets = [(note.quantized_start_step, idx, False)
+              for idx, note in enumerate(sorted_notes)]
+    offsets = [(note.quantized_end_step, idx, True)
+               for idx, note in enumerate(sorted_notes)]
+    note_events = sorted(onsets + offsets)
+
+    current_step = start_step
+    current_velocity_bin = 0
+    performance_events = []
+
+    for step, idx, is_offset in note_events:
+      if step &gt; current_step:
+        # Shift time forward from the current step to this event.
+        while step &gt; current_step + max_shift_steps:
+          # We need to move further than the maximum shift size.
+          performance_events.append(
+              PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                               event_value=max_shift_steps))
+          current_step += max_shift_steps
+        performance_events.append(
+            PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                             event_value=int(step - current_step)))
+        current_step = step
+
+      # If we&#39;re using velocity and this note&#39;s velocity is different from the
+      # current velocity, change the current velocity.
+      if num_velocity_bins:
+        velocity_bin = velocity_to_bin(
+            sorted_notes[idx].velocity, num_velocity_bins)
+        if not is_offset and velocity_bin != current_velocity_bin:
+          current_velocity_bin = velocity_bin
+          performance_events.append(
+              PerformanceEvent(event_type=PerformanceEvent.VELOCITY,
+                               event_value=current_velocity_bin))
+
+      # Add a performance event for this note on/off.
+      event_type = (
+          PerformanceEvent.NOTE_OFF if is_offset else PerformanceEvent.NOTE_ON)
+      performance_events.append(
+          PerformanceEvent(event_type=event_type,
+                           event_value=sorted_notes[idx].pitch))
+
+    return performance_events
+
+  @abc.abstractmethod
+  def to_sequence(self, velocity, instrument, program, max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    pass
+
+  def _to_sequence(self, seconds_per_step, velocity, instrument, program,
+                   max_note_duration=None):
+    sequence_start_time = self.start_step * seconds_per_step
+
+    sequence = music_pb2.NoteSequence()
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+
+    if program is None:
+      # Use program associated with the performance (or default program).
+      program = self.program if self.program is not None else DEFAULT_PROGRAM
+    is_drum = self.is_drum if self.is_drum is not None else False
+
+    # Map pitch to list because one pitch may be active multiple times.
+    pitch_start_steps_and_velocities = collections.defaultdict(list)
+    for i, event in enumerate(self):
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        pitch_start_steps_and_velocities[event.event_value].append(
+            (step, velocity))
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        if not pitch_start_steps_and_velocities[event.event_value]:
+          logging.debug(
+              &#39;Ignoring NOTE_OFF at position %d with no previous NOTE_ON&#39;, i)
+        else:
+          # Create a note for the pitch that is now ending.
+          pitch_start_step, pitch_velocity = pitch_start_steps_and_velocities[
+              event.event_value][0]
+          pitch_start_steps_and_velocities[event.event_value] = (
+              pitch_start_steps_and_velocities[event.event_value][1:])
+          if step == pitch_start_step:
+            logging.debug(
+                &#39;Ignoring note with zero duration at step %d&#39;, step)
+            continue
+          note = sequence.notes.add()
+          note.start_time = (pitch_start_step * seconds_per_step +
+                             sequence_start_time)
+          note.end_time = step * seconds_per_step + sequence_start_time
+          if (max_note_duration and
+              note.end_time - note.start_time &gt; max_note_duration):
+            note.end_time = note.start_time + max_note_duration
+          note.pitch = event.event_value
+          note.velocity = pitch_velocity
+          note.instrument = instrument
+          note.program = program
+          note.is_drum = is_drum
+          if note.end_time &gt; sequence.total_time:
+            sequence.total_time = note.end_time
+      elif event.event_type == PerformanceEvent.TIME_SHIFT:
+        step += event.event_value
+      elif event.event_type == PerformanceEvent.VELOCITY:
+        assert self._num_velocity_bins
+        velocity = velocity_bin_to_velocity(
+            event.event_value, self._num_velocity_bins)
+      else:
+        raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+    # There could be remaining pitches that were never ended. End them now
+    # and create notes.
+    for pitch in pitch_start_steps_and_velocities:
+      for pitch_start_step, pitch_velocity in pitch_start_steps_and_velocities[
+          pitch]:
+        if step == pitch_start_step:
+          logging.debug(&#39;Ignoring note with zero duration at step %d&#39;, step)
+          continue
+        note = sequence.notes.add()
+        note.start_time = (pitch_start_step * seconds_per_step +
+                           sequence_start_time)
+        note.end_time = step * seconds_per_step + sequence_start_time
+        if (max_note_duration and
+            note.end_time - note.start_time &gt; max_note_duration):
+          note.end_time = note.start_time + max_note_duration
+        note.pitch = pitch
+        note.velocity = pitch_velocity
+        note.instrument = instrument
+        note.program = program
+        note.is_drum = is_drum
+        if note.end_time &gt; sequence.total_time:
+          sequence.total_time = note.end_time
+
+    return sequence
+
+
+class Performance(BasePerformance):
+  &#34;&#34;&#34;Performance with absolute timing and unknown meter.&#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, steps_per_second=None,
+               start_step=0, num_velocity_bins=0,
+               max_shift_steps=DEFAULT_MAX_SHIFT_STEPS, instrument=None,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a Performance.
+
+    Either quantized_sequence or steps_per_second should be supplied.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      steps_per_second: Number of quantized time steps per second, if using
+          absolute quantization.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      program: MIDI program used for this performance, or None if not specified.
+          Ignored if `quantized_sequence` is provided.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified. Ignored if `quantized_sequence` is provided.
+
+    Raises:
+      ValueError: If both or neither of `quantized_sequence` or
+          `steps_per_second` is specified.
+    &#34;&#34;&#34;
+    if (quantized_sequence, steps_per_second).count(None) != 1:
+      raise ValueError(
+          &#39;Must specify exactly one of quantized_sequence or steps_per_second&#39;)
+
+    if quantized_sequence:
+      sequences_lib.assert_is_absolute_quantized_sequence(quantized_sequence)
+      self._steps_per_second = (
+          quantized_sequence.quantization_info.steps_per_second)
+      self._events = self._from_quantized_sequence(
+          quantized_sequence, start_step, num_velocity_bins,
+          max_shift_steps=max_shift_steps, instrument=instrument)
+      program, is_drum = _program_and_is_drum_from_sequence(
+          quantized_sequence, instrument)
+
+    else:
+      self._steps_per_second = steps_per_second
+      self._events = []
+
+    super(Performance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=max_shift_steps,
+        program=program,
+        is_drum=is_drum)
+
+  @property
+  def steps_per_second(self):
+    return self._steps_per_second
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=None,
+                  max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 1.0 / self.steps_per_second
+    return self._to_sequence(
+        seconds_per_step=seconds_per_step,
+        velocity=velocity,
+        instrument=instrument,
+        program=program,
+        max_note_duration=max_note_duration)
+
+
+class MetricPerformance(BasePerformance):
+  &#34;&#34;&#34;Performance with quarter-note relative timing.&#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, steps_per_quarter=None,
+               start_step=0, num_velocity_bins=0,
+               max_shift_quarters=DEFAULT_MAX_SHIFT_QUARTERS, instrument=None,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a MetricPerformance.
+
+    Either quantized_sequence or steps_per_quarter should be supplied.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      steps_per_quarter: Number of quantized time steps per quarter note, if
+          using metric quantization.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_quarters: Maximum number of quarter notes for a single time-
+          shift event.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      program: MIDI program used for this performance, or None if not specified.
+          Ignored if `quantized_sequence` is provided.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified. Ignored if `quantized_sequence` is provided.
+
+    Raises:
+      ValueError: If both or neither of `quantized_sequence` or
+          `steps_per_quarter` is specified.
+    &#34;&#34;&#34;
+    if (quantized_sequence, steps_per_quarter).count(None) != 1:
+      raise ValueError(
+          &#39;Must specify exactly one of quantized_sequence or steps_per_quarter&#39;)
+
+    if quantized_sequence:
+      sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+      self._steps_per_quarter = (
+          quantized_sequence.quantization_info.steps_per_quarter)
+      self._events = self._from_quantized_sequence(
+          quantized_sequence, start_step, num_velocity_bins,
+          max_shift_steps=self._steps_per_quarter * max_shift_quarters,
+          instrument=instrument)
+      program, is_drum = _program_and_is_drum_from_sequence(
+          quantized_sequence, instrument)
+
+    else:
+      self._steps_per_quarter = steps_per_quarter
+      self._events = []
+
+    super(MetricPerformance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=self._steps_per_quarter * max_shift_quarters,
+        program=program,
+        is_drum=is_drum)
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=None,
+                  max_note_duration=None,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+      qpm: The tempo to use, in quarter notes per minute.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / (self.steps_per_quarter * qpm)
+    sequence = self._to_sequence(
+        seconds_per_step=seconds_per_step,
+        velocity=velocity,
+        instrument=instrument,
+        program=program,
+        max_note_duration=max_note_duration)
+    sequence.tempos.add(qpm=qpm)
+    return sequence
+
+
+class NotePerformanceError(Exception):
+  pass
+
+
+class TooManyTimeShiftStepsError(NotePerformanceError):
+  pass
+
+
+class TooManyDurationStepsError(NotePerformanceError):
+  pass
+
+
+class NotePerformance(BasePerformance):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a stream of performance events.
+
+  Events are PerformanceEvent objects that encode event type and value.
+  In this version, the performance is encoded in 4-event tuples:
+  TIME_SHIFT, NOTE_ON, VELOCITY, DURATION.
+  &#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence, num_velocity_bins, instrument=0,
+               start_step=0, max_shift_steps=1000, max_duration_steps=1000):
+    &#34;&#34;&#34;Construct a NotePerformance.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      num_velocity_bins: Number of velocity bins to use.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      start_step: The offset of this sequence relative to the beginning of the
+          source sequence.
+      max_shift_steps: Maximum number of steps for a time-shift event.
+      max_duration_steps: Maximum number of steps for a duration event.
+
+    Raises:
+      ValueError: If `num_velocity_bins` is larger than the number of MIDI
+          velocity values.
+    &#34;&#34;&#34;
+    program, is_drum = _program_and_is_drum_from_sequence(
+        quantized_sequence, instrument)
+
+    super(NotePerformance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=max_shift_steps,
+        program=program,
+        is_drum=is_drum)
+
+    self._max_duration_steps = max_duration_steps
+
+    sequences_lib.assert_is_absolute_quantized_sequence(quantized_sequence)
+    self._steps_per_second = (
+        quantized_sequence.quantization_info.steps_per_second)
+    self._events = self._from_quantized_sequence(
+        quantized_sequence, instrument)
+
+  @property
+  def steps_per_second(self):
+    return self._steps_per_second
+
+  def set_length(self, steps, from_left=False):
+    # This is not actually implemented, but to avoid raising exceptions during
+    # generation just return instead of raising NotImplementedError.
+    # TODO(fjord): Implement this.
+    return
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The performance event tuple to append to the end.
+
+    Raises:
+      ValueError: If `event` is not a valid performance event tuple.
+    &#34;&#34;&#34;
+    if not isinstance(event, tuple):
+      raise ValueError(&#39;Invalid performance event tuple: %s&#39; % event)
+    self._events.append(event)
+
+  def __str__(self):
+    strs = []
+    for event in self:
+      strs.append(&#39;TIME_SHIFT&lt;%s&gt;, NOTE_ON&lt;%s&gt;, VELOCITY&lt;%s&gt;, DURATION&lt;%s&gt;&#39; % (
+          event[0].event_value, event[1].event_value, event[2].event_value,
+          event[3].event_value))
+    return &#39;\n&#39;.join(strs)
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    steps = 0
+    for event in self._events:
+      steps += event[0].event_value
+    if self._events:
+      steps += self._events[-1][3].event_value
+    return steps
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Return a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    step = self.start_step
+    result = []
+    for event in self:
+      step += event[0].event_value
+      result.append(step)
+    return result
+
+  def _from_quantized_sequence(self, quantized_sequence, instrument):
+    &#34;&#34;&#34;Extract a list of events from the given quantized NoteSequence object.
+
+    Within a step, new pitches are started with NOTE_ON and existing pitches are
+    ended with NOTE_OFF. TIME_SHIFT shifts the current step forward in time.
+    VELOCITY changes the current velocity value that will be applied to all
+    NOTE_ON events.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      instrument: If not None, extract only the specified instrument. Otherwise,
+          extract all instruments into a single event list.
+
+    Returns:
+      A list of events.
+
+    Raises:
+      TooManyTimeShiftStepsError: If the maximum number of time
+        shift steps is exceeded.
+      TooManyDurationStepsError: If the maximum number of duration
+        shift steps is exceeded.
+    &#34;&#34;&#34;
+    notes = [note for note in quantized_sequence.notes
+             if note.quantized_start_step &gt;= self.start_step
+             and (instrument is None or note.instrument == instrument)]
+    sorted_notes = sorted(notes, key=lambda note: (note.start_time, note.pitch))
+
+    current_step = self.start_step
+    performance_events = []
+
+    for note in sorted_notes:
+      sub_events = []
+
+      # TIME_SHIFT
+      time_shift_steps = note.quantized_start_step - current_step
+      if time_shift_steps &gt; self._max_shift_steps:
+        raise TooManyTimeShiftStepsError(
+            &#39;Too many steps for timeshift: %d&#39; % time_shift_steps)
+      else:
+        sub_events.append(
+            PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                             event_value=time_shift_steps))
+      current_step = note.quantized_start_step
+
+      # NOTE_ON
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.NOTE_ON,
+                           event_value=note.pitch))
+
+      # VELOCITY
+      velocity_bin = velocity_to_bin(note.velocity, self._num_velocity_bins)
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.VELOCITY,
+                           event_value=velocity_bin))
+
+      # DURATION
+      duration_steps = note.quantized_end_step - note.quantized_start_step
+      if duration_steps &gt; self._max_duration_steps:
+        raise TooManyDurationStepsError(
+            &#39;Too many steps for duration: %s&#39; % note)
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.DURATION,
+                           event_value=duration_steps))
+
+      performance_events.append(tuple(sub_events))
+
+    return performance_events
+
+  def to_sequence(self, instrument=0, program=None, max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Not used in this implementation.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 1.0 / self.steps_per_second
+    sequence_start_time = self.start_step * seconds_per_step
+
+    sequence = music_pb2.NoteSequence()
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+
+    if program is None:
+      # Use program associated with the performance (or default program).
+      program = self.program if self.program is not None else DEFAULT_PROGRAM
+    is_drum = self.is_drum if self.is_drum is not None else False
+
+    for event in self:
+      step += event[0].event_value
+
+      note = sequence.notes.add()
+      note.start_time = step * seconds_per_step + sequence_start_time
+      note.end_time = ((step + event[3].event_value) * seconds_per_step +
+                       sequence_start_time)
+      note.pitch = event[1].event_value
+      note.velocity = velocity_bin_to_velocity(
+          event[2].event_value, self._num_velocity_bins)
+      note.instrument = instrument
+      note.program = program
+      note.is_drum = is_drum
+
+      if note.end_time &gt; sequence.total_time:
+        sequence.total_time = note.end_time
+
+    return sequence</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.performance_lib.velocity_bin_to_velocity"><code class="name flex">
+<span>def <span class="ident">velocity_bin_to_velocity</span></span>(<span>velocity_bin, num_velocity_bins)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def velocity_bin_to_velocity(velocity_bin, num_velocity_bins):
+  return (
+      MIN_MIDI_VELOCITY + (velocity_bin - 1) *
+      _velocity_bin_size(num_velocity_bins))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.velocity_to_bin"><code class="name flex">
+<span>def <span class="ident">velocity_to_bin</span></span>(<span>velocity, num_velocity_bins)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def velocity_to_bin(velocity, num_velocity_bins):
+  return ((velocity - MIN_MIDI_VELOCITY) //
+          _velocity_bin_size(num_velocity_bins) + 1)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_lib.BasePerformance"><code class="flex name class">
+<span>class <span class="ident">BasePerformance</span></span>
+<span>(</span><span>start_step, num_velocity_bins, max_shift_steps, program=None, is_drum=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a polyphonic sequence as a stream of performance events.</p>
+<p>Events are PerformanceEvent objects that encode event type and value.</p>
+<p>Construct a BasePerformance.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of this sequence relative to the beginning of the
+source sequence.</dd>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins to use.</dd>
+<dt><strong><code>max_shift_steps</code></strong></dt>
+<dd>Maximum number of steps for a single time-shift event.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program used for this performance, or None if not specified.</dd>
+<dt><strong><code>is_drum</code></strong></dt>
+<dd>Whether or not this performance consists of drums, or None if not
+specified.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>num_velocity_bins</code> is larger than the number of MIDI
+velocity values.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BasePerformance(events_lib.EventSequence):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a stream of performance events.
+
+  Events are PerformanceEvent objects that encode event type and value.
+  &#34;&#34;&#34;
+  __metaclass__ = abc.ABCMeta
+
+  def __init__(self, start_step, num_velocity_bins, max_shift_steps,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a BasePerformance.
+
+    Args:
+      start_step: The offset of this sequence relative to the beginning of the
+          source sequence.
+      num_velocity_bins: Number of velocity bins to use.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      program: MIDI program used for this performance, or None if not specified.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified.
+
+    Raises:
+      ValueError: If `num_velocity_bins` is larger than the number of MIDI
+          velocity values.
+    &#34;&#34;&#34;
+    if num_velocity_bins &gt; MAX_MIDI_VELOCITY - MIN_MIDI_VELOCITY + 1:
+      raise ValueError(
+          &#39;Number of velocity bins is too large: %d&#39; % num_velocity_bins)
+
+    self._start_step = start_step
+    self._num_velocity_bins = num_velocity_bins
+    self._max_shift_steps = max_shift_steps
+    self._program = program
+    self._is_drum = is_drum
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def max_shift_steps(self):
+    return self._max_shift_steps
+
+  @property
+  def program(self):
+    return self._program
+
+  @property
+  def is_drum(self):
+    return self._is_drum
+
+  def _append_steps(self, num_steps):
+    &#34;&#34;&#34;Adds steps to the end of the sequence.&#34;&#34;&#34;
+    if (self._events and
+        self._events[-1].event_type == PerformanceEvent.TIME_SHIFT and
+        self._events[-1].event_value &lt; self._max_shift_steps):
+      # Last event is already non-maximal time shift. Increase its duration.
+      added_steps = min(num_steps,
+                        self._max_shift_steps - self._events[-1].event_value)
+      self._events[-1] = PerformanceEvent(
+          PerformanceEvent.TIME_SHIFT,
+          self._events[-1].event_value + added_steps)
+      num_steps -= added_steps
+
+    while num_steps &gt;= self._max_shift_steps:
+      self._events.append(
+          PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                           event_value=self._max_shift_steps))
+      num_steps -= self._max_shift_steps
+
+    if num_steps &gt; 0:
+      self._events.append(
+          PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                           event_value=num_steps))
+
+  def _trim_steps(self, num_steps):
+    &#34;&#34;&#34;Trims a given number of steps from the end of the sequence.&#34;&#34;&#34;
+    steps_trimmed = 0
+    while self._events and steps_trimmed &lt; num_steps:
+      if self._events[-1].event_type == PerformanceEvent.TIME_SHIFT:
+        if steps_trimmed + self._events[-1].event_value &gt; num_steps:
+          self._events[-1] = PerformanceEvent(
+              event_type=PerformanceEvent.TIME_SHIFT,
+              event_value=(self._events[-1].event_value -
+                           num_steps + steps_trimmed))
+          steps_trimmed = num_steps
+        else:
+          steps_trimmed += self._events[-1].event_value
+          self._events.pop()
+      else:
+        self._events.pop()
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads with time shifts to make the
+    sequence the specified length. If it is too long, it will be truncated to
+    the requested length.
+
+    Args:
+      steps: How many quantized steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if from_left:
+      raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+    if self.num_steps &lt; steps:
+      self._append_steps(steps - self.num_steps)
+    elif self.num_steps &gt; steps:
+      self._trim_steps(self.num_steps - steps)
+
+    assert self.num_steps == steps
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The performance event to append to the end.
+
+    Raises:
+      ValueError: If `event` is not a valid performance event.
+    &#34;&#34;&#34;
+    if not isinstance(event, PerformanceEvent):
+      raise ValueError(&#39;Invalid performance event: %s&#39; % event)
+    self._events.append(event)
+
+  def truncate(self, num_events):
+    &#34;&#34;&#34;Truncates this Performance to the specified number of events.
+
+    Args:
+      num_events: The number of events to which this performance will be
+          truncated.
+    &#34;&#34;&#34;
+    self._events = self._events[:num_events]
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this sequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    return self._events[i]
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this sequence.&#34;&#34;&#34;
+    return iter(self._events)
+
+  def __str__(self):
+    strs = []
+    for event in self:
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        strs.append(&#39;(%s, ON)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        strs.append(&#39;(%s, OFF)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.TIME_SHIFT:
+        strs.append(&#39;(%s, SHIFT)&#39; % event.event_value)
+      elif event.event_type == PerformanceEvent.VELOCITY:
+        strs.append(&#39;(%s, VELOCITY)&#39; % event.event_value)
+      else:
+        raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+    return &#39;\n&#39;.join(strs)
+
+  @property
+  def end_step(self):
+    return self.start_step + self.num_steps
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    steps = 0
+    for event in self:
+      if event.event_type == PerformanceEvent.TIME_SHIFT:
+        steps += event.event_value
+    return steps
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Return a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    step = self.start_step
+    result = []
+    for event in self:
+      result.append(step)
+      if event.event_type == PerformanceEvent.TIME_SHIFT:
+        step += event.event_value
+    return result
+
+  @staticmethod
+  def _from_quantized_sequence(quantized_sequence, start_step,
+                               num_velocity_bins, max_shift_steps,
+                               instrument=None):
+    &#34;&#34;&#34;Extract a list of events from the given quantized NoteSequence object.
+
+    Within a step, new pitches are started with NOTE_ON and existing pitches are
+    ended with NOTE_OFF. TIME_SHIFT shifts the current step forward in time.
+    VELOCITY changes the current velocity value that will be applied to all
+    NOTE_ON events.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start converting the sequence at this time step.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      instrument: If not None, extract only the specified instrument. Otherwise,
+          extract all instruments into a single event list.
+
+    Returns:
+      A list of events.
+    &#34;&#34;&#34;
+    notes = [note for note in quantized_sequence.notes
+             if note.quantized_start_step &gt;= start_step
+             and (instrument is None or note.instrument == instrument)]
+    sorted_notes = sorted(notes, key=lambda note: (note.start_time, note.pitch))
+
+    # Sort all note start and end events.
+    onsets = [(note.quantized_start_step, idx, False)
+              for idx, note in enumerate(sorted_notes)]
+    offsets = [(note.quantized_end_step, idx, True)
+               for idx, note in enumerate(sorted_notes)]
+    note_events = sorted(onsets + offsets)
+
+    current_step = start_step
+    current_velocity_bin = 0
+    performance_events = []
+
+    for step, idx, is_offset in note_events:
+      if step &gt; current_step:
+        # Shift time forward from the current step to this event.
+        while step &gt; current_step + max_shift_steps:
+          # We need to move further than the maximum shift size.
+          performance_events.append(
+              PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                               event_value=max_shift_steps))
+          current_step += max_shift_steps
+        performance_events.append(
+            PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                             event_value=int(step - current_step)))
+        current_step = step
+
+      # If we&#39;re using velocity and this note&#39;s velocity is different from the
+      # current velocity, change the current velocity.
+      if num_velocity_bins:
+        velocity_bin = velocity_to_bin(
+            sorted_notes[idx].velocity, num_velocity_bins)
+        if not is_offset and velocity_bin != current_velocity_bin:
+          current_velocity_bin = velocity_bin
+          performance_events.append(
+              PerformanceEvent(event_type=PerformanceEvent.VELOCITY,
+                               event_value=current_velocity_bin))
+
+      # Add a performance event for this note on/off.
+      event_type = (
+          PerformanceEvent.NOTE_OFF if is_offset else PerformanceEvent.NOTE_ON)
+      performance_events.append(
+          PerformanceEvent(event_type=event_type,
+                           event_value=sorted_notes[idx].pitch))
+
+    return performance_events
+
+  @abc.abstractmethod
+  def to_sequence(self, velocity, instrument, program, max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    pass
+
+  def _to_sequence(self, seconds_per_step, velocity, instrument, program,
+                   max_note_duration=None):
+    sequence_start_time = self.start_step * seconds_per_step
+
+    sequence = music_pb2.NoteSequence()
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+
+    if program is None:
+      # Use program associated with the performance (or default program).
+      program = self.program if self.program is not None else DEFAULT_PROGRAM
+    is_drum = self.is_drum if self.is_drum is not None else False
+
+    # Map pitch to list because one pitch may be active multiple times.
+    pitch_start_steps_and_velocities = collections.defaultdict(list)
+    for i, event in enumerate(self):
+      if event.event_type == PerformanceEvent.NOTE_ON:
+        pitch_start_steps_and_velocities[event.event_value].append(
+            (step, velocity))
+      elif event.event_type == PerformanceEvent.NOTE_OFF:
+        if not pitch_start_steps_and_velocities[event.event_value]:
+          logging.debug(
+              &#39;Ignoring NOTE_OFF at position %d with no previous NOTE_ON&#39;, i)
+        else:
+          # Create a note for the pitch that is now ending.
+          pitch_start_step, pitch_velocity = pitch_start_steps_and_velocities[
+              event.event_value][0]
+          pitch_start_steps_and_velocities[event.event_value] = (
+              pitch_start_steps_and_velocities[event.event_value][1:])
+          if step == pitch_start_step:
+            logging.debug(
+                &#39;Ignoring note with zero duration at step %d&#39;, step)
+            continue
+          note = sequence.notes.add()
+          note.start_time = (pitch_start_step * seconds_per_step +
+                             sequence_start_time)
+          note.end_time = step * seconds_per_step + sequence_start_time
+          if (max_note_duration and
+              note.end_time - note.start_time &gt; max_note_duration):
+            note.end_time = note.start_time + max_note_duration
+          note.pitch = event.event_value
+          note.velocity = pitch_velocity
+          note.instrument = instrument
+          note.program = program
+          note.is_drum = is_drum
+          if note.end_time &gt; sequence.total_time:
+            sequence.total_time = note.end_time
+      elif event.event_type == PerformanceEvent.TIME_SHIFT:
+        step += event.event_value
+      elif event.event_type == PerformanceEvent.VELOCITY:
+        assert self._num_velocity_bins
+        velocity = velocity_bin_to_velocity(
+            event.event_value, self._num_velocity_bins)
+      else:
+        raise ValueError(&#39;Unknown event type: %s&#39; % event.event_type)
+
+    # There could be remaining pitches that were never ended. End them now
+    # and create notes.
+    for pitch in pitch_start_steps_and_velocities:
+      for pitch_start_step, pitch_velocity in pitch_start_steps_and_velocities[
+          pitch]:
+        if step == pitch_start_step:
+          logging.debug(&#39;Ignoring note with zero duration at step %d&#39;, step)
+          continue
+        note = sequence.notes.add()
+        note.start_time = (pitch_start_step * seconds_per_step +
+                           sequence_start_time)
+        note.end_time = step * seconds_per_step + sequence_start_time
+        if (max_note_duration and
+            note.end_time - note.start_time &gt; max_note_duration):
+          note.end_time = note.start_time + max_note_duration
+        note.pitch = pitch
+        note.velocity = pitch_velocity
+        note.instrument = instrument
+        note.program = program
+        note.is_drum = is_drum
+        if note.end_time &gt; sequence.total_time:
+          sequence.total_time = note.end_time
+
+    return sequence</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.MetricPerformance" href="#note_seq.performance_lib.MetricPerformance">MetricPerformance</a></li>
+<li><a title="note_seq.performance_lib.NotePerformance" href="#note_seq.performance_lib.NotePerformance">NotePerformance</a></li>
+<li><a title="note_seq.performance_lib.Performance" href="#note_seq.performance_lib.Performance">Performance</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_lib.BasePerformance.end_step"><code class="name">var <span class="ident">end_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def end_step(self):
+  return self.start_step + self.num_steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.is_drum"><code class="name">var <span class="ident">is_drum</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def is_drum(self):
+  return self._is_drum</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.max_shift_steps"><code class="name">var <span class="ident">max_shift_steps</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def max_shift_steps(self):
+  return self._max_shift_steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.num_steps"><code class="name">var <span class="ident">num_steps</span></code></dt>
+<dd>
+<div class="desc"><p>Returns how many steps long this sequence is.</p>
+<h2 id="returns">Returns</h2>
+<p>Length of the sequence in quantized steps.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def num_steps(self):
+  &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+  Returns:
+    Length of the sequence in quantized steps.
+  &#34;&#34;&#34;
+  steps = 0
+  for event in self:
+    if event.event_type == PerformanceEvent.TIME_SHIFT:
+      steps += event.event_value
+  return steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.program"><code class="name">var <span class="ident">program</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def program(self):
+  return self._program</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.start_step"><code class="name">var <span class="ident">start_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def start_step(self):
+  return self._start_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.steps"><code class="name">var <span class="ident">steps</span></code></dt>
+<dd>
+<div class="desc"><p>Return a Python list of the time step at each event in this sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps(self):
+  &#34;&#34;&#34;Return a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+  step = self.start_step
+  result = []
+  for event in self:
+    result.append(step)
+    if event.event_type == PerformanceEvent.TIME_SHIFT:
+      step += event.event_value
+  return result</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_lib.BasePerformance.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends the event to the end of the sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The performance event to append to the end.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is not a valid performance event.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+  Args:
+    event: The performance event to append to the end.
+
+  Raises:
+    ValueError: If `event` is not a valid performance event.
+  &#34;&#34;&#34;
+  if not isinstance(event, PerformanceEvent):
+    raise ValueError(&#39;Invalid performance event: %s&#39; % event)
+  self._events.append(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps, from_left=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the sequence to the specified number of steps.</p>
+<p>If the event sequence is not long enough, pads with time shifts to make the
+sequence the specified length. If it is too long, it will be truncated to
+the requested length.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many quantized steps long the event sequence should be.</dd>
+<dt><strong><code>from_left</code></strong></dt>
+<dd>Whether to add/remove from the left instead of right.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_length(self, steps, from_left=False):
+  &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+  If the event sequence is not long enough, pads with time shifts to make the
+  sequence the specified length. If it is too long, it will be truncated to
+  the requested length.
+
+  Args:
+    steps: How many quantized steps long the event sequence should be.
+    from_left: Whether to add/remove from the left instead of right.
+  &#34;&#34;&#34;
+  if from_left:
+    raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+  if self.num_steps &lt; steps:
+    self._append_steps(steps - self.num_steps)
+  elif self.num_steps &gt; steps:
+    self._trim_steps(self.num_steps - steps)
+
+  assert self.num_steps == steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity, instrument, program, max_note_duration=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the Performance to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>MIDI velocity to give each note. Between 1 and 127 (inclusive).
+If the performance contains velocity events, those will be used
+instead.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>MIDI instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program to give each note, or None to use the program
+associated with the Performance (or the default program if none
+exists).</dd>
+<dt><strong><code>max_note_duration</code></strong></dt>
+<dd>Maximum note duration in seconds to allow. Notes longer
+than this will be truncated. If None, notes can be any length.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@abc.abstractmethod
+def to_sequence(self, velocity, instrument, program, max_note_duration=None):
+  &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+  Args:
+    velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+        If the performance contains velocity events, those will be used
+        instead.
+    instrument: MIDI instrument to give each note.
+    program: MIDI program to give each note, or None to use the program
+        associated with the Performance (or the default program if none
+        exists).
+    max_note_duration: Maximum note duration in seconds to allow. Notes longer
+        than this will be truncated. If None, notes can be any length.
+
+  Returns:
+    A NoteSequence proto.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.BasePerformance.truncate"><code class="name flex">
+<span>def <span class="ident">truncate</span></span>(<span>self, num_events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Truncates this Performance to the specified number of events.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>num_events</code></strong></dt>
+<dd>The number of events to which this performance will be
+truncated.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def truncate(self, num_events):
+  &#34;&#34;&#34;Truncates this Performance to the specified number of events.
+
+  Args:
+    num_events: The number of events to which this performance will be
+        truncated.
+  &#34;&#34;&#34;
+  self._events = self._events[:num_events]</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_lib.MetricPerformance"><code class="flex name class">
+<span>class <span class="ident">MetricPerformance</span></span>
+<span>(</span><span>quantized_sequence=None, steps_per_quarter=None, start_step=0, num_velocity_bins=0, max_shift_quarters=4, instrument=None, program=None, is_drum=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performance with quarter-note relative timing.</p>
+<p>Construct a MetricPerformance.</p>
+<p>Either quantized_sequence or steps_per_quarter should be supplied.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A quantized NoteSequence proto.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Number of quantized time steps per quarter note, if
+using metric quantization.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of this sequence relative to the
+beginning of the source sequence. If a quantized sequence is used as
+input, only notes starting after this step will be considered.</dd>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins to use. If 0, velocity events
+will not be included at all.</dd>
+<dt><strong><code>max_shift_quarters</code></strong></dt>
+<dd>Maximum number of quarter notes for a single time-
+shift event.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>If not None, extract only the specified instrument from
+<code>quantized_sequence</code>. Otherwise, extract all instruments.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program used for this performance, or None if not specified.
+Ignored if <code>quantized_sequence</code> is provided.</dd>
+<dt><strong><code>is_drum</code></strong></dt>
+<dd>Whether or not this performance consists of drums, or None if not
+specified. Ignored if <code>quantized_sequence</code> is provided.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If both or neither of <code>quantized_sequence</code> or
+<code>steps_per_quarter</code> is specified.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MetricPerformance(BasePerformance):
+  &#34;&#34;&#34;Performance with quarter-note relative timing.&#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, steps_per_quarter=None,
+               start_step=0, num_velocity_bins=0,
+               max_shift_quarters=DEFAULT_MAX_SHIFT_QUARTERS, instrument=None,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a MetricPerformance.
+
+    Either quantized_sequence or steps_per_quarter should be supplied.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      steps_per_quarter: Number of quantized time steps per quarter note, if
+          using metric quantization.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_quarters: Maximum number of quarter notes for a single time-
+          shift event.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      program: MIDI program used for this performance, or None if not specified.
+          Ignored if `quantized_sequence` is provided.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified. Ignored if `quantized_sequence` is provided.
+
+    Raises:
+      ValueError: If both or neither of `quantized_sequence` or
+          `steps_per_quarter` is specified.
+    &#34;&#34;&#34;
+    if (quantized_sequence, steps_per_quarter).count(None) != 1:
+      raise ValueError(
+          &#39;Must specify exactly one of quantized_sequence or steps_per_quarter&#39;)
+
+    if quantized_sequence:
+      sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+      self._steps_per_quarter = (
+          quantized_sequence.quantization_info.steps_per_quarter)
+      self._events = self._from_quantized_sequence(
+          quantized_sequence, start_step, num_velocity_bins,
+          max_shift_steps=self._steps_per_quarter * max_shift_quarters,
+          instrument=instrument)
+      program, is_drum = _program_and_is_drum_from_sequence(
+          quantized_sequence, instrument)
+
+    else:
+      self._steps_per_quarter = steps_per_quarter
+      self._events = []
+
+    super(MetricPerformance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=self._steps_per_quarter * max_shift_quarters,
+        program=program,
+        is_drum=is_drum)
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=None,
+                  max_note_duration=None,
+                  qpm=120.0):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+      qpm: The tempo to use, in quarter notes per minute.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / (self.steps_per_quarter * qpm)
+    sequence = self._to_sequence(
+        seconds_per_step=seconds_per_step,
+        velocity=velocity,
+        instrument=instrument,
+        program=program,
+        max_note_duration=max_note_duration)
+    sequence.tempos.add(qpm=qpm)
+    return sequence</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_lib.MetricPerformance.steps_per_quarter"><code class="name">var <span class="ident">steps_per_quarter</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_quarter(self):
+  return self._steps_per_quarter</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_lib.MetricPerformance.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity=100, instrument=0, program=None, max_note_duration=None, qpm=120.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the Performance to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>MIDI velocity to give each note. Between 1 and 127 (inclusive).
+If the performance contains velocity events, those will be used
+instead.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>MIDI instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program to give each note, or None to use the program
+associated with the Performance (or the default program if none
+exists).</dd>
+<dt><strong><code>max_note_duration</code></strong></dt>
+<dd>Maximum note duration in seconds to allow. Notes longer
+than this will be truncated. If None, notes can be any length.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>The tempo to use, in quarter notes per minute.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                velocity=100,
+                instrument=0,
+                program=None,
+                max_note_duration=None,
+                qpm=120.0):
+  &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+  Args:
+    velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+        If the performance contains velocity events, those will be used
+        instead.
+    instrument: MIDI instrument to give each note.
+    program: MIDI program to give each note, or None to use the program
+        associated with the Performance (or the default program if none
+        exists).
+    max_note_duration: Maximum note duration in seconds to allow. Notes longer
+        than this will be truncated. If None, notes can be any length.
+    qpm: The tempo to use, in quarter notes per minute.
+
+  Returns:
+    A NoteSequence proto.
+  &#34;&#34;&#34;
+  seconds_per_step = 60.0 / (self.steps_per_quarter * qpm)
+  sequence = self._to_sequence(
+      seconds_per_step=seconds_per_step,
+      velocity=velocity,
+      instrument=instrument,
+      program=program,
+      max_note_duration=max_note_duration)
+  sequence.tempos.add(qpm=qpm)
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.performance_lib.BasePerformance.append" href="#note_seq.performance_lib.BasePerformance.append">append</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.num_steps" href="#note_seq.performance_lib.BasePerformance.num_steps">num_steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.set_length" href="#note_seq.performance_lib.BasePerformance.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.steps" href="#note_seq.performance_lib.BasePerformance.steps">steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.truncate" href="#note_seq.performance_lib.BasePerformance.truncate">truncate</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_lib.NotePerformance"><code class="flex name class">
+<span>class <span class="ident">NotePerformance</span></span>
+<span>(</span><span>quantized_sequence, num_velocity_bins, instrument=0, start_step=0, max_shift_steps=1000, max_duration_steps=1000)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a polyphonic sequence as a stream of performance events.</p>
+<p>Events are PerformanceEvent objects that encode event type and value.
+In this version, the performance is encoded in 4-event tuples:
+TIME_SHIFT, NOTE_ON, VELOCITY, DURATION.</p>
+<p>Construct a NotePerformance.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A quantized NoteSequence proto.</dd>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins to use.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>If not None, extract only the specified instrument from
+<code>quantized_sequence</code>. Otherwise, extract all instruments.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of this sequence relative to the beginning of the
+source sequence.</dd>
+<dt><strong><code>max_shift_steps</code></strong></dt>
+<dd>Maximum number of steps for a time-shift event.</dd>
+<dt><strong><code>max_duration_steps</code></strong></dt>
+<dd>Maximum number of steps for a duration event.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>num_velocity_bins</code> is larger than the number of MIDI
+velocity values.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NotePerformance(BasePerformance):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a stream of performance events.
+
+  Events are PerformanceEvent objects that encode event type and value.
+  In this version, the performance is encoded in 4-event tuples:
+  TIME_SHIFT, NOTE_ON, VELOCITY, DURATION.
+  &#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence, num_velocity_bins, instrument=0,
+               start_step=0, max_shift_steps=1000, max_duration_steps=1000):
+    &#34;&#34;&#34;Construct a NotePerformance.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      num_velocity_bins: Number of velocity bins to use.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      start_step: The offset of this sequence relative to the beginning of the
+          source sequence.
+      max_shift_steps: Maximum number of steps for a time-shift event.
+      max_duration_steps: Maximum number of steps for a duration event.
+
+    Raises:
+      ValueError: If `num_velocity_bins` is larger than the number of MIDI
+          velocity values.
+    &#34;&#34;&#34;
+    program, is_drum = _program_and_is_drum_from_sequence(
+        quantized_sequence, instrument)
+
+    super(NotePerformance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=max_shift_steps,
+        program=program,
+        is_drum=is_drum)
+
+    self._max_duration_steps = max_duration_steps
+
+    sequences_lib.assert_is_absolute_quantized_sequence(quantized_sequence)
+    self._steps_per_second = (
+        quantized_sequence.quantization_info.steps_per_second)
+    self._events = self._from_quantized_sequence(
+        quantized_sequence, instrument)
+
+  @property
+  def steps_per_second(self):
+    return self._steps_per_second
+
+  def set_length(self, steps, from_left=False):
+    # This is not actually implemented, but to avoid raising exceptions during
+    # generation just return instead of raising NotImplementedError.
+    # TODO(fjord): Implement this.
+    return
+
+  def append(self, event):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The performance event tuple to append to the end.
+
+    Raises:
+      ValueError: If `event` is not a valid performance event tuple.
+    &#34;&#34;&#34;
+    if not isinstance(event, tuple):
+      raise ValueError(&#39;Invalid performance event tuple: %s&#39; % event)
+    self._events.append(event)
+
+  def __str__(self):
+    strs = []
+    for event in self:
+      strs.append(&#39;TIME_SHIFT&lt;%s&gt;, NOTE_ON&lt;%s&gt;, VELOCITY&lt;%s&gt;, DURATION&lt;%s&gt;&#39; % (
+          event[0].event_value, event[1].event_value, event[2].event_value,
+          event[3].event_value))
+    return &#39;\n&#39;.join(strs)
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    steps = 0
+    for event in self._events:
+      steps += event[0].event_value
+    if self._events:
+      steps += self._events[-1][3].event_value
+    return steps
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Return a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    step = self.start_step
+    result = []
+    for event in self:
+      step += event[0].event_value
+      result.append(step)
+    return result
+
+  def _from_quantized_sequence(self, quantized_sequence, instrument):
+    &#34;&#34;&#34;Extract a list of events from the given quantized NoteSequence object.
+
+    Within a step, new pitches are started with NOTE_ON and existing pitches are
+    ended with NOTE_OFF. TIME_SHIFT shifts the current step forward in time.
+    VELOCITY changes the current velocity value that will be applied to all
+    NOTE_ON events.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      instrument: If not None, extract only the specified instrument. Otherwise,
+          extract all instruments into a single event list.
+
+    Returns:
+      A list of events.
+
+    Raises:
+      TooManyTimeShiftStepsError: If the maximum number of time
+        shift steps is exceeded.
+      TooManyDurationStepsError: If the maximum number of duration
+        shift steps is exceeded.
+    &#34;&#34;&#34;
+    notes = [note for note in quantized_sequence.notes
+             if note.quantized_start_step &gt;= self.start_step
+             and (instrument is None or note.instrument == instrument)]
+    sorted_notes = sorted(notes, key=lambda note: (note.start_time, note.pitch))
+
+    current_step = self.start_step
+    performance_events = []
+
+    for note in sorted_notes:
+      sub_events = []
+
+      # TIME_SHIFT
+      time_shift_steps = note.quantized_start_step - current_step
+      if time_shift_steps &gt; self._max_shift_steps:
+        raise TooManyTimeShiftStepsError(
+            &#39;Too many steps for timeshift: %d&#39; % time_shift_steps)
+      else:
+        sub_events.append(
+            PerformanceEvent(event_type=PerformanceEvent.TIME_SHIFT,
+                             event_value=time_shift_steps))
+      current_step = note.quantized_start_step
+
+      # NOTE_ON
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.NOTE_ON,
+                           event_value=note.pitch))
+
+      # VELOCITY
+      velocity_bin = velocity_to_bin(note.velocity, self._num_velocity_bins)
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.VELOCITY,
+                           event_value=velocity_bin))
+
+      # DURATION
+      duration_steps = note.quantized_end_step - note.quantized_start_step
+      if duration_steps &gt; self._max_duration_steps:
+        raise TooManyDurationStepsError(
+            &#39;Too many steps for duration: %s&#39; % note)
+      sub_events.append(
+          PerformanceEvent(event_type=PerformanceEvent.DURATION,
+                           event_value=duration_steps))
+
+      performance_events.append(tuple(sub_events))
+
+    return performance_events
+
+  def to_sequence(self, instrument=0, program=None, max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Not used in this implementation.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 1.0 / self.steps_per_second
+    sequence_start_time = self.start_step * seconds_per_step
+
+    sequence = music_pb2.NoteSequence()
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+
+    if program is None:
+      # Use program associated with the performance (or default program).
+      program = self.program if self.program is not None else DEFAULT_PROGRAM
+    is_drum = self.is_drum if self.is_drum is not None else False
+
+    for event in self:
+      step += event[0].event_value
+
+      note = sequence.notes.add()
+      note.start_time = step * seconds_per_step + sequence_start_time
+      note.end_time = ((step + event[3].event_value) * seconds_per_step +
+                       sequence_start_time)
+      note.pitch = event[1].event_value
+      note.velocity = velocity_bin_to_velocity(
+          event[2].event_value, self._num_velocity_bins)
+      note.instrument = instrument
+      note.program = program
+      note.is_drum = is_drum
+
+      if note.end_time &gt; sequence.total_time:
+        sequence.total_time = note.end_time
+
+    return sequence</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_lib.NotePerformance.steps_per_second"><code class="name">var <span class="ident">steps_per_second</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_second(self):
+  return self._steps_per_second</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_lib.NotePerformance.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends the event to the end of the sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The performance event tuple to append to the end.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is not a valid performance event tuple.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event):
+  &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+  Args:
+    event: The performance event tuple to append to the end.
+
+  Raises:
+    ValueError: If `event` is not a valid performance event tuple.
+  &#34;&#34;&#34;
+  if not isinstance(event, tuple):
+    raise ValueError(&#39;Invalid performance event tuple: %s&#39; % event)
+  self._events.append(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib.NotePerformance.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, instrument=0, program=None, max_note_duration=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the Performance to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>MIDI instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program to give each note, or None to use the program
+associated with the Performance (or the default program if none
+exists).</dd>
+<dt><strong><code>max_note_duration</code></strong></dt>
+<dd>Not used in this implementation.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self, instrument=0, program=None, max_note_duration=None):
+  &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+  Args:
+    instrument: MIDI instrument to give each note.
+    program: MIDI program to give each note, or None to use the program
+        associated with the Performance (or the default program if none
+        exists).
+    max_note_duration: Not used in this implementation.
+
+  Returns:
+    A NoteSequence proto.
+  &#34;&#34;&#34;
+  seconds_per_step = 1.0 / self.steps_per_second
+  sequence_start_time = self.start_step * seconds_per_step
+
+  sequence = music_pb2.NoteSequence()
+  sequence.ticks_per_quarter = STANDARD_PPQ
+
+  step = 0
+
+  if program is None:
+    # Use program associated with the performance (or default program).
+    program = self.program if self.program is not None else DEFAULT_PROGRAM
+  is_drum = self.is_drum if self.is_drum is not None else False
+
+  for event in self:
+    step += event[0].event_value
+
+    note = sequence.notes.add()
+    note.start_time = step * seconds_per_step + sequence_start_time
+    note.end_time = ((step + event[3].event_value) * seconds_per_step +
+                     sequence_start_time)
+    note.pitch = event[1].event_value
+    note.velocity = velocity_bin_to_velocity(
+        event[2].event_value, self._num_velocity_bins)
+    note.instrument = instrument
+    note.program = program
+    note.is_drum = is_drum
+
+    if note.end_time &gt; sequence.total_time:
+      sequence.total_time = note.end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.performance_lib.BasePerformance.num_steps" href="#note_seq.performance_lib.BasePerformance.num_steps">num_steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.set_length" href="#note_seq.performance_lib.BasePerformance.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.steps" href="#note_seq.performance_lib.BasePerformance.steps">steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.truncate" href="#note_seq.performance_lib.BasePerformance.truncate">truncate</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_lib.NotePerformanceError"><code class="flex name class">
+<span>class <span class="ident">NotePerformanceError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NotePerformanceError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.TooManyDurationStepsError" href="#note_seq.performance_lib.TooManyDurationStepsError">TooManyDurationStepsError</a></li>
+<li><a title="note_seq.performance_lib.TooManyTimeShiftStepsError" href="#note_seq.performance_lib.TooManyTimeShiftStepsError">TooManyTimeShiftStepsError</a></li>
+</ul>
+</dd>
+<dt id="note_seq.performance_lib.Performance"><code class="flex name class">
+<span>class <span class="ident">Performance</span></span>
+<span>(</span><span>quantized_sequence=None, steps_per_second=None, start_step=0, num_velocity_bins=0, max_shift_steps=100, instrument=None, program=None, is_drum=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performance with absolute timing and unknown meter.</p>
+<p>Construct a Performance.</p>
+<p>Either quantized_sequence or steps_per_second should be supplied.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>A quantized NoteSequence proto.</dd>
+<dt><strong><code>steps_per_second</code></strong></dt>
+<dd>Number of quantized time steps per second, if using
+absolute quantization.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of this sequence relative to the
+beginning of the source sequence. If a quantized sequence is used as
+input, only notes starting after this step will be considered.</dd>
+<dt><strong><code>num_velocity_bins</code></strong></dt>
+<dd>Number of velocity bins to use. If 0, velocity events
+will not be included at all.</dd>
+<dt><strong><code>max_shift_steps</code></strong></dt>
+<dd>Maximum number of steps for a single time-shift event.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>If not None, extract only the specified instrument from
+<code>quantized_sequence</code>. Otherwise, extract all instruments.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>MIDI program used for this performance, or None if not specified.
+Ignored if <code>quantized_sequence</code> is provided.</dd>
+<dt><strong><code>is_drum</code></strong></dt>
+<dd>Whether or not this performance consists of drums, or None if not
+specified. Ignored if <code>quantized_sequence</code> is provided.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If both or neither of <code>quantized_sequence</code> or
+<code>steps_per_second</code> is specified.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Performance(BasePerformance):
+  &#34;&#34;&#34;Performance with absolute timing and unknown meter.&#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, steps_per_second=None,
+               start_step=0, num_velocity_bins=0,
+               max_shift_steps=DEFAULT_MAX_SHIFT_STEPS, instrument=None,
+               program=None, is_drum=None):
+    &#34;&#34;&#34;Construct a Performance.
+
+    Either quantized_sequence or steps_per_second should be supplied.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence proto.
+      steps_per_second: Number of quantized time steps per second, if using
+          absolute quantization.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      num_velocity_bins: Number of velocity bins to use. If 0, velocity events
+          will not be included at all.
+      max_shift_steps: Maximum number of steps for a single time-shift event.
+      instrument: If not None, extract only the specified instrument from
+          `quantized_sequence`. Otherwise, extract all instruments.
+      program: MIDI program used for this performance, or None if not specified.
+          Ignored if `quantized_sequence` is provided.
+      is_drum: Whether or not this performance consists of drums, or None if not
+          specified. Ignored if `quantized_sequence` is provided.
+
+    Raises:
+      ValueError: If both or neither of `quantized_sequence` or
+          `steps_per_second` is specified.
+    &#34;&#34;&#34;
+    if (quantized_sequence, steps_per_second).count(None) != 1:
+      raise ValueError(
+          &#39;Must specify exactly one of quantized_sequence or steps_per_second&#39;)
+
+    if quantized_sequence:
+      sequences_lib.assert_is_absolute_quantized_sequence(quantized_sequence)
+      self._steps_per_second = (
+          quantized_sequence.quantization_info.steps_per_second)
+      self._events = self._from_quantized_sequence(
+          quantized_sequence, start_step, num_velocity_bins,
+          max_shift_steps=max_shift_steps, instrument=instrument)
+      program, is_drum = _program_and_is_drum_from_sequence(
+          quantized_sequence, instrument)
+
+    else:
+      self._steps_per_second = steps_per_second
+      self._events = []
+
+    super(Performance, self).__init__(
+        start_step=start_step,
+        num_velocity_bins=num_velocity_bins,
+        max_shift_steps=max_shift_steps,
+        program=program,
+        is_drum=is_drum)
+
+  @property
+  def steps_per_second(self):
+    return self._steps_per_second
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=None,
+                  max_note_duration=None):
+    &#34;&#34;&#34;Converts the Performance to NoteSequence proto.
+
+    Args:
+      velocity: MIDI velocity to give each note. Between 1 and 127 (inclusive).
+          If the performance contains velocity events, those will be used
+          instead.
+      instrument: MIDI instrument to give each note.
+      program: MIDI program to give each note, or None to use the program
+          associated with the Performance (or the default program if none
+          exists).
+      max_note_duration: Maximum note duration in seconds to allow. Notes longer
+          than this will be truncated. If None, notes can be any length.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 1.0 / self.steps_per_second
+    return self._to_sequence(
+        seconds_per_step=seconds_per_step,
+        velocity=velocity,
+        instrument=instrument,
+        program=program,
+        max_note_duration=max_note_duration)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></li>
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.performance_lib.Performance.steps_per_second"><code class="name">var <span class="ident">steps_per_second</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_second(self):
+  return self._steps_per_second</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.performance_lib.BasePerformance.append" href="#note_seq.performance_lib.BasePerformance.append">append</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.num_steps" href="#note_seq.performance_lib.BasePerformance.num_steps">num_steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.set_length" href="#note_seq.performance_lib.BasePerformance.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.steps" href="#note_seq.performance_lib.BasePerformance.steps">steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.to_sequence" href="#note_seq.performance_lib.BasePerformance.to_sequence">to_sequence</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.truncate" href="#note_seq.performance_lib.BasePerformance.truncate">truncate</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_lib.PerformanceEvent"><code class="flex name class">
+<span>class <span class="ident">PerformanceEvent</span></span>
+<span>(</span><span>event_type, event_value)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Class for storing events in a performance.</p>
+<p>Method generated by attrs for class PerformanceEvent.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceEvent(object):
+  &#34;&#34;&#34;Class for storing events in a performance.&#34;&#34;&#34;
+  event_type = attr.ib()
+  event_value = attr.ib()
+
+  # Start of a new note.
+  NOTE_ON = 1
+  # End of a note.
+  NOTE_OFF = 2
+  # Shift time forward.
+  TIME_SHIFT = 3
+  # Change current velocity.
+  VELOCITY = 4
+  # Duration of preceding NOTE_ON.
+  # For Note-based encoding, used instead of NOTE_OFF events.
+  DURATION = 5
+
+  @event_type.validator
+  def _check_event(self, attribute, value):
+    &#34;&#34;&#34;Validate event contents.&#34;&#34;&#34;
+    del attribute, value  # This checks the whole object.
+    if self.event_type in (PerformanceEvent.NOTE_ON, PerformanceEvent.NOTE_OFF):
+      if not MIN_MIDI_PITCH &lt;= self.event_value &lt;= MAX_MIDI_PITCH:
+        raise ValueError(&#39;Invalid pitch value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.TIME_SHIFT:
+      if not 0 &lt;= self.event_value:
+        raise ValueError(&#39;Invalid time shift value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.DURATION:
+      if not 1 &lt;= self.event_value:
+        raise ValueError(&#39;Invalid duration value: %s&#39; % self.event_value)
+    elif self.event_type == PerformanceEvent.VELOCITY:
+      if not 1 &lt;= self.event_value &lt;= MAX_NUM_VELOCITY_BINS:
+        raise ValueError(&#39;Invalid velocity value: %s&#39; % self.event_value)
+    else:
+      raise ValueError(&#39;Invalid event type: %s&#39; % self.event_type)</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.performance_lib.PerformanceEvent.DURATION"><code class="name">var <span class="ident">DURATION</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.performance_lib.PerformanceEvent.NOTE_OFF"><code class="name">var <span class="ident">NOTE_OFF</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.performance_lib.PerformanceEvent.NOTE_ON"><code class="name">var <span class="ident">NOTE_ON</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.performance_lib.PerformanceEvent.TIME_SHIFT"><code class="name">var <span class="ident">TIME_SHIFT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.performance_lib.PerformanceEvent.VELOCITY"><code class="name">var <span class="ident">VELOCITY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.performance_lib.TooManyDurationStepsError"><code class="flex name class">
+<span>class <span class="ident">TooManyDurationStepsError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TooManyDurationStepsError(NotePerformanceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.NotePerformanceError" href="#note_seq.performance_lib.NotePerformanceError">NotePerformanceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.performance_lib.TooManyTimeShiftStepsError"><code class="flex name class">
+<span>class <span class="ident">TooManyTimeShiftStepsError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TooManyTimeShiftStepsError(NotePerformanceError):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.performance_lib.NotePerformanceError" href="#note_seq.performance_lib.NotePerformanceError">NotePerformanceError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.performance_lib.velocity_bin_to_velocity" href="#note_seq.performance_lib.velocity_bin_to_velocity">velocity_bin_to_velocity</a></code></li>
+<li><code><a title="note_seq.performance_lib.velocity_to_bin" href="#note_seq.performance_lib.velocity_to_bin">velocity_to_bin</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_lib.BasePerformance" href="#note_seq.performance_lib.BasePerformance">BasePerformance</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.performance_lib.BasePerformance.append" href="#note_seq.performance_lib.BasePerformance.append">append</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.end_step" href="#note_seq.performance_lib.BasePerformance.end_step">end_step</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.is_drum" href="#note_seq.performance_lib.BasePerformance.is_drum">is_drum</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.max_shift_steps" href="#note_seq.performance_lib.BasePerformance.max_shift_steps">max_shift_steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.num_steps" href="#note_seq.performance_lib.BasePerformance.num_steps">num_steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.program" href="#note_seq.performance_lib.BasePerformance.program">program</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.set_length" href="#note_seq.performance_lib.BasePerformance.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.start_step" href="#note_seq.performance_lib.BasePerformance.start_step">start_step</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.steps" href="#note_seq.performance_lib.BasePerformance.steps">steps</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.to_sequence" href="#note_seq.performance_lib.BasePerformance.to_sequence">to_sequence</a></code></li>
+<li><code><a title="note_seq.performance_lib.BasePerformance.truncate" href="#note_seq.performance_lib.BasePerformance.truncate">truncate</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.MetricPerformance" href="#note_seq.performance_lib.MetricPerformance">MetricPerformance</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_lib.MetricPerformance.steps_per_quarter" href="#note_seq.performance_lib.MetricPerformance.steps_per_quarter">steps_per_quarter</a></code></li>
+<li><code><a title="note_seq.performance_lib.MetricPerformance.to_sequence" href="#note_seq.performance_lib.MetricPerformance.to_sequence">to_sequence</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.NotePerformance" href="#note_seq.performance_lib.NotePerformance">NotePerformance</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_lib.NotePerformance.append" href="#note_seq.performance_lib.NotePerformance.append">append</a></code></li>
+<li><code><a title="note_seq.performance_lib.NotePerformance.steps_per_second" href="#note_seq.performance_lib.NotePerformance.steps_per_second">steps_per_second</a></code></li>
+<li><code><a title="note_seq.performance_lib.NotePerformance.to_sequence" href="#note_seq.performance_lib.NotePerformance.to_sequence">to_sequence</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.NotePerformanceError" href="#note_seq.performance_lib.NotePerformanceError">NotePerformanceError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.Performance" href="#note_seq.performance_lib.Performance">Performance</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_lib.Performance.steps_per_second" href="#note_seq.performance_lib.Performance.steps_per_second">steps_per_second</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.PerformanceEvent" href="#note_seq.performance_lib.PerformanceEvent">PerformanceEvent</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_lib.PerformanceEvent.DURATION" href="#note_seq.performance_lib.PerformanceEvent.DURATION">DURATION</a></code></li>
+<li><code><a title="note_seq.performance_lib.PerformanceEvent.NOTE_OFF" href="#note_seq.performance_lib.PerformanceEvent.NOTE_OFF">NOTE_OFF</a></code></li>
+<li><code><a title="note_seq.performance_lib.PerformanceEvent.NOTE_ON" href="#note_seq.performance_lib.PerformanceEvent.NOTE_ON">NOTE_ON</a></code></li>
+<li><code><a title="note_seq.performance_lib.PerformanceEvent.TIME_SHIFT" href="#note_seq.performance_lib.PerformanceEvent.TIME_SHIFT">TIME_SHIFT</a></code></li>
+<li><code><a title="note_seq.performance_lib.PerformanceEvent.VELOCITY" href="#note_seq.performance_lib.PerformanceEvent.VELOCITY">VELOCITY</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.TooManyDurationStepsError" href="#note_seq.performance_lib.TooManyDurationStepsError">TooManyDurationStepsError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.performance_lib.TooManyTimeShiftStepsError" href="#note_seq.performance_lib.TooManyTimeShiftStepsError">TooManyTimeShiftStepsError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/performance_lib_test.html
+++ b/docs/performance_lib_test.html
@@ -1,0 +1,1522 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.performance_lib_test API documentation</title>
+<meta name="description" content="Tests for performance_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.performance_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for performance_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for performance_lib.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import performance_lib
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+
+class PerformanceLibTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.maxDiff = None  # pylint:disable=invalid-name
+
+    self.note_sequence = music_pb2.NoteSequence()
+    self.note_sequence.ticks_per_quarter = 220
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(quantized_sequence)
+
+    self.assertEqual(100, performance.steps_per_second)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+  def testFromQuantizedNoteSequenceWithVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = list(performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=127))
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.VELOCITY, 100),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.VELOCITY, 127),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, performance)
+
+  def testFromQuantizedNoteSequenceWithQuantizedVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = list(performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=16))
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.VELOCITY, 13),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.VELOCITY, 16),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, performance)
+
+  def testFromRelativeQuantizedNoteSequence(self):
+    self.note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=100)
+    performance = performance_lib.MetricPerformance(quantized_sequence)
+
+    self.assertEqual(100, performance.steps_per_quarter)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+  def testNotePerformanceFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 97, 0.0, 4.0), (64, 97, 0.0, 3.0), (67, 121, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.NotePerformance(
+        quantized_sequence, num_velocity_bins=16)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 400)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 64),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 300)),
+        (pe(pe.TIME_SHIFT, 100), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+    ns = performance.to_sequence(instrument=0)
+    self.assertEqual(self.note_sequence, ns)
+
+  def testProgramAndIsDrumFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)],
+        program=1)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1, [(36, 100, 0.0, 4.0), (48, 100, 0.0, 4.0)],
+        program=2)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 2, [(57, 100, 0.0, 0.1)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=0)
+    self.assertEqual(1, performance.program)
+    self.assertFalse(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=1)
+    self.assertEqual(2, performance.program)
+    self.assertFalse(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=2)
+    self.assertIsNone(performance.program)
+    self.assertTrue(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence)
+    self.assertIsNone(performance.program)
+    self.assertIsNone(performance.is_drum)
+
+  def testToSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(quantized_sequence)
+    performance_ns = performance.to_sequence()
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 115, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=127)
+    performance_ns = performance.to_sequence()
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithUnmatchedNoteOffs(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_OFF, 67),  # Was not started, should be ignored.
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 0.5), (64, 100, 0.0, 0.5)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithUnmatchedNoteOns(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithRepeatedNotes(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 2.0), (64, 100, 0.0, 2.0), (60, 100, 1.0, 2.0)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceRelativeQuantized(self):
+    self.note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=100)
+    performance = performance_lib.MetricPerformance(quantized_sequence)
+    performance_ns = performance.to_sequence(qpm=60.0)
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testSetLengthAddSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    performance.set_length(50)
+    self.assertEqual(50, performance.num_steps)
+    self.assertListEqual([0], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [pe(pe.TIME_SHIFT, 50)]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(150)
+    self.assertEqual(150, performance.num_steps)
+    self.assertListEqual([0, 100], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.TIME_SHIFT, 50),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(200)
+    self.assertEqual(200, performance.num_steps)
+    self.assertListEqual([0, 100], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+  def testSetLengthRemoveSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance.set_length(200)
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_ON, 67),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(50)
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 50),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+  def testNumSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    self.assertEqual(100, performance.num_steps)
+    self.assertListEqual([0, 0, 0, 100, 100], performance.steps)
+
+  def testSteps(self):
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+    ]
+
+    performance = performance_lib.Performance(steps_per_second=100)
+    for event in perf_events:
+      performance.append(event)
+    self.assertListEqual([0, 0, 0, 100, 100], performance.steps)
+
+    performance = performance_lib.Performance(
+        steps_per_second=100, start_step=100)
+    for event in perf_events:
+      performance.append(event)
+    self.assertListEqual([100, 100, 100, 200, 200], performance.steps)
+
+  def testPeEqAndHash(self):
+    pe = performance_lib.PerformanceEvent
+    self.assertEqual(pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60))
+    self.assertLen(set([pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60)]), 1)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest"><code class="flex name class">
+<span>class <span class="ident">PerformanceLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PerformanceLibTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.maxDiff = None  # pylint:disable=invalid-name
+
+    self.note_sequence = music_pb2.NoteSequence()
+    self.note_sequence.ticks_per_quarter = 220
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(quantized_sequence)
+
+    self.assertEqual(100, performance.steps_per_second)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+  def testFromQuantizedNoteSequenceWithVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = list(performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=127))
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.VELOCITY, 100),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.VELOCITY, 127),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, performance)
+
+  def testFromQuantizedNoteSequenceWithQuantizedVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = list(performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=16))
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.VELOCITY, 13),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.VELOCITY, 16),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, performance)
+
+  def testFromRelativeQuantizedNoteSequence(self):
+    self.note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=100)
+    performance = performance_lib.MetricPerformance(quantized_sequence)
+
+    self.assertEqual(100, performance.steps_per_quarter)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+  def testNotePerformanceFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 97, 0.0, 4.0), (64, 97, 0.0, 3.0), (67, 121, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.NotePerformance(
+        quantized_sequence, num_velocity_bins=16)
+
+    pe = performance_lib.PerformanceEvent
+    expected_performance = [
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 400)),
+        (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 64),
+         pe(pe.VELOCITY, 13), pe(pe.DURATION, 300)),
+        (pe(pe.TIME_SHIFT, 100), pe(pe.NOTE_ON, 67),
+         pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+    ]
+    self.assertEqual(expected_performance, list(performance))
+
+    ns = performance.to_sequence(instrument=0)
+    self.assertEqual(self.note_sequence, ns)
+
+  def testProgramAndIsDrumFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)],
+        program=1)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1, [(36, 100, 0.0, 4.0), (48, 100, 0.0, 4.0)],
+        program=2)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 2, [(57, 100, 0.0, 0.1)],
+        is_drum=True)
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=0)
+    self.assertEqual(1, performance.program)
+    self.assertFalse(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=1)
+    self.assertEqual(2, performance.program)
+    self.assertFalse(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence, instrument=2)
+    self.assertIsNone(performance.program)
+    self.assertTrue(performance.is_drum)
+
+    performance = performance_lib.Performance(quantized_sequence)
+    self.assertIsNone(performance.program)
+    self.assertIsNone(performance.is_drum)
+
+  def testToSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(quantized_sequence)
+    performance_ns = performance.to_sequence()
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithVelocity(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 115, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=100)
+    performance = performance_lib.Performance(
+        quantized_sequence, num_velocity_bins=127)
+    performance_ns = performance.to_sequence()
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithUnmatchedNoteOffs(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 50),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_OFF, 67),  # Was not started, should be ignored.
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 0.5), (64, 100, 0.0, 0.5)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithUnmatchedNoteOns(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceWithRepeatedNotes(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance_ns = performance.to_sequence()
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 2.0), (64, 100, 0.0, 2.0), (60, 100, 1.0, 2.0)])
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testToSequenceRelativeQuantized(self):
+    self.note_sequence.tempos.add(qpm=60.0)
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=100)
+    performance = performance_lib.MetricPerformance(quantized_sequence)
+    performance_ns = performance.to_sequence(qpm=60.0)
+
+    # Make comparison easier by sorting.
+    performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, performance_ns)
+
+  def testSetLengthAddSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    performance.set_length(50)
+    self.assertEqual(50, performance.num_steps)
+    self.assertListEqual([0], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [pe(pe.TIME_SHIFT, 50)]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(150)
+    self.assertEqual(150, performance.num_steps)
+    self.assertListEqual([0, 100], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.TIME_SHIFT, 50),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(200)
+    self.assertEqual(200, performance.num_steps)
+    self.assertListEqual([0, 100], performance.steps)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.TIME_SHIFT, 100),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+  def testSetLengthRemoveSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_ON, 67),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 67),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    performance.set_length(200)
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 64),
+        pe(pe.NOTE_ON, 67),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+    performance.set_length(50)
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.TIME_SHIFT, 50),
+    ]
+    self.assertEqual(perf_events, list(performance))
+
+  def testNumSteps(self):
+    performance = performance_lib.Performance(steps_per_second=100)
+
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+    ]
+    for event in perf_events:
+      performance.append(event)
+
+    self.assertEqual(100, performance.num_steps)
+    self.assertListEqual([0, 0, 0, 100, 100], performance.steps)
+
+  def testSteps(self):
+    pe = performance_lib.PerformanceEvent
+    perf_events = [
+        pe(pe.NOTE_ON, 60),
+        pe(pe.NOTE_ON, 64),
+        pe(pe.TIME_SHIFT, 100),
+        pe(pe.NOTE_OFF, 60),
+        pe(pe.NOTE_OFF, 64),
+    ]
+
+    performance = performance_lib.Performance(steps_per_second=100)
+    for event in perf_events:
+      performance.append(event)
+    self.assertListEqual([0, 0, 0, 100, 100], performance.steps)
+
+    performance = performance_lib.Performance(
+        steps_per_second=100, start_step=100)
+    for event in perf_events:
+      performance.append(event)
+    self.assertListEqual([100, 100, 100, 200, 200], performance.steps)
+
+  def testPeEqAndHash(self):
+    pe = performance_lib.PerformanceEvent
+    self.assertEqual(pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60))
+    self.assertLen(set([pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60)]), 1)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  super().setUp()
+  self.maxDiff = None  # pylint:disable=invalid-name
+
+  self.note_sequence = music_pb2.NoteSequence()
+  self.note_sequence.ticks_per_quarter = 220</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = performance_lib.Performance(quantized_sequence)
+
+  self.assertEqual(100, performance.steps_per_second)
+
+  pe = performance_lib.PerformanceEvent
+  expected_performance = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+  ]
+  self.assertEqual(expected_performance, list(performance))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithQuantizedVelocity"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceWithQuantizedVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceWithQuantizedVelocity(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = list(performance_lib.Performance(
+      quantized_sequence, num_velocity_bins=16))
+
+  pe = performance_lib.PerformanceEvent
+  expected_performance = [
+      pe(pe.VELOCITY, 13),
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.VELOCITY, 16),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+  ]
+  self.assertEqual(expected_performance, performance)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithVelocity"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequenceWithVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequenceWithVelocity(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = list(performance_lib.Performance(
+      quantized_sequence, num_velocity_bins=127))
+
+  pe = performance_lib.PerformanceEvent
+  expected_performance = [
+      pe(pe.VELOCITY, 100),
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.VELOCITY, 127),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+  ]
+  self.assertEqual(expected_performance, performance)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testFromRelativeQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromRelativeQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromRelativeQuantizedNoteSequence(self):
+  self.note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=100)
+  performance = performance_lib.MetricPerformance(quantized_sequence)
+
+  self.assertEqual(100, performance.steps_per_quarter)
+
+  pe = performance_lib.PerformanceEvent
+  expected_performance = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+  ]
+  self.assertEqual(expected_performance, list(performance))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testNotePerformanceFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testNotePerformanceFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNotePerformanceFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 97, 0.0, 4.0), (64, 97, 0.0, 3.0), (67, 121, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = performance_lib.NotePerformance(
+      quantized_sequence, num_velocity_bins=16)
+
+  pe = performance_lib.PerformanceEvent
+  expected_performance = [
+      (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 60),
+       pe(pe.VELOCITY, 13), pe(pe.DURATION, 400)),
+      (pe(pe.TIME_SHIFT, 0), pe(pe.NOTE_ON, 64),
+       pe(pe.VELOCITY, 13), pe(pe.DURATION, 300)),
+      (pe(pe.TIME_SHIFT, 100), pe(pe.NOTE_ON, 67),
+       pe(pe.VELOCITY, 16), pe(pe.DURATION, 100)),
+  ]
+  self.assertEqual(expected_performance, list(performance))
+
+  ns = performance.to_sequence(instrument=0)
+  self.assertEqual(self.note_sequence, ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testNumSteps"><code class="name flex">
+<span>def <span class="ident">testNumSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testNumSteps(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_OFF, 64),
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  self.assertEqual(100, performance.num_steps)
+  self.assertListEqual([0, 0, 0, 100, 100], performance.steps)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testPeEqAndHash"><code class="name flex">
+<span>def <span class="ident">testPeEqAndHash</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPeEqAndHash(self):
+  pe = performance_lib.PerformanceEvent
+  self.assertEqual(pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60))
+  self.assertLen(set([pe(pe.NOTE_ON, 60), pe(pe.NOTE_ON, 60)]), 1)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testProgramAndIsDrumFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testProgramAndIsDrumFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testProgramAndIsDrumFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)],
+      program=1)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 1, [(36, 100, 0.0, 4.0), (48, 100, 0.0, 4.0)],
+      program=2)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 2, [(57, 100, 0.0, 0.1)],
+      is_drum=True)
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+
+  performance = performance_lib.Performance(quantized_sequence, instrument=0)
+  self.assertEqual(1, performance.program)
+  self.assertFalse(performance.is_drum)
+
+  performance = performance_lib.Performance(quantized_sequence, instrument=1)
+  self.assertEqual(2, performance.program)
+  self.assertFalse(performance.is_drum)
+
+  performance = performance_lib.Performance(quantized_sequence, instrument=2)
+  self.assertIsNone(performance.program)
+  self.assertTrue(performance.is_drum)
+
+  performance = performance_lib.Performance(quantized_sequence)
+  self.assertIsNone(performance.program)
+  self.assertIsNone(performance.is_drum)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testSetLengthAddSteps"><code class="name flex">
+<span>def <span class="ident">testSetLengthAddSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLengthAddSteps(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  performance.set_length(50)
+  self.assertEqual(50, performance.num_steps)
+  self.assertListEqual([0], performance.steps)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [pe(pe.TIME_SHIFT, 50)]
+  self.assertEqual(perf_events, list(performance))
+
+  performance.set_length(150)
+  self.assertEqual(150, performance.num_steps)
+  self.assertListEqual([0, 100], performance.steps)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.TIME_SHIFT, 50),
+  ]
+  self.assertEqual(perf_events, list(performance))
+
+  performance.set_length(200)
+  self.assertEqual(200, performance.num_steps)
+  self.assertListEqual([0, 100], performance.steps)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.TIME_SHIFT, 100),
+  ]
+  self.assertEqual(perf_events, list(performance))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testSetLengthRemoveSteps"><code class="name flex">
+<span>def <span class="ident">testSetLengthRemoveSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLengthRemoveSteps(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.NOTE_ON, 67),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 67),
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  performance.set_length(200)
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.NOTE_ON, 67),
+  ]
+  self.assertEqual(perf_events, list(performance))
+
+  performance.set_length(50)
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.TIME_SHIFT, 50),
+  ]
+  self.assertEqual(perf_events, list(performance))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testSteps"><code class="name flex">
+<span>def <span class="ident">testSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSteps(self):
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_OFF, 64),
+  ]
+
+  performance = performance_lib.Performance(steps_per_second=100)
+  for event in perf_events:
+    performance.append(event)
+  self.assertListEqual([0, 0, 0, 100, 100], performance.steps)
+
+  performance = performance_lib.Performance(
+      steps_per_second=100, start_step=100)
+  for event in perf_events:
+    performance.append(event)
+  self.assertListEqual([100, 100, 100, 200, 200], performance.steps)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequence"><code class="name flex">
+<span>def <span class="ident">testToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = performance_lib.Performance(quantized_sequence)
+  performance_ns = performance.to_sequence()
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceRelativeQuantized"><code class="name flex">
+<span>def <span class="ident">testToSequenceRelativeQuantized</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceRelativeQuantized(self):
+  self.note_sequence.tempos.add(qpm=60.0)
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=100)
+  performance = performance_lib.MetricPerformance(quantized_sequence)
+  performance_ns = performance.to_sequence(qpm=60.0)
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithRepeatedNotes"><code class="name flex">
+<span>def <span class="ident">testToSequenceWithRepeatedNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceWithRepeatedNotes(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+      pe(pe.NOTE_ON, 60),
+      pe(pe.TIME_SHIFT, 100),
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  performance_ns = performance.to_sequence()
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 2.0), (64, 100, 0.0, 2.0), (60, 100, 1.0, 2.0)])
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOffs"><code class="name flex">
+<span>def <span class="ident">testToSequenceWithUnmatchedNoteOffs</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceWithUnmatchedNoteOffs(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 50),
+      pe(pe.NOTE_OFF, 60),
+      pe(pe.NOTE_OFF, 64),
+      pe(pe.NOTE_OFF, 67),  # Was not started, should be ignored.
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  performance_ns = performance.to_sequence()
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 0.5), (64, 100, 0.0, 0.5)])
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOns"><code class="name flex">
+<span>def <span class="ident">testToSequenceWithUnmatchedNoteOns</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceWithUnmatchedNoteOns(self):
+  performance = performance_lib.Performance(steps_per_second=100)
+
+  pe = performance_lib.PerformanceEvent
+  perf_events = [
+      pe(pe.NOTE_ON, 60),
+      pe(pe.NOTE_ON, 64),
+      pe(pe.TIME_SHIFT, 100),
+  ]
+  for event in perf_events:
+    performance.append(event)
+
+  performance_ns = performance.to_sequence()
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 1.0), (64, 100, 0.0, 1.0)])
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithVelocity"><code class="name flex">
+<span>def <span class="ident">testToSequenceWithVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceWithVelocity(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 115, 0.0, 3.0), (67, 127, 1.0, 2.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=100)
+  performance = performance_lib.Performance(
+      quantized_sequence, num_velocity_bins=127)
+  performance_ns = performance.to_sequence()
+
+  # Make comparison easier by sorting.
+  performance_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, performance_ns)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.performance_lib_test.PerformanceLibTest" href="#note_seq.performance_lib_test.PerformanceLibTest">PerformanceLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.setUp" href="#note_seq.performance_lib_test.PerformanceLibTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequence" href="#note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequence">testFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithQuantizedVelocity" href="#note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithQuantizedVelocity">testFromQuantizedNoteSequenceWithQuantizedVelocity</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithVelocity" href="#note_seq.performance_lib_test.PerformanceLibTest.testFromQuantizedNoteSequenceWithVelocity">testFromQuantizedNoteSequenceWithVelocity</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testFromRelativeQuantizedNoteSequence" href="#note_seq.performance_lib_test.PerformanceLibTest.testFromRelativeQuantizedNoteSequence">testFromRelativeQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testNotePerformanceFromQuantizedNoteSequence" href="#note_seq.performance_lib_test.PerformanceLibTest.testNotePerformanceFromQuantizedNoteSequence">testNotePerformanceFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testNumSteps" href="#note_seq.performance_lib_test.PerformanceLibTest.testNumSteps">testNumSteps</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testPeEqAndHash" href="#note_seq.performance_lib_test.PerformanceLibTest.testPeEqAndHash">testPeEqAndHash</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testProgramAndIsDrumFromQuantizedNoteSequence" href="#note_seq.performance_lib_test.PerformanceLibTest.testProgramAndIsDrumFromQuantizedNoteSequence">testProgramAndIsDrumFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testSetLengthAddSteps" href="#note_seq.performance_lib_test.PerformanceLibTest.testSetLengthAddSteps">testSetLengthAddSteps</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testSetLengthRemoveSteps" href="#note_seq.performance_lib_test.PerformanceLibTest.testSetLengthRemoveSteps">testSetLengthRemoveSteps</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testSteps" href="#note_seq.performance_lib_test.PerformanceLibTest.testSteps">testSteps</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequence" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequence">testToSequence</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceRelativeQuantized" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequenceRelativeQuantized">testToSequenceRelativeQuantized</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithRepeatedNotes" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithRepeatedNotes">testToSequenceWithRepeatedNotes</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOffs" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOffs">testToSequenceWithUnmatchedNoteOffs</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOns" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithUnmatchedNoteOns">testToSequenceWithUnmatchedNoteOns</a></code></li>
+<li><code><a title="note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithVelocity" href="#note_seq.performance_lib_test.PerformanceLibTest.testToSequenceWithVelocity">testToSequenceWithVelocity</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/pianoroll_encoder_decoder.html
+++ b/docs/pianoroll_encoder_decoder.html
@@ -1,0 +1,503 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.pianoroll_encoder_decoder API documentation</title>
+<meta name="description" content="Classes for converting between pianoroll input and model input/output." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.pianoroll_encoder_decoder</code></h1>
+</header>
+<section id="section-intro">
+<p>Classes for converting between pianoroll input and model input/output.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Classes for converting between pianoroll input and model input/output.&#34;&#34;&#34;
+
+from note_seq import encoder_decoder
+import numpy as np
+
+
+class PianorollEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces a pianoroll encoding.
+
+  Inputs are binary arrays with active pitches (with some offset) at each step
+  set to 1 and inactive pitches set to 0.
+
+  Events are PianorollSequence events, which are tuples of active pitches
+  (with some offset) at each step.
+  &#34;&#34;&#34;
+
+  def __init__(self, input_size=88):
+    &#34;&#34;&#34;Initialize a PianorollEncoderDecoder object.
+
+    Args:
+      input_size: The size of the input vector.
+    &#34;&#34;&#34;
+    self._input_size = input_size
+
+  @property
+  def input_size(self):
+    return self._input_size
+
+  @property
+  def num_classes(self):
+    return 2 ** self.input_size
+
+  @property
+  def default_event_label(self):
+    return 0
+
+  def _event_to_label(self, event):
+    label = 0
+    for pitch in event:
+      label += 2**pitch
+    return label
+
+  def _event_to_input(self, event):
+    input_ = np.zeros(self.input_size, np.float32)
+    input_[list(event)] = 1
+    return input_
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Args:
+      events: A list-like sequence of PianorollSequence events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    return self._event_to_input(events[position])
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Args:
+      events: A list-like sequence of PianorollSequence events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._event_to_label(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An PianorollSequence event value.
+    &#34;&#34;&#34;
+    assert class_index &lt; self.num_classes
+    event = []
+    for i in range(self.input_size):
+      if class_index % 2:
+        event.append(i)
+      class_index &gt;&gt;= 1
+    assert class_index == 0
+    return tuple(event)
+
+  def extend_event_sequences(self, event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by adding the new samples.
+
+    Args:
+      event_sequences: A collection of PianorollSequences to append `samples`
+         to.
+      softmax: A collection of binary arrays with active pitches set to 1 and
+         inactive pitches set to 0, which will be added to the corresponding
+         `pianoroll_seqs`.
+    Raises:
+      ValueError: if inputs are not of equal length.
+    &#34;&#34;&#34;
+    pianoroll_seqs = event_sequences
+    samples = softmax
+    if len(pianoroll_seqs) != len(samples):
+      raise ValueError(
+          &#39;`pianoroll_seqs` and `samples` must have equal lengths.&#39;)
+    for pianoroll_seq, sample in zip(pianoroll_seqs, samples):
+      event = tuple(np.where(sample)[0])
+      pianoroll_seq.append(event)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder"><code class="flex name class">
+<span>class <span class="ident">PianorollEncoderDecoder</span></span>
+<span>(</span><span>input_size=88)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An EventSequenceEncoderDecoder that produces a pianoroll encoding.</p>
+<p>Inputs are binary arrays with active pitches (with some offset) at each step
+set to 1 and inactive pitches set to 0.</p>
+<p>Events are PianorollSequence events, which are tuples of active pitches
+(with some offset) at each step.</p>
+<p>Initialize a PianorollEncoderDecoder object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>input_size</code></strong></dt>
+<dd>The size of the input vector.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PianorollEncoderDecoder(encoder_decoder.EventSequenceEncoderDecoder):
+  &#34;&#34;&#34;An EventSequenceEncoderDecoder that produces a pianoroll encoding.
+
+  Inputs are binary arrays with active pitches (with some offset) at each step
+  set to 1 and inactive pitches set to 0.
+
+  Events are PianorollSequence events, which are tuples of active pitches
+  (with some offset) at each step.
+  &#34;&#34;&#34;
+
+  def __init__(self, input_size=88):
+    &#34;&#34;&#34;Initialize a PianorollEncoderDecoder object.
+
+    Args:
+      input_size: The size of the input vector.
+    &#34;&#34;&#34;
+    self._input_size = input_size
+
+  @property
+  def input_size(self):
+    return self._input_size
+
+  @property
+  def num_classes(self):
+    return 2 ** self.input_size
+
+  @property
+  def default_event_label(self):
+    return 0
+
+  def _event_to_label(self, event):
+    label = 0
+    for pitch in event:
+      label += 2**pitch
+    return label
+
+  def _event_to_input(self, event):
+    input_ = np.zeros(self.input_size, np.float32)
+    input_[list(event)] = 1
+    return input_
+
+  def events_to_input(self, events, position):
+    &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+    Args:
+      events: A list-like sequence of PianorollSequence events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      An input vector, a list of floats.
+    &#34;&#34;&#34;
+    return self._event_to_input(events[position])
+
+  def events_to_label(self, events, position):
+    &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+    Args:
+      events: A list-like sequence of PianorollSequence events.
+      position: An integer event position in the event sequence.
+
+    Returns:
+      A label, an integer.
+    &#34;&#34;&#34;
+    return self._event_to_label(events[position])
+
+  def class_index_to_event(self, class_index, events):
+    &#34;&#34;&#34;Returns the event for the given class index.
+
+    This is the reverse process of the self.events_to_label method.
+
+    Args:
+      class_index: An integer in the range [0, self.num_classes).
+      events: A list-like sequence of events. This object is not used in this
+          implementation.
+
+    Returns:
+      An PianorollSequence event value.
+    &#34;&#34;&#34;
+    assert class_index &lt; self.num_classes
+    event = []
+    for i in range(self.input_size):
+      if class_index % 2:
+        event.append(i)
+      class_index &gt;&gt;= 1
+    assert class_index == 0
+    return tuple(event)
+
+  def extend_event_sequences(self, event_sequences, softmax):
+    &#34;&#34;&#34;Extends the event sequences by adding the new samples.
+
+    Args:
+      event_sequences: A collection of PianorollSequences to append `samples`
+         to.
+      softmax: A collection of binary arrays with active pitches set to 1 and
+         inactive pitches set to 0, which will be added to the corresponding
+         `pianoroll_seqs`.
+    Raises:
+      ValueError: if inputs are not of equal length.
+    &#34;&#34;&#34;
+    pianoroll_seqs = event_sequences
+    samples = softmax
+    if len(pianoroll_seqs) != len(samples):
+      raise ValueError(
+          &#39;`pianoroll_seqs` and `samples` must have equal lengths.&#39;)
+    for pianoroll_seq, sample in zip(pianoroll_seqs, samples):
+      event = tuple(np.where(sample)[0])
+      pianoroll_seq.append(event)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.class_index_to_event"><code class="name flex">
+<span>def <span class="ident">class_index_to_event</span></span>(<span>self, class_index, events)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the event for the given class index.</p>
+<p>This is the reverse process of the self.events_to_label method.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>class_index</code></strong></dt>
+<dd>An integer in the range [0, self.num_classes).</dd>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of events. This object is not used in this
+implementation.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An PianorollSequence event value.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def class_index_to_event(self, class_index, events):
+  &#34;&#34;&#34;Returns the event for the given class index.
+
+  This is the reverse process of the self.events_to_label method.
+
+  Args:
+    class_index: An integer in the range [0, self.num_classes).
+    events: A list-like sequence of events. This object is not used in this
+        implementation.
+
+  Returns:
+    An PianorollSequence event value.
+  &#34;&#34;&#34;
+  assert class_index &lt; self.num_classes
+  event = []
+  for i in range(self.input_size):
+    if class_index % 2:
+      event.append(i)
+    class_index &gt;&gt;= 1
+  assert class_index == 0
+  return tuple(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_input"><code class="name flex">
+<span>def <span class="ident">events_to_input</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the input vector for the given position in the event sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of PianorollSequence events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An input vector, a list of floats.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_input(self, events, position):
+  &#34;&#34;&#34;Returns the input vector for the given position in the event sequence.
+
+  Args:
+    events: A list-like sequence of PianorollSequence events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    An input vector, a list of floats.
+  &#34;&#34;&#34;
+  return self._event_to_input(events[position])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_label"><code class="name flex">
+<span>def <span class="ident">events_to_label</span></span>(<span>self, events, position)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the label for the given position in the event sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>events</code></strong></dt>
+<dd>A list-like sequence of PianorollSequence events.</dd>
+<dt><strong><code>position</code></strong></dt>
+<dd>An integer event position in the event sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A label, an integer.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def events_to_label(self, events, position):
+  &#34;&#34;&#34;Returns the label for the given position in the event sequence.
+
+  Args:
+    events: A list-like sequence of PianorollSequence events.
+    position: An integer event position in the event sequence.
+
+  Returns:
+    A label, an integer.
+  &#34;&#34;&#34;
+  return self._event_to_label(events[position])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.extend_event_sequences"><code class="name flex">
+<span>def <span class="ident">extend_event_sequences</span></span>(<span>self, event_sequences, softmax)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extends the event sequences by adding the new samples.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event_sequences</code></strong></dt>
+<dd>A collection of PianorollSequences to append <code>samples</code>
+to.</dd>
+<dt><strong><code>softmax</code></strong></dt>
+<dd>A collection of binary arrays with active pitches set to 1 and
+inactive pitches set to 0, which will be added to the corresponding
+<code>pianoroll_seqs</code>.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>if inputs are not of equal length.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extend_event_sequences(self, event_sequences, softmax):
+  &#34;&#34;&#34;Extends the event sequences by adding the new samples.
+
+  Args:
+    event_sequences: A collection of PianorollSequences to append `samples`
+       to.
+    softmax: A collection of binary arrays with active pitches set to 1 and
+       inactive pitches set to 0, which will be added to the corresponding
+       `pianoroll_seqs`.
+  Raises:
+    ValueError: if inputs are not of equal length.
+  &#34;&#34;&#34;
+  pianoroll_seqs = event_sequences
+  samples = softmax
+  if len(pianoroll_seqs) != len(samples):
+    raise ValueError(
+        &#39;`pianoroll_seqs` and `samples` must have equal lengths.&#39;)
+  for pianoroll_seq, sample in zip(pianoroll_seqs, samples):
+    event = tuple(np.where(sample)[0])
+    pianoroll_seq.append(event)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder">EventSequenceEncoderDecoder</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.default_event_label">default_event_label</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.encode">encode</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.evaluate_log_likelihood">evaluate_log_likelihood</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.get_inputs_batch">get_inputs_batch</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.input_size">input_size</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.labels_to_num_steps">labels_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.EventSequenceEncoderDecoder.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder" href="#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder">PianorollEncoderDecoder</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.class_index_to_event" href="#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.class_index_to_event">class_index_to_event</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_input" href="#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_input">events_to_input</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_label" href="#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.events_to_label">events_to_label</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.extend_event_sequences" href="#note_seq.pianoroll_encoder_decoder.PianorollEncoderDecoder.extend_event_sequences">extend_event_sequences</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/pianoroll_encoder_decoder_test.html
+++ b/docs/pianoroll_encoder_decoder_test.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.pianoroll_encoder_decoder_test API documentation</title>
+<meta name="description" content="Tests for pianoroll_encoder_decoder." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.pianoroll_encoder_decoder_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for pianoroll_encoder_decoder.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for pianoroll_encoder_decoder.&#34;&#34;&#34;
+
+from absl.testing import absltest
+from note_seq import pianoroll_encoder_decoder
+import numpy as np
+
+
+class PianorollEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = pianoroll_encoder_decoder.PianorollEncoderDecoder(5)
+
+  def testProperties(self):
+    self.assertEqual(5, self.enc.input_size)
+    self.assertEqual(32, self.enc.num_classes)
+    self.assertEqual(0, self.enc.default_event_label)
+
+  def testEncodeInput(self):
+    events = [(), (1, 2), (2,)]
+    self.assertTrue(np.array_equal(
+        np.zeros(5, np.bool), self.enc.events_to_input(events, 0)))
+    self.assertTrue(np.array_equal(
+        [0, 1, 1, 0, 0], self.enc.events_to_input(events, 1)))
+    self.assertTrue(np.array_equal(
+        [0, 0, 1, 0, 0], self.enc.events_to_input(events, 2)))
+
+  def testEncodeLabel(self):
+    events = [[], [1, 2], [2]]
+    self.assertEqual(0, self.enc.events_to_label(events, 0))
+    self.assertEqual(6, self.enc.events_to_label(events, 1))
+    self.assertEqual(4, self.enc.events_to_label(events, 2))
+
+  def testDecodeLabel(self):
+    self.assertEqual((), self.enc.class_index_to_event(0, None))
+    self.assertEqual((1, 2), self.enc.class_index_to_event(6, None))
+    self.assertEqual((2,), self.enc.class_index_to_event(4, None))
+
+  def testExtendEventSequences(self):
+    seqs = ([(0,), (1, 2)], [(), ()])
+    samples = ([0, 0, 0, 0, 0], [1, 1, 0, 0, 1])
+    self.enc.extend_event_sequences(seqs, samples)
+    self.assertEqual(([(0,), (1, 2), ()], [(), (), (0, 1, 4)]), seqs)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest"><code class="flex name class">
+<span>class <span class="ident">PianorollEncodingTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PianorollEncodingTest(absltest.TestCase):
+
+  def setUp(self):
+    self.enc = pianoroll_encoder_decoder.PianorollEncoderDecoder(5)
+
+  def testProperties(self):
+    self.assertEqual(5, self.enc.input_size)
+    self.assertEqual(32, self.enc.num_classes)
+    self.assertEqual(0, self.enc.default_event_label)
+
+  def testEncodeInput(self):
+    events = [(), (1, 2), (2,)]
+    self.assertTrue(np.array_equal(
+        np.zeros(5, np.bool), self.enc.events_to_input(events, 0)))
+    self.assertTrue(np.array_equal(
+        [0, 1, 1, 0, 0], self.enc.events_to_input(events, 1)))
+    self.assertTrue(np.array_equal(
+        [0, 0, 1, 0, 0], self.enc.events_to_input(events, 2)))
+
+  def testEncodeLabel(self):
+    events = [[], [1, 2], [2]]
+    self.assertEqual(0, self.enc.events_to_label(events, 0))
+    self.assertEqual(6, self.enc.events_to_label(events, 1))
+    self.assertEqual(4, self.enc.events_to_label(events, 2))
+
+  def testDecodeLabel(self):
+    self.assertEqual((), self.enc.class_index_to_event(0, None))
+    self.assertEqual((1, 2), self.enc.class_index_to_event(6, None))
+    self.assertEqual((2,), self.enc.class_index_to_event(4, None))
+
+  def testExtendEventSequences(self):
+    seqs = ([(0,), (1, 2)], [(), ()])
+    samples = ([0, 0, 0, 0, 0], [1, 1, 0, 0, 1])
+    self.enc.extend_event_sequences(seqs, samples)
+    self.assertEqual(([(0,), (1, 2), ()], [(), (), (0, 1, 4)]), seqs)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.enc = pianoroll_encoder_decoder.PianorollEncoderDecoder(5)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testDecodeLabel"><code class="name flex">
+<span>def <span class="ident">testDecodeLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testDecodeLabel(self):
+  self.assertEqual((), self.enc.class_index_to_event(0, None))
+  self.assertEqual((1, 2), self.enc.class_index_to_event(6, None))
+  self.assertEqual((2,), self.enc.class_index_to_event(4, None))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeInput"><code class="name flex">
+<span>def <span class="ident">testEncodeInput</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeInput(self):
+  events = [(), (1, 2), (2,)]
+  self.assertTrue(np.array_equal(
+      np.zeros(5, np.bool), self.enc.events_to_input(events, 0)))
+  self.assertTrue(np.array_equal(
+      [0, 1, 1, 0, 0], self.enc.events_to_input(events, 1)))
+  self.assertTrue(np.array_equal(
+      [0, 0, 1, 0, 0], self.enc.events_to_input(events, 2)))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeLabel"><code class="name flex">
+<span>def <span class="ident">testEncodeLabel</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testEncodeLabel(self):
+  events = [[], [1, 2], [2]]
+  self.assertEqual(0, self.enc.events_to_label(events, 0))
+  self.assertEqual(6, self.enc.events_to_label(events, 1))
+  self.assertEqual(4, self.enc.events_to_label(events, 2))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testExtendEventSequences"><code class="name flex">
+<span>def <span class="ident">testExtendEventSequences</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtendEventSequences(self):
+  seqs = ([(0,), (1, 2)], [(), ()])
+  samples = ([0, 0, 0, 0, 0], [1, 1, 0, 0, 1])
+  self.enc.extend_event_sequences(seqs, samples)
+  self.assertEqual(([(0,), (1, 2), ()], [(), (), (0, 1, 4)]), seqs)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testProperties"><code class="name flex">
+<span>def <span class="ident">testProperties</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testProperties(self):
+  self.assertEqual(5, self.enc.input_size)
+  self.assertEqual(32, self.enc.num_classes)
+  self.assertEqual(0, self.enc.default_event_label)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest">PianorollEncodingTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.setUp" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testDecodeLabel" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testDecodeLabel">testDecodeLabel</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeInput" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeInput">testEncodeInput</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeLabel" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testEncodeLabel">testEncodeLabel</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testExtendEventSequences" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testExtendEventSequences">testExtendEventSequences</a></code></li>
+<li><code><a title="note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testProperties" href="#note_seq.pianoroll_encoder_decoder_test.PianorollEncodingTest.testProperties">testProperties</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/pianoroll_lib.html
+++ b/docs/pianoroll_lib.html
@@ -1,0 +1,901 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.pianoroll_lib API documentation</title>
+<meta name="description" content="Utility functions for working with pianoroll sequences." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.pianoroll_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for working with pianoroll sequences.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for working with pianoroll sequences.&#34;&#34;&#34;
+
+import copy
+
+from note_seq import constants
+from note_seq import events_lib
+from note_seq import sequences_lib
+from note_seq.protobuf import music_pb2
+import numpy as np
+
+DEFAULT_STEPS_PER_QUARTER = constants.DEFAULT_STEPS_PER_QUARTER
+MAX_MIDI_PITCH = 108  # Max piano pitch.
+MIN_MIDI_PITCH = 21  # Min piano pitch.
+STANDARD_PPQ = constants.STANDARD_PPQ
+
+
+class PianorollSequence(events_lib.EventSequence):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a pianoroll.
+
+  Events are collections of active pitches at each step, offset from
+  `min_pitch`.
+  &#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, events_list=None,
+               steps_per_quarter=None, start_step=0, min_pitch=MIN_MIDI_PITCH,
+               max_pitch=MAX_MIDI_PITCH, split_repeats=True, shift_range=False):
+    &#34;&#34;&#34;Construct a PianorollSequence.
+
+    Exactly one of `quantized_sequence` or `steps_per_quarter` must be supplied.
+    At most one of `quantized_sequence` and `events_list` may be supplied.
+
+    Args:
+      quantized_sequence: an optional quantized NoteSequence proto to base
+          PianorollSequence on.
+      events_list: an optional list of Pianoroll events to base
+          PianorollSequence on.
+      steps_per_quarter: how many steps a quarter note represents. Must be
+          provided if `quanitzed_sequence` not given.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      min_pitch: The minimum valid pitch value, inclusive.
+      max_pitch: The maximum valid pitch value, inclusive.
+      split_repeats: Whether to force repeated notes to have a 0-state step
+          between them when initializing from a quantized NoteSequence.
+      shift_range: If True, assume that the given events_list is in the full
+         MIDI pitch range and needs to be shifted and filtered based on
+         `min_pitch` and `max_pitch`.
+    &#34;&#34;&#34;
+    assert (quantized_sequence, steps_per_quarter).count(None) == 1
+    assert (quantized_sequence, events_list).count(None) &gt;= 1
+
+    self._min_pitch = min_pitch
+    self._max_pitch = max_pitch
+
+    if quantized_sequence:
+      sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+      self._events = self._from_quantized_sequence(quantized_sequence,
+                                                   start_step, min_pitch,
+                                                   max_pitch, split_repeats)
+      self._steps_per_quarter = (
+          quantized_sequence.quantization_info.steps_per_quarter)
+    else:
+      self._events = []
+      self._steps_per_quarter = steps_per_quarter
+      if events_list:
+        for e in events_list:
+          self.append(e, shift_range)
+    self._start_step = start_step
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads with silence to make the
+    sequence the specified length. If it is too long, it will be truncated to
+    the requested length.
+
+    Note that this will append a STEP_END event to the end of the sequence if
+    there is an unfinished step.
+
+    Args:
+      steps: How many quantized steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if from_left:
+      raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+    # Then trim or pad as needed.
+    if self.num_steps &lt; steps:
+      self._events += [()] * (steps - self.num_steps)
+    elif self.num_steps &gt; steps:
+      del self._events[steps:]
+    assert self.num_steps == steps
+
+  def append(self, event, shift_range=False):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The polyphonic event to append to the end.
+      shift_range: If True, assume that the given event is in the full MIDI
+         pitch range and needs to be shifted and filtered based on `min_pitch`
+         and `max_pitch`.
+    Raises:
+      ValueError: If `event` is not a valid polyphonic event.
+    &#34;&#34;&#34;
+    if shift_range:
+      event = tuple(p - self._min_pitch for p in event
+                    if self._min_pitch &lt;= p &lt;= self._max_pitch)
+    self._events.append(event)
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this sequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    return self._events[i]
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this sequence.&#34;&#34;&#34;
+    return iter(self._events)
+
+  @property
+  def end_step(self):
+    return self.start_step + self.num_steps
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    return len(self)
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Returns a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    return list(range(self.start_step, self.end_step))
+
+  @staticmethod
+  def _from_quantized_sequence(
+      quantized_sequence, start_step, min_pitch, max_pitch, split_repeats):
+    &#34;&#34;&#34;Populate self with events from the given quantized NoteSequence object.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start converting the sequence at this time step.
+          Assumed to be the beginning of a bar.
+      min_pitch: The minimum valid pitch value, inclusive.
+      max_pitch: The maximum valid pitch value, inclusive.
+      split_repeats: Whether to force repeated notes to have a 0-state step
+          between them.
+
+    Returns:
+      A list of events.
+    &#34;&#34;&#34;
+    piano_roll = np.zeros(
+        (quantized_sequence.total_quantized_steps - start_step,
+         max_pitch - min_pitch + 1), np.bool)
+
+    for note in quantized_sequence.notes:
+      if note.quantized_start_step &lt; start_step:
+        continue
+      if not min_pitch &lt;= note.pitch &lt;= max_pitch:
+        continue
+      note_pitch_offset = note.pitch - min_pitch
+      note_start_offset = note.quantized_start_step - start_step
+      note_end_offset = note.quantized_end_step - start_step
+
+      if split_repeats:
+        piano_roll[note_start_offset - 1, note_pitch_offset] = 0
+      piano_roll[note_start_offset:note_end_offset, note_pitch_offset] = 1
+
+    events = [tuple(np.where(frame)[0]) for frame in piano_roll]
+
+    return events
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=0,
+                  qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                  base_note_sequence=None):
+    &#34;&#34;&#34;Converts the PianorollSequence to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      qpm: Quarter notes per minute (float).
+      base_note_sequence: A NoteSequence to use a starting point. Must match the
+          specified qpm.
+
+    Raises:
+      ValueError: if an unknown event is encountered.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self._steps_per_quarter
+
+    sequence_start_time = self.start_step * seconds_per_step
+
+    if base_note_sequence:
+      sequence = copy.deepcopy(base_note_sequence)
+      if sequence.tempos[0].qpm != qpm:
+        raise ValueError(
+            &#39;Supplied QPM (%d) does not match QPM of base_note_sequence (%d)&#39;
+            % (qpm, sequence.tempos[0].qpm))
+    else:
+      sequence = music_pb2.NoteSequence()
+      sequence.tempos.add().qpm = qpm
+      sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+    # Keep a dictionary of open notes for each pitch.
+    open_notes = {}
+    for step, event in enumerate(self):
+      frame_pitches = set(event)
+      open_pitches = set(open_notes)
+
+      for pitch_to_close in open_pitches - frame_pitches:
+        note_to_close = open_notes[pitch_to_close]
+        note_to_close.end_time = step * seconds_per_step + sequence_start_time
+        del open_notes[pitch_to_close]
+
+      for pitch_to_open in frame_pitches - open_pitches:
+        new_note = sequence.notes.add()
+        new_note.start_time = step * seconds_per_step + sequence_start_time
+        new_note.pitch = pitch_to_open + self._min_pitch
+        new_note.velocity = velocity
+        new_note.instrument = instrument
+        new_note.program = program
+        open_notes[pitch_to_open] = new_note
+
+    final_step = step + (len(open_notes) &gt; 0)  # pylint: disable=g-explicit-length-test
+    for note_to_close in open_notes.values():
+      note_to_close.end_time = (
+          final_step * seconds_per_step + sequence_start_time)
+
+    sequence.total_time = seconds_per_step * final_step + sequence_start_time
+    if sequence.notes:
+      assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+    return sequence</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.pianoroll_lib.PianorollSequence"><code class="flex name class">
+<span>class <span class="ident">PianorollSequence</span></span>
+<span>(</span><span>quantized_sequence=None, events_list=None, steps_per_quarter=None, start_step=0, min_pitch=21, max_pitch=108, split_repeats=True, shift_range=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Stores a polyphonic sequence as a pianoroll.</p>
+<p>Events are collections of active pitches at each step, offset from
+<code>min_pitch</code>.</p>
+<p>Construct a PianorollSequence.</p>
+<p>Exactly one of <code>quantized_sequence</code> or <code>steps_per_quarter</code> must be supplied.
+At most one of <code>quantized_sequence</code> and <code>events_list</code> may be supplied.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>quantized_sequence</code></strong></dt>
+<dd>an optional quantized NoteSequence proto to base
+PianorollSequence on.</dd>
+<dt><strong><code>events_list</code></strong></dt>
+<dd>an optional list of Pianoroll events to base
+PianorollSequence on.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>how many steps a quarter note represents. Must be
+provided if <code>quanitzed_sequence</code> not given.</dd>
+<dt><strong><code>start_step</code></strong></dt>
+<dd>The offset of this sequence relative to the
+beginning of the source sequence. If a quantized sequence is used as
+input, only notes starting after this step will be considered.</dd>
+<dt><strong><code>min_pitch</code></strong></dt>
+<dd>The minimum valid pitch value, inclusive.</dd>
+<dt><strong><code>max_pitch</code></strong></dt>
+<dd>The maximum valid pitch value, inclusive.</dd>
+<dt><strong><code>split_repeats</code></strong></dt>
+<dd>Whether to force repeated notes to have a 0-state step
+between them when initializing from a quantized NoteSequence.</dd>
+<dt><strong><code>shift_range</code></strong></dt>
+<dd>If True, assume that the given events_list is in the full
+MIDI pitch range and needs to be shifted and filtered based on
+<code>min_pitch</code> and <code>max_pitch</code>.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PianorollSequence(events_lib.EventSequence):
+  &#34;&#34;&#34;Stores a polyphonic sequence as a pianoroll.
+
+  Events are collections of active pitches at each step, offset from
+  `min_pitch`.
+  &#34;&#34;&#34;
+
+  def __init__(self, quantized_sequence=None, events_list=None,
+               steps_per_quarter=None, start_step=0, min_pitch=MIN_MIDI_PITCH,
+               max_pitch=MAX_MIDI_PITCH, split_repeats=True, shift_range=False):
+    &#34;&#34;&#34;Construct a PianorollSequence.
+
+    Exactly one of `quantized_sequence` or `steps_per_quarter` must be supplied.
+    At most one of `quantized_sequence` and `events_list` may be supplied.
+
+    Args:
+      quantized_sequence: an optional quantized NoteSequence proto to base
+          PianorollSequence on.
+      events_list: an optional list of Pianoroll events to base
+          PianorollSequence on.
+      steps_per_quarter: how many steps a quarter note represents. Must be
+          provided if `quanitzed_sequence` not given.
+      start_step: The offset of this sequence relative to the
+          beginning of the source sequence. If a quantized sequence is used as
+          input, only notes starting after this step will be considered.
+      min_pitch: The minimum valid pitch value, inclusive.
+      max_pitch: The maximum valid pitch value, inclusive.
+      split_repeats: Whether to force repeated notes to have a 0-state step
+          between them when initializing from a quantized NoteSequence.
+      shift_range: If True, assume that the given events_list is in the full
+         MIDI pitch range and needs to be shifted and filtered based on
+         `min_pitch` and `max_pitch`.
+    &#34;&#34;&#34;
+    assert (quantized_sequence, steps_per_quarter).count(None) == 1
+    assert (quantized_sequence, events_list).count(None) &gt;= 1
+
+    self._min_pitch = min_pitch
+    self._max_pitch = max_pitch
+
+    if quantized_sequence:
+      sequences_lib.assert_is_relative_quantized_sequence(quantized_sequence)
+      self._events = self._from_quantized_sequence(quantized_sequence,
+                                                   start_step, min_pitch,
+                                                   max_pitch, split_repeats)
+      self._steps_per_quarter = (
+          quantized_sequence.quantization_info.steps_per_quarter)
+    else:
+      self._events = []
+      self._steps_per_quarter = steps_per_quarter
+      if events_list:
+        for e in events_list:
+          self.append(e, shift_range)
+    self._start_step = start_step
+
+  @property
+  def start_step(self):
+    return self._start_step
+
+  @property
+  def steps_per_quarter(self):
+    return self._steps_per_quarter
+
+  def set_length(self, steps, from_left=False):
+    &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+    If the event sequence is not long enough, pads with silence to make the
+    sequence the specified length. If it is too long, it will be truncated to
+    the requested length.
+
+    Note that this will append a STEP_END event to the end of the sequence if
+    there is an unfinished step.
+
+    Args:
+      steps: How many quantized steps long the event sequence should be.
+      from_left: Whether to add/remove from the left instead of right.
+    &#34;&#34;&#34;
+    if from_left:
+      raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+    # Then trim or pad as needed.
+    if self.num_steps &lt; steps:
+      self._events += [()] * (steps - self.num_steps)
+    elif self.num_steps &gt; steps:
+      del self._events[steps:]
+    assert self.num_steps == steps
+
+  def append(self, event, shift_range=False):
+    &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+    Args:
+      event: The polyphonic event to append to the end.
+      shift_range: If True, assume that the given event is in the full MIDI
+         pitch range and needs to be shifted and filtered based on `min_pitch`
+         and `max_pitch`.
+    Raises:
+      ValueError: If `event` is not a valid polyphonic event.
+    &#34;&#34;&#34;
+    if shift_range:
+      event = tuple(p - self._min_pitch for p in event
+                    if self._min_pitch &lt;= p &lt;= self._max_pitch)
+    self._events.append(event)
+
+  def __len__(self):
+    &#34;&#34;&#34;How many events are in this sequence.
+
+    Returns:
+      Number of events as an integer.
+    &#34;&#34;&#34;
+    return len(self._events)
+
+  def __getitem__(self, i):
+    &#34;&#34;&#34;Returns the event at the given index.&#34;&#34;&#34;
+    return self._events[i]
+
+  def __iter__(self):
+    &#34;&#34;&#34;Return an iterator over the events in this sequence.&#34;&#34;&#34;
+    return iter(self._events)
+
+  @property
+  def end_step(self):
+    return self.start_step + self.num_steps
+
+  @property
+  def num_steps(self):
+    &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+    Returns:
+      Length of the sequence in quantized steps.
+    &#34;&#34;&#34;
+    return len(self)
+
+  @property
+  def steps(self):
+    &#34;&#34;&#34;Returns a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+    return list(range(self.start_step, self.end_step))
+
+  @staticmethod
+  def _from_quantized_sequence(
+      quantized_sequence, start_step, min_pitch, max_pitch, split_repeats):
+    &#34;&#34;&#34;Populate self with events from the given quantized NoteSequence object.
+
+    Args:
+      quantized_sequence: A quantized NoteSequence instance.
+      start_step: Start converting the sequence at this time step.
+          Assumed to be the beginning of a bar.
+      min_pitch: The minimum valid pitch value, inclusive.
+      max_pitch: The maximum valid pitch value, inclusive.
+      split_repeats: Whether to force repeated notes to have a 0-state step
+          between them.
+
+    Returns:
+      A list of events.
+    &#34;&#34;&#34;
+    piano_roll = np.zeros(
+        (quantized_sequence.total_quantized_steps - start_step,
+         max_pitch - min_pitch + 1), np.bool)
+
+    for note in quantized_sequence.notes:
+      if note.quantized_start_step &lt; start_step:
+        continue
+      if not min_pitch &lt;= note.pitch &lt;= max_pitch:
+        continue
+      note_pitch_offset = note.pitch - min_pitch
+      note_start_offset = note.quantized_start_step - start_step
+      note_end_offset = note.quantized_end_step - start_step
+
+      if split_repeats:
+        piano_roll[note_start_offset - 1, note_pitch_offset] = 0
+      piano_roll[note_start_offset:note_end_offset, note_pitch_offset] = 1
+
+    events = [tuple(np.where(frame)[0]) for frame in piano_roll]
+
+    return events
+
+  def to_sequence(self,
+                  velocity=100,
+                  instrument=0,
+                  program=0,
+                  qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                  base_note_sequence=None):
+    &#34;&#34;&#34;Converts the PianorollSequence to NoteSequence proto.
+
+    Args:
+      velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+      instrument: Midi instrument to give each note.
+      program: Midi program to give each note.
+      qpm: Quarter notes per minute (float).
+      base_note_sequence: A NoteSequence to use a starting point. Must match the
+          specified qpm.
+
+    Raises:
+      ValueError: if an unknown event is encountered.
+
+    Returns:
+      A NoteSequence proto.
+    &#34;&#34;&#34;
+    seconds_per_step = 60.0 / qpm / self._steps_per_quarter
+
+    sequence_start_time = self.start_step * seconds_per_step
+
+    if base_note_sequence:
+      sequence = copy.deepcopy(base_note_sequence)
+      if sequence.tempos[0].qpm != qpm:
+        raise ValueError(
+            &#39;Supplied QPM (%d) does not match QPM of base_note_sequence (%d)&#39;
+            % (qpm, sequence.tempos[0].qpm))
+    else:
+      sequence = music_pb2.NoteSequence()
+      sequence.tempos.add().qpm = qpm
+      sequence.ticks_per_quarter = STANDARD_PPQ
+
+    step = 0
+    # Keep a dictionary of open notes for each pitch.
+    open_notes = {}
+    for step, event in enumerate(self):
+      frame_pitches = set(event)
+      open_pitches = set(open_notes)
+
+      for pitch_to_close in open_pitches - frame_pitches:
+        note_to_close = open_notes[pitch_to_close]
+        note_to_close.end_time = step * seconds_per_step + sequence_start_time
+        del open_notes[pitch_to_close]
+
+      for pitch_to_open in frame_pitches - open_pitches:
+        new_note = sequence.notes.add()
+        new_note.start_time = step * seconds_per_step + sequence_start_time
+        new_note.pitch = pitch_to_open + self._min_pitch
+        new_note.velocity = velocity
+        new_note.instrument = instrument
+        new_note.program = program
+        open_notes[pitch_to_open] = new_note
+
+    final_step = step + (len(open_notes) &gt; 0)  # pylint: disable=g-explicit-length-test
+    for note_to_close in open_notes.values():
+      note_to_close.end_time = (
+          final_step * seconds_per_step + sequence_start_time)
+
+    sequence.total_time = seconds_per_step * final_step + sequence_start_time
+    if sequence.notes:
+      assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+    return sequence</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.events_lib.EventSequence" href="events_lib.html#note_seq.events_lib.EventSequence">EventSequence</a></li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.end_step"><code class="name">var <span class="ident">end_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def end_step(self):
+  return self.start_step + self.num_steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.num_steps"><code class="name">var <span class="ident">num_steps</span></code></dt>
+<dd>
+<div class="desc"><p>Returns how many steps long this sequence is.</p>
+<h2 id="returns">Returns</h2>
+<p>Length of the sequence in quantized steps.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def num_steps(self):
+  &#34;&#34;&#34;Returns how many steps long this sequence is.
+
+  Returns:
+    Length of the sequence in quantized steps.
+  &#34;&#34;&#34;
+  return len(self)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.start_step"><code class="name">var <span class="ident">start_step</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def start_step(self):
+  return self._start_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.steps"><code class="name">var <span class="ident">steps</span></code></dt>
+<dd>
+<div class="desc"><p>Returns a Python list of the time step at each event in this sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps(self):
+  &#34;&#34;&#34;Returns a Python list of the time step at each event in this sequence.&#34;&#34;&#34;
+  return list(range(self.start_step, self.end_step))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.steps_per_quarter"><code class="name">var <span class="ident">steps_per_quarter</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def steps_per_quarter(self):
+  return self._steps_per_quarter</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.append"><code class="name flex">
+<span>def <span class="ident">append</span></span>(<span>self, event, shift_range=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Appends the event to the end of the sequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>event</code></strong></dt>
+<dd>The polyphonic event to append to the end.</dd>
+<dt><strong><code>shift_range</code></strong></dt>
+<dd>If True, assume that the given event is in the full MIDI
+pitch range and needs to be shifted and filtered based on <code>min_pitch</code>
+and <code>max_pitch</code>.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>event</code> is not a valid polyphonic event.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def append(self, event, shift_range=False):
+  &#34;&#34;&#34;Appends the event to the end of the sequence.
+
+  Args:
+    event: The polyphonic event to append to the end.
+    shift_range: If True, assume that the given event is in the full MIDI
+       pitch range and needs to be shifted and filtered based on `min_pitch`
+       and `max_pitch`.
+  Raises:
+    ValueError: If `event` is not a valid polyphonic event.
+  &#34;&#34;&#34;
+  if shift_range:
+    event = tuple(p - self._min_pitch for p in event
+                  if self._min_pitch &lt;= p &lt;= self._max_pitch)
+  self._events.append(event)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.set_length"><code class="name flex">
+<span>def <span class="ident">set_length</span></span>(<span>self, steps, from_left=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Sets the length of the sequence to the specified number of steps.</p>
+<p>If the event sequence is not long enough, pads with silence to make the
+sequence the specified length. If it is too long, it will be truncated to
+the requested length.</p>
+<p>Note that this will append a STEP_END event to the end of the sequence if
+there is an unfinished step.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>steps</code></strong></dt>
+<dd>How many quantized steps long the event sequence should be.</dd>
+<dt><strong><code>from_left</code></strong></dt>
+<dd>Whether to add/remove from the left instead of right.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_length(self, steps, from_left=False):
+  &#34;&#34;&#34;Sets the length of the sequence to the specified number of steps.
+
+  If the event sequence is not long enough, pads with silence to make the
+  sequence the specified length. If it is too long, it will be truncated to
+  the requested length.
+
+  Note that this will append a STEP_END event to the end of the sequence if
+  there is an unfinished step.
+
+  Args:
+    steps: How many quantized steps long the event sequence should be.
+    from_left: Whether to add/remove from the left instead of right.
+  &#34;&#34;&#34;
+  if from_left:
+    raise NotImplementedError(&#39;from_left is not supported&#39;)
+
+  # Then trim or pad as needed.
+  if self.num_steps &lt; steps:
+    self._events += [()] * (steps - self.num_steps)
+  elif self.num_steps &gt; steps:
+    del self._events[steps:]
+  assert self.num_steps == steps</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib.PianorollSequence.to_sequence"><code class="name flex">
+<span>def <span class="ident">to_sequence</span></span>(<span>self, velocity=100, instrument=0, program=0, qpm=120.0, base_note_sequence=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converts the PianorollSequence to NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Midi velocity to give each note. Between 1 and 127 (inclusive).</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Midi instrument to give each note.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>Midi program to give each note.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>Quarter notes per minute (float).</dd>
+<dt><strong><code>base_note_sequence</code></strong></dt>
+<dd>A NoteSequence to use a starting point. Must match the
+specified qpm.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>if an unknown event is encountered.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def to_sequence(self,
+                velocity=100,
+                instrument=0,
+                program=0,
+                qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                base_note_sequence=None):
+  &#34;&#34;&#34;Converts the PianorollSequence to NoteSequence proto.
+
+  Args:
+    velocity: Midi velocity to give each note. Between 1 and 127 (inclusive).
+    instrument: Midi instrument to give each note.
+    program: Midi program to give each note.
+    qpm: Quarter notes per minute (float).
+    base_note_sequence: A NoteSequence to use a starting point. Must match the
+        specified qpm.
+
+  Raises:
+    ValueError: if an unknown event is encountered.
+
+  Returns:
+    A NoteSequence proto.
+  &#34;&#34;&#34;
+  seconds_per_step = 60.0 / qpm / self._steps_per_quarter
+
+  sequence_start_time = self.start_step * seconds_per_step
+
+  if base_note_sequence:
+    sequence = copy.deepcopy(base_note_sequence)
+    if sequence.tempos[0].qpm != qpm:
+      raise ValueError(
+          &#39;Supplied QPM (%d) does not match QPM of base_note_sequence (%d)&#39;
+          % (qpm, sequence.tempos[0].qpm))
+  else:
+    sequence = music_pb2.NoteSequence()
+    sequence.tempos.add().qpm = qpm
+    sequence.ticks_per_quarter = STANDARD_PPQ
+
+  step = 0
+  # Keep a dictionary of open notes for each pitch.
+  open_notes = {}
+  for step, event in enumerate(self):
+    frame_pitches = set(event)
+    open_pitches = set(open_notes)
+
+    for pitch_to_close in open_pitches - frame_pitches:
+      note_to_close = open_notes[pitch_to_close]
+      note_to_close.end_time = step * seconds_per_step + sequence_start_time
+      del open_notes[pitch_to_close]
+
+    for pitch_to_open in frame_pitches - open_pitches:
+      new_note = sequence.notes.add()
+      new_note.start_time = step * seconds_per_step + sequence_start_time
+      new_note.pitch = pitch_to_open + self._min_pitch
+      new_note.velocity = velocity
+      new_note.instrument = instrument
+      new_note.program = program
+      open_notes[pitch_to_open] = new_note
+
+  final_step = step + (len(open_notes) &gt; 0)  # pylint: disable=g-explicit-length-test
+  for note_to_close in open_notes.values():
+    note_to_close.end_time = (
+        final_step * seconds_per_step + sequence_start_time)
+
+  sequence.total_time = seconds_per_step * final_step + sequence_start_time
+  if sequence.notes:
+    assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.pianoroll_lib.PianorollSequence" href="#note_seq.pianoroll_lib.PianorollSequence">PianorollSequence</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.append" href="#note_seq.pianoroll_lib.PianorollSequence.append">append</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.end_step" href="#note_seq.pianoroll_lib.PianorollSequence.end_step">end_step</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.num_steps" href="#note_seq.pianoroll_lib.PianorollSequence.num_steps">num_steps</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.set_length" href="#note_seq.pianoroll_lib.PianorollSequence.set_length">set_length</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.start_step" href="#note_seq.pianoroll_lib.PianorollSequence.start_step">start_step</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.steps" href="#note_seq.pianoroll_lib.PianorollSequence.steps">steps</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.steps_per_quarter" href="#note_seq.pianoroll_lib.PianorollSequence.steps_per_quarter">steps_per_quarter</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib.PianorollSequence.to_sequence" href="#note_seq.pianoroll_lib.PianorollSequence.to_sequence">to_sequence</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/pianoroll_lib_test.html
+++ b/docs/pianoroll_lib_test.html
@@ -1,0 +1,634 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.pianoroll_lib_test API documentation</title>
+<meta name="description" content="Tests for pianoroll_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.pianoroll_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for pianoroll_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for pianoroll_lib.&#34;&#34;&#34;
+
+import copy
+
+from absl.testing import absltest
+from note_seq import pianoroll_lib
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+
+
+class PianorollLibTest(absltest.TestCase):
+
+  def setUp(self):
+    self.maxDiff = None  # pylint:disable=invalid-name
+
+    self.note_sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        tempos: {
+          qpm: 60
+        }
+        ticks_per_quarter: 220
+        &#34;&#34;&#34;)
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(20, 100, 0.0, 4.0), (24, 100, 0.0, 1.0), (26, 100, 0.0, 3.0),
+         (110, 100, 1.0, 2.0), (24, 100, 2.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(quantized_sequence))
+
+    expected_pianoroll_seq = [
+        (3, 5),
+        (5,),
+        (3, 5),
+        (3,),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testFromQuantizedNoteSequence_SplitRepeats(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(0, 100, 0.0, 2.0), (0, 100, 2.0, 4.0), (1, 100, 0.0, 2.0),
+         (2, 100, 2.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+        quantized_sequence, min_pitch=0, split_repeats=True))
+
+    expected_pianoroll_seq = [
+        (0, 1),
+        (1,),
+        (0, 2),
+        (0, 2),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testFromEventsList_ShiftRange(self):
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+        events_list=[(0, 1), (2, 3), (4, 5), (6,)], steps_per_quarter=1,
+        min_pitch=1, max_pitch=4, shift_range=True))
+
+    expected_pianoroll_seq = [
+        (0,),
+        (1, 2),
+        (3,),
+        (),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testToSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 0.0, 1.0),
+         (67, 100, 3.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = pianoroll_lib.PianorollSequence(quantized_sequence)
+    pianoroll_seq_ns = pianoroll_seq.to_sequence(qpm=60.0)
+
+    # Make comparison easier
+    pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, pianoroll_seq_ns)
+
+  def testToSequenceWithBaseNoteSequence(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(
+        steps_per_quarter=1, start_step=1)
+
+    pianoroll_events = [(39, 43), (39, 43)]
+    for event in pianoroll_events:
+      pianoroll_seq.append(event)
+
+    base_seq = copy.deepcopy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        base_seq, 0, [(60, 100, 0.0, 1.0)])
+
+    pianoroll_seq_ns = pianoroll_seq.to_sequence(
+        qpm=60.0, base_note_sequence=base_seq)
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 1.0), (60, 100, 1.0, 3.0), (64, 100, 1.0, 3.0)])
+
+    # Make comparison easier
+    pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, pianoroll_seq_ns)
+
+  def testSetLengthAddSteps(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+    pianoroll_seq.append((0))
+
+    self.assertEqual(1, pianoroll_seq.num_steps)
+    self.assertListEqual([0], pianoroll_seq.steps)
+
+    pianoroll_seq.set_length(5)
+
+    self.assertEqual(5, pianoroll_seq.num_steps)
+    self.assertListEqual([0, 1, 2, 3, 4], pianoroll_seq.steps)
+
+    self.assertEqual([(0), (), (), (), ()], list(pianoroll_seq))
+
+    # Add 5 more steps.
+    pianoroll_seq.set_length(10)
+
+    self.assertEqual(10, pianoroll_seq.num_steps)
+    self.assertListEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], pianoroll_seq.steps)
+
+    self.assertEqual([(0)] + [()] * 9, list(pianoroll_seq))
+
+  def testSetLengthRemoveSteps(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+
+    pianoroll_events = [(), (2, 4), (2, 4), (2,), (5,)]
+    for event in pianoroll_events:
+      pianoroll_seq.append(event)
+
+    pianoroll_seq.set_length(2)
+
+    self.assertEqual([(), (2, 4)], list(pianoroll_seq))
+
+    pianoroll_seq.set_length(1)
+    self.assertEqual([()], list(pianoroll_seq))
+
+    pianoroll_seq.set_length(0)
+    self.assertEqual([], list(pianoroll_seq))
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest"><code class="flex name class">
+<span>class <span class="ident">PianorollLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extension of unittest.TestCase providing more power.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class PianorollLibTest(absltest.TestCase):
+
+  def setUp(self):
+    self.maxDiff = None  # pylint:disable=invalid-name
+
+    self.note_sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        tempos: {
+          qpm: 60
+        }
+        ticks_per_quarter: 220
+        &#34;&#34;&#34;)
+
+  def testFromQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(20, 100, 0.0, 4.0), (24, 100, 0.0, 1.0), (26, 100, 0.0, 3.0),
+         (110, 100, 1.0, 2.0), (24, 100, 2.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(quantized_sequence))
+
+    expected_pianoroll_seq = [
+        (3, 5),
+        (5,),
+        (3, 5),
+        (3,),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testFromQuantizedNoteSequence_SplitRepeats(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(0, 100, 0.0, 2.0), (0, 100, 2.0, 4.0), (1, 100, 0.0, 2.0),
+         (2, 100, 2.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+        quantized_sequence, min_pitch=0, split_repeats=True))
+
+    expected_pianoroll_seq = [
+        (0, 1),
+        (1,),
+        (0, 2),
+        (0, 2),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testFromEventsList_ShiftRange(self):
+    pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+        events_list=[(0, 1), (2, 3), (4, 5), (6,)], steps_per_quarter=1,
+        min_pitch=1, max_pitch=4, shift_range=True))
+
+    expected_pianoroll_seq = [
+        (0,),
+        (1, 2),
+        (3,),
+        (),
+    ]
+    self.assertEqual(expected_pianoroll_seq, pianoroll_seq)
+
+  def testToSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 0.0, 1.0),
+         (67, 100, 3.0, 4.0)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=1)
+    pianoroll_seq = pianoroll_lib.PianorollSequence(quantized_sequence)
+    pianoroll_seq_ns = pianoroll_seq.to_sequence(qpm=60.0)
+
+    # Make comparison easier
+    pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, pianoroll_seq_ns)
+
+  def testToSequenceWithBaseNoteSequence(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(
+        steps_per_quarter=1, start_step=1)
+
+    pianoroll_events = [(39, 43), (39, 43)]
+    for event in pianoroll_events:
+      pianoroll_seq.append(event)
+
+    base_seq = copy.deepcopy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        base_seq, 0, [(60, 100, 0.0, 1.0)])
+
+    pianoroll_seq_ns = pianoroll_seq.to_sequence(
+        qpm=60.0, base_note_sequence=base_seq)
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(60, 100, 0.0, 1.0), (60, 100, 1.0, 3.0), (64, 100, 1.0, 3.0)])
+
+    # Make comparison easier
+    pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+    self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+    self.assertEqual(self.note_sequence, pianoroll_seq_ns)
+
+  def testSetLengthAddSteps(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+    pianoroll_seq.append((0))
+
+    self.assertEqual(1, pianoroll_seq.num_steps)
+    self.assertListEqual([0], pianoroll_seq.steps)
+
+    pianoroll_seq.set_length(5)
+
+    self.assertEqual(5, pianoroll_seq.num_steps)
+    self.assertListEqual([0, 1, 2, 3, 4], pianoroll_seq.steps)
+
+    self.assertEqual([(0), (), (), (), ()], list(pianoroll_seq))
+
+    # Add 5 more steps.
+    pianoroll_seq.set_length(10)
+
+    self.assertEqual(10, pianoroll_seq.num_steps)
+    self.assertListEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], pianoroll_seq.steps)
+
+    self.assertEqual([(0)] + [()] * 9, list(pianoroll_seq))
+
+  def testSetLengthRemoveSteps(self):
+    pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+
+    pianoroll_events = [(), (2, 4), (2, 4), (2,), (5,)]
+    for event in pianoroll_events:
+      pianoroll_seq.append(event)
+
+    pianoroll_seq.set_length(2)
+
+    self.assertEqual([(), (2, 4)], list(pianoroll_seq))
+
+    pianoroll_seq.set_length(1)
+    self.assertEqual([()], list(pianoroll_seq))
+
+    pianoroll_seq.set_length(0)
+    self.assertEqual([], list(pianoroll_seq))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.maxDiff = None  # pylint:disable=invalid-name
+
+  self.note_sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      tempos: {
+        qpm: 60
+      }
+      ticks_per_quarter: 220
+      &#34;&#34;&#34;)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testFromEventsList_ShiftRange"><code class="name flex">
+<span>def <span class="ident">testFromEventsList_ShiftRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromEventsList_ShiftRange(self):
+  pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+      events_list=[(0, 1), (2, 3), (4, 5), (6,)], steps_per_quarter=1,
+      min_pitch=1, max_pitch=4, shift_range=True))
+
+  expected_pianoroll_seq = [
+      (0,),
+      (1, 2),
+      (3,),
+      (),
+  ]
+  self.assertEqual(expected_pianoroll_seq, pianoroll_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(20, 100, 0.0, 4.0), (24, 100, 0.0, 1.0), (26, 100, 0.0, 3.0),
+       (110, 100, 1.0, 2.0), (24, 100, 2.0, 4.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=1)
+  pianoroll_seq = list(pianoroll_lib.PianorollSequence(quantized_sequence))
+
+  expected_pianoroll_seq = [
+      (3, 5),
+      (5,),
+      (3, 5),
+      (3,),
+  ]
+  self.assertEqual(expected_pianoroll_seq, pianoroll_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence_SplitRepeats"><code class="name flex">
+<span>def <span class="ident">testFromQuantizedNoteSequence_SplitRepeats</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromQuantizedNoteSequence_SplitRepeats(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(0, 100, 0.0, 2.0), (0, 100, 2.0, 4.0), (1, 100, 0.0, 2.0),
+       (2, 100, 2.0, 4.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=1)
+  pianoroll_seq = list(pianoroll_lib.PianorollSequence(
+      quantized_sequence, min_pitch=0, split_repeats=True))
+
+  expected_pianoroll_seq = [
+      (0, 1),
+      (1,),
+      (0, 2),
+      (0, 2),
+  ]
+  self.assertEqual(expected_pianoroll_seq, pianoroll_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthAddSteps"><code class="name flex">
+<span>def <span class="ident">testSetLengthAddSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLengthAddSteps(self):
+  pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+  pianoroll_seq.append((0))
+
+  self.assertEqual(1, pianoroll_seq.num_steps)
+  self.assertListEqual([0], pianoroll_seq.steps)
+
+  pianoroll_seq.set_length(5)
+
+  self.assertEqual(5, pianoroll_seq.num_steps)
+  self.assertListEqual([0, 1, 2, 3, 4], pianoroll_seq.steps)
+
+  self.assertEqual([(0), (), (), (), ()], list(pianoroll_seq))
+
+  # Add 5 more steps.
+  pianoroll_seq.set_length(10)
+
+  self.assertEqual(10, pianoroll_seq.num_steps)
+  self.assertListEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], pianoroll_seq.steps)
+
+  self.assertEqual([(0)] + [()] * 9, list(pianoroll_seq))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthRemoveSteps"><code class="name flex">
+<span>def <span class="ident">testSetLengthRemoveSteps</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSetLengthRemoveSteps(self):
+  pianoroll_seq = pianoroll_lib.PianorollSequence(steps_per_quarter=1)
+
+  pianoroll_events = [(), (2, 4), (2, 4), (2,), (5,)]
+  for event in pianoroll_events:
+    pianoroll_seq.append(event)
+
+  pianoroll_seq.set_length(2)
+
+  self.assertEqual([(), (2, 4)], list(pianoroll_seq))
+
+  pianoroll_seq.set_length(1)
+  self.assertEqual([()], list(pianoroll_seq))
+
+  pianoroll_seq.set_length(0)
+  self.assertEqual([], list(pianoroll_seq))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testToSequence"><code class="name flex">
+<span>def <span class="ident">testToSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 4.0), (64, 100, 0.0, 3.0), (67, 100, 0.0, 1.0),
+       (67, 100, 3.0, 4.0)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=1)
+  pianoroll_seq = pianoroll_lib.PianorollSequence(quantized_sequence)
+  pianoroll_seq_ns = pianoroll_seq.to_sequence(qpm=60.0)
+
+  # Make comparison easier
+  pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, pianoroll_seq_ns)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.pianoroll_lib_test.PianorollLibTest.testToSequenceWithBaseNoteSequence"><code class="name flex">
+<span>def <span class="ident">testToSequenceWithBaseNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testToSequenceWithBaseNoteSequence(self):
+  pianoroll_seq = pianoroll_lib.PianorollSequence(
+      steps_per_quarter=1, start_step=1)
+
+  pianoroll_events = [(39, 43), (39, 43)]
+  for event in pianoroll_events:
+    pianoroll_seq.append(event)
+
+  base_seq = copy.deepcopy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      base_seq, 0, [(60, 100, 0.0, 1.0)])
+
+  pianoroll_seq_ns = pianoroll_seq.to_sequence(
+      qpm=60.0, base_note_sequence=base_seq)
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(60, 100, 0.0, 1.0), (60, 100, 1.0, 3.0), (64, 100, 1.0, 3.0)])
+
+  # Make comparison easier
+  pianoroll_seq_ns.notes.sort(key=lambda n: (n.start_time, n.pitch))
+  self.note_sequence.notes.sort(key=lambda n: (n.start_time, n.pitch))
+
+  self.assertEqual(self.note_sequence, pianoroll_seq_ns)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest" href="#note_seq.pianoroll_lib_test.PianorollLibTest">PianorollLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.setUp" href="#note_seq.pianoroll_lib_test.PianorollLibTest.setUp">setUp</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testFromEventsList_ShiftRange" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testFromEventsList_ShiftRange">testFromEventsList_ShiftRange</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence">testFromQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence_SplitRepeats" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testFromQuantizedNoteSequence_SplitRepeats">testFromQuantizedNoteSequence_SplitRepeats</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthAddSteps" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthAddSteps">testSetLengthAddSteps</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthRemoveSteps" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testSetLengthRemoveSteps">testSetLengthRemoveSteps</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testToSequence" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testToSequence">testToSequence</a></code></li>
+<li><code><a title="note_seq.pianoroll_lib_test.PianorollLibTest.testToSequenceWithBaseNoteSequence" href="#note_seq.pianoroll_lib_test.PianorollLibTest.testToSequenceWithBaseNoteSequence">testToSequenceWithBaseNoteSequence</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/protobuf/compare.html
+++ b/docs/protobuf/compare.html
@@ -1,0 +1,674 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.protobuf.compare API documentation</title>
+<meta name="description" content="Utility functions for comparing proto2 messages in Python …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.protobuf.compare</code></h1>
+</header>
+<section id="section-intro">
+<p>Utility functions for comparing proto2 messages in Python.</p>
+<p>Forked from tensorflow.python.util.prtobuf</p>
+<p>ProtoEq() compares two proto2 messages for equality.</p>
+<p>ClearDefaultValuedFields() recursively clears the fields that are set to their
+default values. This is useful for comparing protocol buffers where the
+semantics of unset fields and default valued fields are the same.</p>
+<p>assertProtoEqual() is useful for unit tests.
+It produces much more helpful
+output than assertEqual() for proto2 messages, e.g. this:</p>
+<p>outer {
+inner {
+-
+strings: "x"
+?
+^
++
+strings: "y"
+?
+^
+}
+}</p>
+<p>&hellip;compared to the default output from assertEqual() that looks like this:</p>
+<p>AssertionError: <my.Msg object at 0x9fb353c> != <my.Msg object at 0x9fb35cc></p>
+<p>Call it inside your unit test's googletest.TestCase subclasses like this:</p>
+<p>from tensorflow.python.util.protobuf import compare</p>
+<p>class MyTest(googletest.TestCase):
+&hellip;
+def testXXX(self):
+&hellip;
+compare.assertProtoEqual(self, a, b)</p>
+<h2 id="alternatively">Alternatively</h2>
+<p>from tensorflow.python.util.protobuf import compare</p>
+<p>class MyTest(compare.ProtoAssertions, googletest.TestCase):
+&hellip;
+def testXXX(self):
+&hellip;
+self.assertProtoEqual(a, b)</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Utility functions for comparing proto2 messages in Python.
+
+Forked from tensorflow.python.util.prtobuf
+
+ProtoEq() compares two proto2 messages for equality.
+
+ClearDefaultValuedFields() recursively clears the fields that are set to their
+default values. This is useful for comparing protocol buffers where the
+semantics of unset fields and default valued fields are the same.
+
+assertProtoEqual() is useful for unit tests.  It produces much more helpful
+output than assertEqual() for proto2 messages, e.g. this:
+
+  outer {
+    inner {
+-     strings: &#34;x&#34;
+?               ^
++     strings: &#34;y&#34;
+?               ^
+    }
+  }
+
+...compared to the default output from assertEqual() that looks like this:
+
+AssertionError: &lt;my.Msg object at 0x9fb353c&gt; != &lt;my.Msg object at 0x9fb35cc&gt;
+
+Call it inside your unit test&#39;s googletest.TestCase subclasses like this:
+
+  from tensorflow.python.util.protobuf import compare
+
+  class MyTest(googletest.TestCase):
+    ...
+    def testXXX(self):
+      ...
+      compare.assertProtoEqual(self, a, b)
+
+Alternatively:
+
+  from tensorflow.python.util.protobuf import compare
+
+  class MyTest(compare.ProtoAssertions, googletest.TestCase):
+    ...
+    def testXXX(self):
+      ...
+      self.assertProtoEqual(a, b)
+&#34;&#34;&#34;
+import collections.abc as collections_abc
+import difflib
+
+from google.protobuf import descriptor
+from google.protobuf import descriptor_pool
+from google.protobuf import message
+from google.protobuf import text_format
+
+
+def assertProtoEqual(self, a, b, check_initialized=True,  # pylint: disable=invalid-name
+                     normalize_numbers=False, msg=None):
+  &#34;&#34;&#34;Fails with a useful error if a and b aren&#39;t equal.
+
+  Comparison of repeated fields matches the semantics of
+  unittest.TestCase.assertEqual(), ie order and extra duplicates fields matter.
+
+  Args:
+    self: googletest.TestCase
+    a: proto2 PB instance, or text string representing one.
+    b: proto2 PB instance -- message.Message or subclass thereof.
+    check_initialized: boolean, whether to fail if either a or b isn&#39;t
+      initialized.
+    normalize_numbers: boolean, whether to normalize types and precision of
+      numbers before comparison.
+    msg: if specified, is used as the error message on failure.
+  &#34;&#34;&#34;
+  pool = descriptor_pool.Default()
+  if isinstance(a, str):
+    a = text_format.Parse(a, b.__class__(), descriptor_pool=pool)
+
+  for pb in a, b:
+    if check_initialized:
+      errors = pb.FindInitializationErrors()
+      if errors:
+        self.fail(&#39;Initialization errors: %s\n%s&#39; % (errors, pb))
+    if normalize_numbers:
+      NormalizeNumberFields(pb)
+
+  a_str = text_format.MessageToString(a, descriptor_pool=pool)
+  b_str = text_format.MessageToString(b, descriptor_pool=pool)
+
+  # Some Python versions would perform regular diff instead of multi-line
+  # diff if string is longer than 2**16. We substitute this behavior
+  # with a call to unified_diff instead to have easier-to-read diffs.
+  # For context, see: https://bugs.python.org/issue11763.
+  if len(a_str) &lt; 2**16 and len(b_str) &lt; 2**16:
+    self.assertMultiLineEqual(a_str, b_str, msg=msg)
+  else:
+    diff = &#39;\n&#39; + &#39;&#39;.join(difflib.unified_diff(a_str.splitlines(True),
+                                               b_str.splitlines(True)))
+    self.fail(&#39;%s : %s&#39; % (msg, diff))
+
+
+def NormalizeNumberFields(pb):
+  &#34;&#34;&#34;Normalizes types and precisions of number fields in a protocol buffer.
+
+  Due to subtleties in the python protocol buffer implementation, it is possible
+  for values to have different types and precision depending on whether they
+  were set and retrieved directly or deserialized from a protobuf. This function
+  normalizes integer values to ints and longs based on width, 32-bit floats to
+  five digits of precision to account for python always storing them as 64-bit,
+  and ensures doubles are floating point for when they&#39;re set to integers.
+
+  Modifies pb in place. Recurses into nested objects.
+
+  Args:
+    pb: proto2 message.
+
+  Returns:
+    the given pb, modified in place.
+  &#34;&#34;&#34;
+  for desc, values in pb.ListFields():
+    is_repeated = True
+    if desc.label is not descriptor.FieldDescriptor.LABEL_REPEATED:
+      is_repeated = False
+      values = [values]
+
+    normalized_values = None
+
+    # We force 32-bit values to int and 64-bit values to long to make
+    # alternate implementations where the distinction is more significant
+    # (e.g. the C++ implementation) simpler.
+    if desc.type in (descriptor.FieldDescriptor.TYPE_INT64,
+                     descriptor.FieldDescriptor.TYPE_UINT64,
+                     descriptor.FieldDescriptor.TYPE_SINT64):
+      normalized_values = [int(x) for x in values]
+    elif desc.type in (descriptor.FieldDescriptor.TYPE_INT32,
+                       descriptor.FieldDescriptor.TYPE_UINT32,
+                       descriptor.FieldDescriptor.TYPE_SINT32,
+                       descriptor.FieldDescriptor.TYPE_ENUM):
+      normalized_values = [int(x) for x in values]
+    elif desc.type == descriptor.FieldDescriptor.TYPE_FLOAT:
+      normalized_values = [round(x, 6) for x in values]
+    elif desc.type == descriptor.FieldDescriptor.TYPE_DOUBLE:
+      normalized_values = [round(float(x), 7) for x in values]
+
+    if normalized_values is not None:
+      if is_repeated:
+        pb.ClearField(desc.name)
+        getattr(pb, desc.name).extend(normalized_values)
+      else:
+        setattr(pb, desc.name, normalized_values[0])
+
+    if (desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE or
+        desc.type == descriptor.FieldDescriptor.TYPE_GROUP):
+      if (desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE and
+          desc.message_type.has_options and
+          desc.message_type.GetOptions().map_entry):
+        # This is a map, only recurse if the values have a message type.
+        if (desc.message_type.fields_by_number[2].type ==
+            descriptor.FieldDescriptor.TYPE_MESSAGE):
+          for v in values.items():
+            NormalizeNumberFields(v)
+      else:
+        for v in values:
+          # recursive step
+          NormalizeNumberFields(v)
+
+  return pb
+
+
+def _IsMap(value):
+  return isinstance(value, collections_abc.Mapping)
+
+
+def _IsRepeatedContainer(value):
+  if isinstance(value, str):
+    return False
+  try:
+    iter(value)
+    return True
+  except TypeError:
+    return False
+
+
+def ProtoEq(a, b):
+  &#34;&#34;&#34;Compares two proto2 objects for equality.
+
+  Recurses into nested messages. Uses list (not set) semantics for comparing
+  repeated fields, ie duplicates and order matter.
+
+  Args:
+    a: A proto2 message or a primitive.
+    b: A proto2 message or a primitive.
+
+  Returns:
+    `True` if the messages are equal.
+  &#34;&#34;&#34;
+  def Format(pb):
+    &#34;&#34;&#34;Returns a dictionary or unchanged pb bases on its type.
+
+    Specifically, this function returns a dictionary that maps tag
+    number (for messages) or element index (for repeated fields) to
+    value, or just pb unchanged if it&#39;s neither.
+
+    Args:
+      pb: A proto2 message or a primitive.
+    Returns:
+      A dict or unchanged pb.
+    &#34;&#34;&#34;
+    if isinstance(pb, message.Message):
+      return dict((desc.number, value) for desc, value in pb.ListFields())
+    elif _IsMap(pb):
+      return dict(pb.items())
+    elif _IsRepeatedContainer(pb):
+      return dict(enumerate(list(pb)))
+    else:
+      return pb
+
+  a, b = Format(a), Format(b)
+
+  # Base case
+  if not isinstance(a, dict) or not isinstance(b, dict):
+    return a == b
+
+  # This list performs double duty: it compares two messages by tag value *or*
+  # two repeated fields by element, in order. the magic is in the format()
+  # function, which converts them both to the same easily comparable format.
+  for tag in sorted(set(a.keys()) | set(b.keys())):
+    if tag not in a or tag not in b:
+      return False
+    else:
+      # Recursive step
+      if not ProtoEq(a[tag], b[tag]):
+        return False
+
+  # Didn&#39;t find any values that differed, so they&#39;re equal!
+  return True
+
+
+class ProtoAssertions(object):
+  &#34;&#34;&#34;Mix this into a googletest.TestCase class to get proto2 assertions.
+
+  Usage:
+
+  class SomeTestCase(compare.ProtoAssertions, googletest.TestCase):
+    ...
+    def testSomething(self):
+      ...
+      self.assertProtoEqual(a, b)
+
+  See module-level definitions for method documentation.
+  &#34;&#34;&#34;
+
+  # pylint: disable=invalid-name
+  def assertProtoEqual(self, *args, **kwargs):
+    return assertProtoEqual(self, *args, **kwargs)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.protobuf.compare.NormalizeNumberFields"><code class="name flex">
+<span>def <span class="ident">NormalizeNumberFields</span></span>(<span>pb)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Normalizes types and precisions of number fields in a protocol buffer.</p>
+<p>Due to subtleties in the python protocol buffer implementation, it is possible
+for values to have different types and precision depending on whether they
+were set and retrieved directly or deserialized from a protobuf. This function
+normalizes integer values to ints and longs based on width, 32-bit floats to
+five digits of precision to account for python always storing them as 64-bit,
+and ensures doubles are floating point for when they're set to integers.</p>
+<p>Modifies pb in place. Recurses into nested objects.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>pb</code></strong></dt>
+<dd>proto2 message.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>the given pb, modified in place.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def NormalizeNumberFields(pb):
+  &#34;&#34;&#34;Normalizes types and precisions of number fields in a protocol buffer.
+
+  Due to subtleties in the python protocol buffer implementation, it is possible
+  for values to have different types and precision depending on whether they
+  were set and retrieved directly or deserialized from a protobuf. This function
+  normalizes integer values to ints and longs based on width, 32-bit floats to
+  five digits of precision to account for python always storing them as 64-bit,
+  and ensures doubles are floating point for when they&#39;re set to integers.
+
+  Modifies pb in place. Recurses into nested objects.
+
+  Args:
+    pb: proto2 message.
+
+  Returns:
+    the given pb, modified in place.
+  &#34;&#34;&#34;
+  for desc, values in pb.ListFields():
+    is_repeated = True
+    if desc.label is not descriptor.FieldDescriptor.LABEL_REPEATED:
+      is_repeated = False
+      values = [values]
+
+    normalized_values = None
+
+    # We force 32-bit values to int and 64-bit values to long to make
+    # alternate implementations where the distinction is more significant
+    # (e.g. the C++ implementation) simpler.
+    if desc.type in (descriptor.FieldDescriptor.TYPE_INT64,
+                     descriptor.FieldDescriptor.TYPE_UINT64,
+                     descriptor.FieldDescriptor.TYPE_SINT64):
+      normalized_values = [int(x) for x in values]
+    elif desc.type in (descriptor.FieldDescriptor.TYPE_INT32,
+                       descriptor.FieldDescriptor.TYPE_UINT32,
+                       descriptor.FieldDescriptor.TYPE_SINT32,
+                       descriptor.FieldDescriptor.TYPE_ENUM):
+      normalized_values = [int(x) for x in values]
+    elif desc.type == descriptor.FieldDescriptor.TYPE_FLOAT:
+      normalized_values = [round(x, 6) for x in values]
+    elif desc.type == descriptor.FieldDescriptor.TYPE_DOUBLE:
+      normalized_values = [round(float(x), 7) for x in values]
+
+    if normalized_values is not None:
+      if is_repeated:
+        pb.ClearField(desc.name)
+        getattr(pb, desc.name).extend(normalized_values)
+      else:
+        setattr(pb, desc.name, normalized_values[0])
+
+    if (desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE or
+        desc.type == descriptor.FieldDescriptor.TYPE_GROUP):
+      if (desc.type == descriptor.FieldDescriptor.TYPE_MESSAGE and
+          desc.message_type.has_options and
+          desc.message_type.GetOptions().map_entry):
+        # This is a map, only recurse if the values have a message type.
+        if (desc.message_type.fields_by_number[2].type ==
+            descriptor.FieldDescriptor.TYPE_MESSAGE):
+          for v in values.items():
+            NormalizeNumberFields(v)
+      else:
+        for v in values:
+          # recursive step
+          NormalizeNumberFields(v)
+
+  return pb</code></pre>
+</details>
+</dd>
+<dt id="note_seq.protobuf.compare.ProtoEq"><code class="name flex">
+<span>def <span class="ident">ProtoEq</span></span>(<span>a, b)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Compares two proto2 objects for equality.</p>
+<p>Recurses into nested messages. Uses list (not set) semantics for comparing
+repeated fields, ie duplicates and order matter.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>a</code></strong></dt>
+<dd>A proto2 message or a primitive.</dd>
+<dt><strong><code>b</code></strong></dt>
+<dd>A proto2 message or a primitive.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p><code>True</code> if the messages are equal.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def ProtoEq(a, b):
+  &#34;&#34;&#34;Compares two proto2 objects for equality.
+
+  Recurses into nested messages. Uses list (not set) semantics for comparing
+  repeated fields, ie duplicates and order matter.
+
+  Args:
+    a: A proto2 message or a primitive.
+    b: A proto2 message or a primitive.
+
+  Returns:
+    `True` if the messages are equal.
+  &#34;&#34;&#34;
+  def Format(pb):
+    &#34;&#34;&#34;Returns a dictionary or unchanged pb bases on its type.
+
+    Specifically, this function returns a dictionary that maps tag
+    number (for messages) or element index (for repeated fields) to
+    value, or just pb unchanged if it&#39;s neither.
+
+    Args:
+      pb: A proto2 message or a primitive.
+    Returns:
+      A dict or unchanged pb.
+    &#34;&#34;&#34;
+    if isinstance(pb, message.Message):
+      return dict((desc.number, value) for desc, value in pb.ListFields())
+    elif _IsMap(pb):
+      return dict(pb.items())
+    elif _IsRepeatedContainer(pb):
+      return dict(enumerate(list(pb)))
+    else:
+      return pb
+
+  a, b = Format(a), Format(b)
+
+  # Base case
+  if not isinstance(a, dict) or not isinstance(b, dict):
+    return a == b
+
+  # This list performs double duty: it compares two messages by tag value *or*
+  # two repeated fields by element, in order. the magic is in the format()
+  # function, which converts them both to the same easily comparable format.
+  for tag in sorted(set(a.keys()) | set(b.keys())):
+    if tag not in a or tag not in b:
+      return False
+    else:
+      # Recursive step
+      if not ProtoEq(a[tag], b[tag]):
+        return False
+
+  # Didn&#39;t find any values that differed, so they&#39;re equal!
+  return True</code></pre>
+</details>
+</dd>
+<dt id="note_seq.protobuf.compare.assertProtoEqual"><code class="name flex">
+<span>def <span class="ident">assertProtoEqual</span></span>(<span>self, a, b, check_initialized=True, normalize_numbers=False, msg=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Fails with a useful error if a and b aren't equal.</p>
+<p>Comparison of repeated fields matches the semantics of
+unittest.TestCase.assertEqual(), ie order and extra duplicates fields matter.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>self</code></strong></dt>
+<dd>googletest.TestCase</dd>
+<dt><strong><code>a</code></strong></dt>
+<dd>proto2 PB instance, or text string representing one.</dd>
+<dt><strong><code>b</code></strong></dt>
+<dd>proto2 PB instance &ndash; message.Message or subclass thereof.</dd>
+<dt><strong><code>check_initialized</code></strong></dt>
+<dd>boolean, whether to fail if either a or b isn't
+initialized.</dd>
+<dt><strong><code>normalize_numbers</code></strong></dt>
+<dd>boolean, whether to normalize types and precision of
+numbers before comparison.</dd>
+<dt><strong><code>msg</code></strong></dt>
+<dd>if specified, is used as the error message on failure.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assertProtoEqual(self, a, b, check_initialized=True,  # pylint: disable=invalid-name
+                     normalize_numbers=False, msg=None):
+  &#34;&#34;&#34;Fails with a useful error if a and b aren&#39;t equal.
+
+  Comparison of repeated fields matches the semantics of
+  unittest.TestCase.assertEqual(), ie order and extra duplicates fields matter.
+
+  Args:
+    self: googletest.TestCase
+    a: proto2 PB instance, or text string representing one.
+    b: proto2 PB instance -- message.Message or subclass thereof.
+    check_initialized: boolean, whether to fail if either a or b isn&#39;t
+      initialized.
+    normalize_numbers: boolean, whether to normalize types and precision of
+      numbers before comparison.
+    msg: if specified, is used as the error message on failure.
+  &#34;&#34;&#34;
+  pool = descriptor_pool.Default()
+  if isinstance(a, str):
+    a = text_format.Parse(a, b.__class__(), descriptor_pool=pool)
+
+  for pb in a, b:
+    if check_initialized:
+      errors = pb.FindInitializationErrors()
+      if errors:
+        self.fail(&#39;Initialization errors: %s\n%s&#39; % (errors, pb))
+    if normalize_numbers:
+      NormalizeNumberFields(pb)
+
+  a_str = text_format.MessageToString(a, descriptor_pool=pool)
+  b_str = text_format.MessageToString(b, descriptor_pool=pool)
+
+  # Some Python versions would perform regular diff instead of multi-line
+  # diff if string is longer than 2**16. We substitute this behavior
+  # with a call to unified_diff instead to have easier-to-read diffs.
+  # For context, see: https://bugs.python.org/issue11763.
+  if len(a_str) &lt; 2**16 and len(b_str) &lt; 2**16:
+    self.assertMultiLineEqual(a_str, b_str, msg=msg)
+  else:
+    diff = &#39;\n&#39; + &#39;&#39;.join(difflib.unified_diff(a_str.splitlines(True),
+                                               b_str.splitlines(True)))
+    self.fail(&#39;%s : %s&#39; % (msg, diff))</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.protobuf.compare.ProtoAssertions"><code class="flex name class">
+<span>class <span class="ident">ProtoAssertions</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Mix this into a googletest.TestCase class to get proto2 assertions.</p>
+<p>Usage:</p>
+<p>class SomeTestCase(compare.ProtoAssertions, googletest.TestCase):
+&hellip;
+def testSomething(self):
+&hellip;
+self.assertProtoEqual(a, b)</p>
+<p>See module-level definitions for method documentation.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ProtoAssertions(object):
+  &#34;&#34;&#34;Mix this into a googletest.TestCase class to get proto2 assertions.
+
+  Usage:
+
+  class SomeTestCase(compare.ProtoAssertions, googletest.TestCase):
+    ...
+    def testSomething(self):
+      ...
+      self.assertProtoEqual(a, b)
+
+  See module-level definitions for method documentation.
+  &#34;&#34;&#34;
+
+  # pylint: disable=invalid-name
+  def assertProtoEqual(self, *args, **kwargs):
+    return assertProtoEqual(self, *args, **kwargs)</code></pre>
+</details>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.protobuf.compare.ProtoAssertions.assertProtoEqual"><code class="name flex">
+<span>def <span class="ident">assertProtoEqual</span></span>(<span>self, *args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assertProtoEqual(self, *args, **kwargs):
+  return assertProtoEqual(self, *args, **kwargs)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq.protobuf" href="index.html">note_seq.protobuf</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.protobuf.compare.NormalizeNumberFields" href="#note_seq.protobuf.compare.NormalizeNumberFields">NormalizeNumberFields</a></code></li>
+<li><code><a title="note_seq.protobuf.compare.ProtoEq" href="#note_seq.protobuf.compare.ProtoEq">ProtoEq</a></code></li>
+<li><code><a title="note_seq.protobuf.compare.assertProtoEqual" href="#note_seq.protobuf.compare.assertProtoEqual">assertProtoEqual</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.protobuf.compare.ProtoAssertions" href="#note_seq.protobuf.compare.ProtoAssertions">ProtoAssertions</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.protobuf.compare.ProtoAssertions.assertProtoEqual" href="#note_seq.protobuf.compare.ProtoAssertions.assertProtoEqual">assertProtoEqual</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/protobuf/generator_pb2.html
+++ b/docs/protobuf/generator_pb2.html
@@ -1,0 +1,641 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.protobuf.generator_pb2 API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.protobuf.generator_pb2</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: skip-file
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: note_seq/protobuf/generator.proto
+
+import sys
+_b=sys.version_info[0]&lt;3 and (lambda x:x) or (lambda x:x.encode(&#39;latin1&#39;))
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import reflection as _reflection
+from google.protobuf import symbol_database as _symbol_database
+# @@protoc_insertion_point(imports)
+
+_sym_db = _symbol_database.Default()
+
+
+
+
+DESCRIPTOR = _descriptor.FileDescriptor(
+  name=&#39;note_seq/protobuf/generator.proto&#39;,
+  package=&#39;magenta&#39;,
+  syntax=&#39;proto3&#39;,
+  serialized_options=None,
+  serialized_pb=_b(&#39;\n!note_seq/protobuf/generator.proto\x12\x07magenta\&#34;3\n\x10GeneratorDetails\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\&#34;\xdd\x03\n\x10GeneratorOptions\x12\x41\n\x0einput_sections\x18\x01 \x03(\x0b\x32).magenta.GeneratorOptions.SequenceSection\x12\x44\n\x11generate_sections\x18\x02 \x03(\x0b\x32).magenta.GeneratorOptions.SequenceSection\x12\x31\n\x04\x61rgs\x18\x03 \x03(\x0b\x32#.magenta.GeneratorOptions.ArgsEntry\x1a\x37\n\x0fSequenceSection\x12\x12\n\nstart_time\x18\x01 \x01(\x01\x12\x10\n\x08\x65nd_time\x18\x02 \x01(\x01\x1a\x82\x01\n\x08\x41rgValue\x12\x14\n\nbyte_value\x18\x01 \x01(\x0cH\x00\x12\x13\n\tint_value\x18\x02 \x01(\x05H\x00\x12\x15\n\x0b\x66loat_value\x18\x03 \x01(\x01H\x00\x12\x14\n\nbool_value\x18\x04 \x01(\x08H\x00\x12\x16\n\x0cstring_value\x18\x05 \x01(\tH\x00\x42\x06\n\x04kind\x1aO\n\tArgsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\&#34;.magenta.GeneratorOptions.ArgValue:\x02\x38\x01\&#34;\xde\x01\n\x0fGeneratorBundle\x12\x34\n\x11generator_details\x18\x01 \x01(\x0b\x32\x19.magenta.GeneratorDetails\x12&gt;\n\x0e\x62undle_details\x18\x04 \x01(\x0b\x32&amp;.magenta.GeneratorBundle.BundleDetails\x12\x17\n\x0f\x63heckpoint_file\x18\x02 \x03(\x0c\x12\x16\n\x0emetagraph_file\x18\x03 \x01(\x0c\x1a$\n\rBundleDetails\x12\x13\n\x0b\x64\x65scription\x18\x01 \x01(\tb\x06proto3&#39;)
+)
+
+
+
+
+_GENERATORDETAILS = _descriptor.Descriptor(
+  name=&#39;GeneratorDetails&#39;,
+  full_name=&#39;magenta.GeneratorDetails&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;id&#39;, full_name=&#39;magenta.GeneratorDetails.id&#39;, index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;description&#39;, full_name=&#39;magenta.GeneratorDetails.description&#39;, index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=46,
+  serialized_end=97,
+)
+
+
+_GENERATOROPTIONS_SEQUENCESECTION = _descriptor.Descriptor(
+  name=&#39;SequenceSection&#39;,
+  full_name=&#39;magenta.GeneratorOptions.SequenceSection&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;start_time&#39;, full_name=&#39;magenta.GeneratorOptions.SequenceSection.start_time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;end_time&#39;, full_name=&#39;magenta.GeneratorOptions.SequenceSection.end_time&#39;, index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=308,
+  serialized_end=363,
+)
+
+_GENERATOROPTIONS_ARGVALUE = _descriptor.Descriptor(
+  name=&#39;ArgValue&#39;,
+  full_name=&#39;magenta.GeneratorOptions.ArgValue&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;byte_value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.byte_value&#39;, index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;int_value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.int_value&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;float_value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.float_value&#39;, index=2,
+      number=3, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;bool_value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.bool_value&#39;, index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;string_value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.string_value&#39;, index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name=&#39;kind&#39;, full_name=&#39;magenta.GeneratorOptions.ArgValue.kind&#39;,
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=366,
+  serialized_end=496,
+)
+
+_GENERATOROPTIONS_ARGSENTRY = _descriptor.Descriptor(
+  name=&#39;ArgsEntry&#39;,
+  full_name=&#39;magenta.GeneratorOptions.ArgsEntry&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;key&#39;, full_name=&#39;magenta.GeneratorOptions.ArgsEntry.key&#39;, index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;value&#39;, full_name=&#39;magenta.GeneratorOptions.ArgsEntry.value&#39;, index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b(&#39;8\001&#39;),
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=498,
+  serialized_end=577,
+)
+
+_GENERATOROPTIONS = _descriptor.Descriptor(
+  name=&#39;GeneratorOptions&#39;,
+  full_name=&#39;magenta.GeneratorOptions&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;input_sections&#39;, full_name=&#39;magenta.GeneratorOptions.input_sections&#39;, index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;generate_sections&#39;, full_name=&#39;magenta.GeneratorOptions.generate_sections&#39;, index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;args&#39;, full_name=&#39;magenta.GeneratorOptions.args&#39;, index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GENERATOROPTIONS_SEQUENCESECTION, _GENERATOROPTIONS_ARGVALUE, _GENERATOROPTIONS_ARGSENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=100,
+  serialized_end=577,
+)
+
+
+_GENERATORBUNDLE_BUNDLEDETAILS = _descriptor.Descriptor(
+  name=&#39;BundleDetails&#39;,
+  full_name=&#39;magenta.GeneratorBundle.BundleDetails&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;description&#39;, full_name=&#39;magenta.GeneratorBundle.BundleDetails.description&#39;, index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=766,
+  serialized_end=802,
+)
+
+_GENERATORBUNDLE = _descriptor.Descriptor(
+  name=&#39;GeneratorBundle&#39;,
+  full_name=&#39;magenta.GeneratorBundle&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;generator_details&#39;, full_name=&#39;magenta.GeneratorBundle.generator_details&#39;, index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;bundle_details&#39;, full_name=&#39;magenta.GeneratorBundle.bundle_details&#39;, index=1,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;checkpoint_file&#39;, full_name=&#39;magenta.GeneratorBundle.checkpoint_file&#39;, index=2,
+      number=2, type=12, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;metagraph_file&#39;, full_name=&#39;magenta.GeneratorBundle.metagraph_file&#39;, index=3,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GENERATORBUNDLE_BUNDLEDETAILS, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=580,
+  serialized_end=802,
+)
+
+_GENERATOROPTIONS_SEQUENCESECTION.containing_type = _GENERATOROPTIONS
+_GENERATOROPTIONS_ARGVALUE.containing_type = _GENERATOROPTIONS
+_GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;].fields.append(
+  _GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;byte_value&#39;])
+_GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;byte_value&#39;].containing_oneof = _GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;]
+_GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;].fields.append(
+  _GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;int_value&#39;])
+_GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;int_value&#39;].containing_oneof = _GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;]
+_GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;].fields.append(
+  _GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;float_value&#39;])
+_GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;float_value&#39;].containing_oneof = _GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;]
+_GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;].fields.append(
+  _GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;bool_value&#39;])
+_GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;bool_value&#39;].containing_oneof = _GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;]
+_GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;].fields.append(
+  _GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;string_value&#39;])
+_GENERATOROPTIONS_ARGVALUE.fields_by_name[&#39;string_value&#39;].containing_oneof = _GENERATOROPTIONS_ARGVALUE.oneofs_by_name[&#39;kind&#39;]
+_GENERATOROPTIONS_ARGSENTRY.fields_by_name[&#39;value&#39;].message_type = _GENERATOROPTIONS_ARGVALUE
+_GENERATOROPTIONS_ARGSENTRY.containing_type = _GENERATOROPTIONS
+_GENERATOROPTIONS.fields_by_name[&#39;input_sections&#39;].message_type = _GENERATOROPTIONS_SEQUENCESECTION
+_GENERATOROPTIONS.fields_by_name[&#39;generate_sections&#39;].message_type = _GENERATOROPTIONS_SEQUENCESECTION
+_GENERATOROPTIONS.fields_by_name[&#39;args&#39;].message_type = _GENERATOROPTIONS_ARGSENTRY
+_GENERATORBUNDLE_BUNDLEDETAILS.containing_type = _GENERATORBUNDLE
+_GENERATORBUNDLE.fields_by_name[&#39;generator_details&#39;].message_type = _GENERATORDETAILS
+_GENERATORBUNDLE.fields_by_name[&#39;bundle_details&#39;].message_type = _GENERATORBUNDLE_BUNDLEDETAILS
+DESCRIPTOR.message_types_by_name[&#39;GeneratorDetails&#39;] = _GENERATORDETAILS
+DESCRIPTOR.message_types_by_name[&#39;GeneratorOptions&#39;] = _GENERATOROPTIONS
+DESCRIPTOR.message_types_by_name[&#39;GeneratorBundle&#39;] = _GENERATORBUNDLE
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
+GeneratorDetails = _reflection.GeneratedProtocolMessageType(&#39;GeneratorDetails&#39;, (_message.Message,), dict(
+  DESCRIPTOR = _GENERATORDETAILS,
+  __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.GeneratorDetails)
+  ))
+_sym_db.RegisterMessage(GeneratorDetails)
+
+GeneratorOptions = _reflection.GeneratedProtocolMessageType(&#39;GeneratorOptions&#39;, (_message.Message,), dict(
+
+  SequenceSection = _reflection.GeneratedProtocolMessageType(&#39;SequenceSection&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _GENERATOROPTIONS_SEQUENCESECTION,
+    __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.GeneratorOptions.SequenceSection)
+    ))
+  ,
+
+  ArgValue = _reflection.GeneratedProtocolMessageType(&#39;ArgValue&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _GENERATOROPTIONS_ARGVALUE,
+    __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.GeneratorOptions.ArgValue)
+    ))
+  ,
+
+  ArgsEntry = _reflection.GeneratedProtocolMessageType(&#39;ArgsEntry&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _GENERATOROPTIONS_ARGSENTRY,
+    __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.GeneratorOptions.ArgsEntry)
+    ))
+  ,
+  DESCRIPTOR = _GENERATOROPTIONS,
+  __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.GeneratorOptions)
+  ))
+_sym_db.RegisterMessage(GeneratorOptions)
+_sym_db.RegisterMessage(GeneratorOptions.SequenceSection)
+_sym_db.RegisterMessage(GeneratorOptions.ArgValue)
+_sym_db.RegisterMessage(GeneratorOptions.ArgsEntry)
+
+GeneratorBundle = _reflection.GeneratedProtocolMessageType(&#39;GeneratorBundle&#39;, (_message.Message,), dict(
+
+  BundleDetails = _reflection.GeneratedProtocolMessageType(&#39;BundleDetails&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _GENERATORBUNDLE_BUNDLEDETAILS,
+    __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.GeneratorBundle.BundleDetails)
+    ))
+  ,
+  DESCRIPTOR = _GENERATORBUNDLE,
+  __module__ = &#39;note_seq.protobuf.generator_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.GeneratorBundle)
+  ))
+_sym_db.RegisterMessage(GeneratorBundle)
+_sym_db.RegisterMessage(GeneratorBundle.BundleDetails)
+
+
+_GENERATOROPTIONS_ARGSENTRY._options = None
+# @@protoc_insertion_point(module_scope)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle"><code class="flex name class">
+<span>class <span class="ident">GeneratorBundle</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.BundleDetails"><code class="name">var <span class="ident">BundleDetails</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.bundle_details"><code class="name">var <span class="ident">bundle_details</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorBundle.bundle_details</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.checkpoint_file"><code class="name">var <span class="ident">checkpoint_file</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorBundle.checkpoint_file</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.generator_details"><code class="name">var <span class="ident">generator_details</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorBundle.generator_details</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorBundle.metagraph_file"><code class="name">var <span class="ident">metagraph_file</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorBundle.metagraph_file</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorDetails"><code class="flex name class">
+<span>class <span class="ident">GeneratorDetails</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorDetails.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorDetails.description"><code class="name">var <span class="ident">description</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorDetails.description</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorDetails.id"><code class="name">var <span class="ident">id</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorDetails.id</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions"><code class="flex name class">
+<span>class <span class="ident">GeneratorOptions</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.ArgValue"><code class="name">var <span class="ident">ArgValue</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.ArgsEntry"><code class="name">var <span class="ident">ArgsEntry</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.SequenceSection"><code class="name">var <span class="ident">SequenceSection</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.args"><code class="name">var <span class="ident">args</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorOptions.args</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.generate_sections"><code class="name">var <span class="ident">generate_sections</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorOptions.generate_sections</p></div>
+</dd>
+<dt id="note_seq.protobuf.generator_pb2.GeneratorOptions.input_sections"><code class="name">var <span class="ident">input_sections</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.GeneratorOptions.input_sections</p></div>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq.protobuf" href="index.html">note_seq.protobuf</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle" href="#note_seq.protobuf.generator_pb2.GeneratorBundle">GeneratorBundle</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.BundleDetails" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.BundleDetails">BundleDetails</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.DESCRIPTOR" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.bundle_details" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.bundle_details">bundle_details</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.checkpoint_file" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.checkpoint_file">checkpoint_file</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.generator_details" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.generator_details">generator_details</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorBundle.metagraph_file" href="#note_seq.protobuf.generator_pb2.GeneratorBundle.metagraph_file">metagraph_file</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.protobuf.generator_pb2.GeneratorDetails" href="#note_seq.protobuf.generator_pb2.GeneratorDetails">GeneratorDetails</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorDetails.DESCRIPTOR" href="#note_seq.protobuf.generator_pb2.GeneratorDetails.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorDetails.description" href="#note_seq.protobuf.generator_pb2.GeneratorDetails.description">description</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorDetails.id" href="#note_seq.protobuf.generator_pb2.GeneratorDetails.id">id</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions" href="#note_seq.protobuf.generator_pb2.GeneratorOptions">GeneratorOptions</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.ArgValue" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.ArgValue">ArgValue</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.ArgsEntry" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.ArgsEntry">ArgsEntry</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.DESCRIPTOR" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.SequenceSection" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.SequenceSection">SequenceSection</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.args" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.args">args</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.generate_sections" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.generate_sections">generate_sections</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2.GeneratorOptions.input_sections" href="#note_seq.protobuf.generator_pb2.GeneratorOptions.input_sections">input_sections</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/protobuf/index.html
+++ b/docs/protobuf/index.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.protobuf API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.protobuf</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.</code></pre>
+</details>
+</section>
+<section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="note_seq.protobuf.compare" href="compare.html">note_seq.protobuf.compare</a></code></dt>
+<dd>
+<div class="desc"><p>Utility functions for comparing proto2 messages in Python …</p></div>
+</dd>
+<dt><code class="name"><a title="note_seq.protobuf.generator_pb2" href="generator_pb2.html">note_seq.protobuf.generator_pb2</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="note_seq.protobuf.music_pb2" href="music_pb2.html">note_seq.protobuf.music_pb2</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="../index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="note_seq.protobuf.compare" href="compare.html">note_seq.protobuf.compare</a></code></li>
+<li><code><a title="note_seq.protobuf.generator_pb2" href="generator_pb2.html">note_seq.protobuf.generator_pb2</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2" href="music_pb2.html">note_seq.protobuf.music_pb2</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/protobuf/music_pb2.html
+++ b/docs/protobuf/music_pb2.html
@@ -1,0 +1,2222 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.protobuf.music_pb2 API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.protobuf.music_pb2</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: skip-file
+# Generated by the protocol buffer compiler.  DO NOT EDIT!
+# source: note_seq/protobuf/music.proto
+
+import sys
+_b=sys.version_info[0]&lt;3 and (lambda x:x) or (lambda x:x.encode(&#39;latin1&#39;))
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import reflection as _reflection
+from google.protobuf import symbol_database as _symbol_database
+# @@protoc_insertion_point(imports)
+
+_sym_db = _symbol_database.Default()
+
+
+
+
+DESCRIPTOR = _descriptor.FileDescriptor(
+  name=&#39;note_seq/protobuf/music.proto&#39;,
+  package=&#39;magenta&#39;,
+  syntax=&#39;proto3&#39;,
+  serialized_options=None,
+  serialized_pb=_b(&#39;\n\x1dnote_seq/protobuf/music.proto\x12\x07magenta\&#34;\xd3\x1e\n\x0cNoteSequence\x12\n\n\x02id\x18\x01 \x01(\t\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x18\n\x10reference_number\x18\x12 \x01(\x03\x12\x17\n\x0f\x63ollection_name\x18\x03 \x01(\t\x12\x19\n\x11ticks_per_quarter\x18\x04 \x01(\x05\x12&lt;\n\x0ftime_signatures\x18\x05 \x03(\x0b\x32#.magenta.NoteSequence.TimeSignature\x12:\n\x0ekey_signatures\x18\x06 \x03(\x0b\x32\&#34;.magenta.NoteSequence.KeySignature\x12+\n\x06tempos\x18\x07 \x03(\x0b\x32\x1b.magenta.NoteSequence.Tempo\x12)\n\x05notes\x18\x08 \x03(\x0b\x32\x1a.magenta.NoteSequence.Note\x12\x12\n\ntotal_time\x18\t \x01(\x01\x12\x1d\n\x15total_quantized_steps\x18\x10 \x01(\x03\x12\x34\n\x0bpitch_bends\x18\n \x03(\x0b\x32\x1f.magenta.NoteSequence.PitchBend\x12&lt;\n\x0f\x63ontrol_changes\x18\x0b \x03(\x0b\x32#.magenta.NoteSequence.ControlChange\x12\x32\n\npart_infos\x18\x0c \x03(\x0b\x32\x1e.magenta.NoteSequence.PartInfo\x12\x35\n\x0bsource_info\x18\r \x01(\x0b\x32 .magenta.NoteSequence.SourceInfo\x12&gt;\n\x10text_annotations\x18\x0e \x03(\x0b\x32$.magenta.NoteSequence.TextAnnotation\x12\x44\n\x13section_annotations\x18\x14 \x03(\x0b\x32\&#39;.magenta.NoteSequence.SectionAnnotation\x12:\n\x0esection_groups\x18\x15 \x03(\x0b\x32\&#34;.magenta.NoteSequence.SectionGroup\x12\x41\n\x11quantization_info\x18\x0f \x01(\x0b\x32&amp;.magenta.NoteSequence.QuantizationInfo\x12?\n\x10subsequence_info\x18\x11 \x01(\x0b\x32%.magenta.NoteSequence.SubsequenceInfo\x12\x34\n\x11sequence_metadata\x18\x13 \x01(\x0b\x32\x19.magenta.SequenceMetadata\x12&gt;\n\x10instrument_infos\x18\x17 \x03(\x0b\x32$.magenta.NoteSequence.InstrumentInfo\x1a\xb7\x02\n\x04Note\x12\r\n\x05pitch\x18\x01 \x01(\x05\x12\x33\n\npitch_name\x18\x0b \x01(\x0e\x32\x1f.magenta.NoteSequence.PitchName\x12\x10\n\x08velocity\x18\x02 \x01(\x05\x12\x12\n\nstart_time\x18\x03 \x01(\x01\x12\x1c\n\x14quantized_start_step\x18\r \x01(\x03\x12\x10\n\x08\x65nd_time\x18\x04 \x01(\x01\x12\x1a\n\x12quantized_end_step\x18\x0e \x01(\x03\x12\x11\n\tnumerator\x18\x05 \x01(\x05\x12\x13\n\x0b\x64\x65nominator\x18\x06 \x01(\x05\x12\x12\n\ninstrument\x18\x07 \x01(\x05\x12\x0f\n\x07program\x18\x08 \x01(\x05\x12\x0f\n\x07is_drum\x18\t \x01(\x08\x12\x0c\n\x04part\x18\n \x01(\x05\x12\r\n\x05voice\x18\x0c \x01(\x05\x1a\x45\n\rTimeSignature\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x11\n\tnumerator\x18\x02 \x01(\x05\x12\x13\n\x0b\x64\x65nominator\x18\x03 \x01(\x05\x1a\xb6\x03\n\x0cKeySignature\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x33\n\x03key\x18\x02 \x01(\x0e\x32&amp;.magenta.NoteSequence.KeySignature.Key\x12\x35\n\x04mode\x18\x03 \x01(\x0e\x32\&#39;.magenta.NoteSequence.KeySignature.Mode\&#34;\xb7\x01\n\x03Key\x12\x05\n\x01\x43\x10\x00\x12\x0b\n\x07\x43_SHARP\x10\x01\x12\n\n\x06\x44_FLAT\x10\x01\x12\x05\n\x01\x44\x10\x02\x12\x0b\n\x07\x44_SHARP\x10\x03\x12\n\n\x06\x45_FLAT\x10\x03\x12\x05\n\x01\x45\x10\x04\x12\x05\n\x01\x46\x10\x05\x12\x0b\n\x07\x46_SHARP\x10\x06\x12\n\n\x06G_FLAT\x10\x06\x12\x05\n\x01G\x10\x07\x12\x0b\n\x07G_SHARP\x10\x08\x12\n\n\x06\x41_FLAT\x10\x08\x12\x05\n\x01\x41\x10\t\x12\x0b\n\x07\x41_SHARP\x10\n\x12\n\n\x06\x42_FLAT\x10\n\x12\x05\n\x01\x42\x10\x0b\x1a\x02\x10\x01\&#34;r\n\x04Mode\x12\t\n\x05MAJOR\x10\x00\x12\t\n\x05MINOR\x10\x01\x12\x11\n\rNOT_SPECIFIED\x10\x02\x12\x0e\n\nMIXOLYDIAN\x10\x03\x12\n\n\x06\x44ORIAN\x10\x04\x12\x0c\n\x08PHRYGIAN\x10\x05\x12\n\n\x06LYDIAN\x10\x06\x12\x0b\n\x07LOCRIAN\x10\x07\x1a\&#34;\n\x05Tempo\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x0b\n\x03qpm\x18\x02 \x01(\x01\x1a]\n\tPitchBend\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x0c\n\x04\x62\x65nd\x18\x02 \x01(\x05\x12\x12\n\ninstrument\x18\x03 \x01(\x05\x12\x0f\n\x07program\x18\x04 \x01(\x05\x12\x0f\n\x07is_drum\x18\x05 \x01(\x08\x1a\x9a\x01\n\rControlChange\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x16\n\x0equantized_step\x18\x07 \x01(\x03\x12\x16\n\x0e\x63ontrol_number\x18\x02 \x01(\x05\x12\x15\n\rcontrol_value\x18\x03 \x01(\x05\x12\x12\n\ninstrument\x18\x04 \x01(\x05\x12\x0f\n\x07program\x18\x05 \x01(\x05\x12\x0f\n\x07is_drum\x18\x06 \x01(\x08\x1a&amp;\n\x08PartInfo\x12\x0c\n\x04part\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a\x32\n\x0eInstrumentInfo\x12\x12\n\ninstrument\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a\x8b\x04\n\nSourceInfo\x12@\n\x0bsource_type\x18\x01 \x01(\x0e\x32+.magenta.NoteSequence.SourceInfo.SourceType\x12\x44\n\rencoding_type\x18\x02 \x01(\x0e\x32-.magenta.NoteSequence.SourceInfo.EncodingType\x12\x37\n\x06parser\x18\x03 \x01(\x0e\x32\&#39;.magenta.NoteSequence.SourceInfo.Parser\&#34;M\n\nSourceType\x12\x17\n\x13UNKNOWN_SOURCE_TYPE\x10\x00\x12\x0f\n\x0bSCORE_BASED\x10\x01\x12\x15\n\x11PERFORMANCE_BASED\x10\x02\&#34;Y\n\x0c\x45ncodingType\x12\x19\n\x15UNKNOWN_ENCODING_TYPE\x10\x00\x12\r\n\tMUSIC_XML\x10\x01\x12\x07\n\x03\x41\x42\x43\x10\x02\x12\x08\n\x04MIDI\x10\x03\x12\x0c\n\x08MUSICNET\x10\x04\&#34;\x91\x01\n\x06Parser\x12\x12\n\x0eUNKNOWN_PARSER\x10\x00\x12\x0b\n\x07MUSIC21\x10\x01\x12\x0f\n\x0bPRETTY_MIDI\x10\x02\x12\x15\n\x11MAGENTA_MUSIC_XML\x10\x03\x12\x14\n\x10MAGENTA_MUSICNET\x10\x04\x12\x0f\n\x0bMAGENTA_ABC\x10\x05\x12\x17\n\x13TONEJS_MIDI_CONVERT\x10\x06\x1a\xd5\x01\n\x0eTextAnnotation\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x16\n\x0equantized_step\x18\x04 \x01(\x03\x12\x0c\n\x04text\x18\x02 \x01(\t\x12P\n\x0f\x61nnotation_type\x18\x03 \x01(\x0e\x32\x37.magenta.NoteSequence.TextAnnotation.TextAnnotationType\&#34;=\n\x12TextAnnotationType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x10\n\x0c\x43HORD_SYMBOL\x10\x01\x12\x08\n\x04\x42\x45\x41T\x10\x02\x1aY\n\x10QuantizationInfo\x12\x1b\n\x11steps_per_quarter\x18\x01 \x01(\x05H\x00\x12\x1a\n\x10steps_per_second\x18\x02 \x01(\x05H\x00\x42\x0c\n\nresolution\x1a\x45\n\x0fSubsequenceInfo\x12\x19\n\x11start_time_offset\x18\x01 \x01(\x01\x12\x17\n\x0f\x65nd_time_offset\x18\x02 \x01(\x01\x1a\x35\n\x11SectionAnnotation\x12\x0c\n\x04time\x18\x01 \x01(\x01\x12\x12\n\nsection_id\x18\x04 \x01(\x03\x1al\n\x07Section\x12\x14\n\nsection_id\x18\x01 \x01(\x03H\x00\x12;\n\rsection_group\x18\x02 \x01(\x0b\x32\&#34;.magenta.NoteSequence.SectionGroupH\x00\x42\x0e\n\x0csection_type\x1aR\n\x0cSectionGroup\x12/\n\x08sections\x18\x01 \x03(\x0b\x32\x1d.magenta.NoteSequence.Section\x12\x11\n\tnum_times\x18\x02 \x01(\x05\&#34;\xff\x03\n\tPitchName\x12\x16\n\x12UNKNOWN_PITCH_NAME\x10\x00\x12\x0f\n\x0b\x46_FLAT_FLAT\x10\x01\x12\x0f\n\x0b\x43_FLAT_FLAT\x10\x02\x12\x0f\n\x0bG_FLAT_FLAT\x10\x03\x12\x0f\n\x0b\x44_FLAT_FLAT\x10\x04\x12\x0f\n\x0b\x41_FLAT_FLAT\x10\x05\x12\x0f\n\x0b\x45_FLAT_FLAT\x10\x06\x12\x0f\n\x0b\x42_FLAT_FLAT\x10\x07\x12\n\n\x06\x46_FLAT\x10\x08\x12\n\n\x06\x43_FLAT\x10\t\x12\n\n\x06G_FLAT\x10\n\x12\n\n\x06\x44_FLAT\x10\x0b\x12\n\n\x06\x41_FLAT\x10\x0c\x12\n\n\x06\x45_FLAT\x10\r\x12\n\n\x06\x42_FLAT\x10\x0e\x12\x05\n\x01\x46\x10\x0f\x12\x05\n\x01\x43\x10\x10\x12\x05\n\x01G\x10\x11\x12\x05\n\x01\x44\x10\x12\x12\x05\n\x01\x41\x10\x13\x12\x05\n\x01\x45\x10\x14\x12\x05\n\x01\x42\x10\x15\x12\x0b\n\x07\x46_SHARP\x10\x16\x12\x0b\n\x07\x43_SHARP\x10\x17\x12\x0b\n\x07G_SHARP\x10\x18\x12\x0b\n\x07\x44_SHARP\x10\x19\x12\x0b\n\x07\x41_SHARP\x10\x1a\x12\x0b\n\x07\x45_SHARP\x10\x1b\x12\x0b\n\x07\x42_SHARP\x10\x1c\x12\x11\n\rF_SHARP_SHARP\x10\x1d\x12\x11\n\rC_SHARP_SHARP\x10\x1e\x12\x11\n\rG_SHARP_SHARP\x10\x1f\x12\x11\n\rD_SHARP_SHARP\x10 \x12\x11\n\rA_SHARP_SHARP\x10!\x12\x11\n\rE_SHARP_SHARP\x10\&#34;\x12\x11\n\rB_SHARP_SHARP\x10#\&#34;S\n\x10SequenceMetadata\x12\r\n\x05title\x18\x01 \x01(\t\x12\x0e\n\x06\x61rtist\x18\x02 \x01(\t\x12\r\n\x05genre\x18\x03 \x03(\t\x12\x11\n\tcomposers\x18\x04 \x03(\t\&#34;)\n\rVelocityRange\x12\x0b\n\x03min\x18\x01 \x01(\x05\x12\x0b\n\x03max\x18\x02 \x01(\x05\x62\x06proto3&#39;)
+)
+
+
+
+_NOTESEQUENCE_KEYSIGNATURE_KEY = _descriptor.EnumDescriptor(
+  name=&#39;Key&#39;,
+  full_name=&#39;magenta.NoteSequence.KeySignature.Key&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C_SHARP&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_FLAT&#39;, index=2, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D&#39;, index=3, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_SHARP&#39;, index=4, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E_FLAT&#39;, index=5, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E&#39;, index=6, number=4,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F&#39;, index=7, number=5,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F_SHARP&#39;, index=8, number=6,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_FLAT&#39;, index=9, number=6,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G&#39;, index=10, number=7,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_SHARP&#39;, index=11, number=8,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_FLAT&#39;, index=12, number=8,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A&#39;, index=13, number=9,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_SHARP&#39;, index=14, number=10,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B_FLAT&#39;, index=15, number=10,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B&#39;, index=16, number=11,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=_b(&#39;\020\001&#39;),
+  serialized_start=1620,
+  serialized_end=1803,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_KEYSIGNATURE_KEY)
+
+_NOTESEQUENCE_KEYSIGNATURE_MODE = _descriptor.EnumDescriptor(
+  name=&#39;Mode&#39;,
+  full_name=&#39;magenta.NoteSequence.KeySignature.Mode&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MAJOR&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MINOR&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;NOT_SPECIFIED&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MIXOLYDIAN&#39;, index=3, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;DORIAN&#39;, index=4, number=4,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;PHRYGIAN&#39;, index=5, number=5,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;LYDIAN&#39;, index=6, number=6,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;LOCRIAN&#39;, index=7, number=7,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=1805,
+  serialized_end=1919,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_KEYSIGNATURE_MODE)
+
+_NOTESEQUENCE_SOURCEINFO_SOURCETYPE = _descriptor.EnumDescriptor(
+  name=&#39;SourceType&#39;,
+  full_name=&#39;magenta.NoteSequence.SourceInfo.SourceType&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;UNKNOWN_SOURCE_TYPE&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;SCORE_BASED&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;PERFORMANCE_BASED&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=2509,
+  serialized_end=2586,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_SOURCEINFO_SOURCETYPE)
+
+_NOTESEQUENCE_SOURCEINFO_ENCODINGTYPE = _descriptor.EnumDescriptor(
+  name=&#39;EncodingType&#39;,
+  full_name=&#39;magenta.NoteSequence.SourceInfo.EncodingType&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;UNKNOWN_ENCODING_TYPE&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MUSIC_XML&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;ABC&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MIDI&#39;, index=3, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MUSICNET&#39;, index=4, number=4,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=2588,
+  serialized_end=2677,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_SOURCEINFO_ENCODINGTYPE)
+
+_NOTESEQUENCE_SOURCEINFO_PARSER = _descriptor.EnumDescriptor(
+  name=&#39;Parser&#39;,
+  full_name=&#39;magenta.NoteSequence.SourceInfo.Parser&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;UNKNOWN_PARSER&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MUSIC21&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;PRETTY_MIDI&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MAGENTA_MUSIC_XML&#39;, index=3, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MAGENTA_MUSICNET&#39;, index=4, number=4,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;MAGENTA_ABC&#39;, index=5, number=5,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;TONEJS_MIDI_CONVERT&#39;, index=6, number=6,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=2680,
+  serialized_end=2825,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_SOURCEINFO_PARSER)
+
+_NOTESEQUENCE_TEXTANNOTATION_TEXTANNOTATIONTYPE = _descriptor.EnumDescriptor(
+  name=&#39;TextAnnotationType&#39;,
+  full_name=&#39;magenta.NoteSequence.TextAnnotation.TextAnnotationType&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;UNKNOWN&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;CHORD_SYMBOL&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;BEAT&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=2980,
+  serialized_end=3041,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_TEXTANNOTATION_TEXTANNOTATIONTYPE)
+
+_NOTESEQUENCE_PITCHNAME = _descriptor.EnumDescriptor(
+  name=&#39;PitchName&#39;,
+  full_name=&#39;magenta.NoteSequence.PitchName&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name=&#39;UNKNOWN_PITCH_NAME&#39;, index=0, number=0,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F_FLAT_FLAT&#39;, index=1, number=1,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C_FLAT_FLAT&#39;, index=2, number=2,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_FLAT_FLAT&#39;, index=3, number=3,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_FLAT_FLAT&#39;, index=4, number=4,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_FLAT_FLAT&#39;, index=5, number=5,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E_FLAT_FLAT&#39;, index=6, number=6,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B_FLAT_FLAT&#39;, index=7, number=7,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F_FLAT&#39;, index=8, number=8,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C_FLAT&#39;, index=9, number=9,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_FLAT&#39;, index=10, number=10,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_FLAT&#39;, index=11, number=11,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_FLAT&#39;, index=12, number=12,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E_FLAT&#39;, index=13, number=13,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B_FLAT&#39;, index=14, number=14,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F&#39;, index=15, number=15,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C&#39;, index=16, number=16,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G&#39;, index=17, number=17,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D&#39;, index=18, number=18,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A&#39;, index=19, number=19,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E&#39;, index=20, number=20,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B&#39;, index=21, number=21,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F_SHARP&#39;, index=22, number=22,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C_SHARP&#39;, index=23, number=23,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_SHARP&#39;, index=24, number=24,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_SHARP&#39;, index=25, number=25,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_SHARP&#39;, index=26, number=26,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E_SHARP&#39;, index=27, number=27,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B_SHARP&#39;, index=28, number=28,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;F_SHARP_SHARP&#39;, index=29, number=29,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;C_SHARP_SHARP&#39;, index=30, number=30,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;G_SHARP_SHARP&#39;, index=31, number=31,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;D_SHARP_SHARP&#39;, index=32, number=32,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;A_SHARP_SHARP&#39;, index=33, number=33,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;E_SHARP_SHARP&#39;, index=34, number=34,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name=&#39;B_SHARP_SHARP&#39;, index=35, number=35,
+      serialized_options=None,
+      type=None),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=3455,
+  serialized_end=3966,
+)
+_sym_db.RegisterEnumDescriptor(_NOTESEQUENCE_PITCHNAME)
+
+
+_NOTESEQUENCE_NOTE = _descriptor.Descriptor(
+  name=&#39;Note&#39;,
+  full_name=&#39;magenta.NoteSequence.Note&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;pitch&#39;, full_name=&#39;magenta.NoteSequence.Note.pitch&#39;, index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;pitch_name&#39;, full_name=&#39;magenta.NoteSequence.Note.pitch_name&#39;, index=1,
+      number=11, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;velocity&#39;, full_name=&#39;magenta.NoteSequence.Note.velocity&#39;, index=2,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;start_time&#39;, full_name=&#39;magenta.NoteSequence.Note.start_time&#39;, index=3,
+      number=3, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;quantized_start_step&#39;, full_name=&#39;magenta.NoteSequence.Note.quantized_start_step&#39;, index=4,
+      number=13, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;end_time&#39;, full_name=&#39;magenta.NoteSequence.Note.end_time&#39;, index=5,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;quantized_end_step&#39;, full_name=&#39;magenta.NoteSequence.Note.quantized_end_step&#39;, index=6,
+      number=14, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;numerator&#39;, full_name=&#39;magenta.NoteSequence.Note.numerator&#39;, index=7,
+      number=5, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;denominator&#39;, full_name=&#39;magenta.NoteSequence.Note.denominator&#39;, index=8,
+      number=6, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;instrument&#39;, full_name=&#39;magenta.NoteSequence.Note.instrument&#39;, index=9,
+      number=7, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;program&#39;, full_name=&#39;magenta.NoteSequence.Note.program&#39;, index=10,
+      number=8, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;is_drum&#39;, full_name=&#39;magenta.NoteSequence.Note.is_drum&#39;, index=11,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;part&#39;, full_name=&#39;magenta.NoteSequence.Note.part&#39;, index=12,
+      number=10, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;voice&#39;, full_name=&#39;magenta.NoteSequence.Note.voice&#39;, index=13,
+      number=12, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1096,
+  serialized_end=1407,
+)
+
+_NOTESEQUENCE_TIMESIGNATURE = _descriptor.Descriptor(
+  name=&#39;TimeSignature&#39;,
+  full_name=&#39;magenta.NoteSequence.TimeSignature&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.TimeSignature.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;numerator&#39;, full_name=&#39;magenta.NoteSequence.TimeSignature.numerator&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;denominator&#39;, full_name=&#39;magenta.NoteSequence.TimeSignature.denominator&#39;, index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1409,
+  serialized_end=1478,
+)
+
+_NOTESEQUENCE_KEYSIGNATURE = _descriptor.Descriptor(
+  name=&#39;KeySignature&#39;,
+  full_name=&#39;magenta.NoteSequence.KeySignature&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.KeySignature.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;key&#39;, full_name=&#39;magenta.NoteSequence.KeySignature.key&#39;, index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;mode&#39;, full_name=&#39;magenta.NoteSequence.KeySignature.mode&#39;, index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _NOTESEQUENCE_KEYSIGNATURE_KEY,
+    _NOTESEQUENCE_KEYSIGNATURE_MODE,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1481,
+  serialized_end=1919,
+)
+
+_NOTESEQUENCE_TEMPO = _descriptor.Descriptor(
+  name=&#39;Tempo&#39;,
+  full_name=&#39;magenta.NoteSequence.Tempo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.Tempo.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;qpm&#39;, full_name=&#39;magenta.NoteSequence.Tempo.qpm&#39;, index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1921,
+  serialized_end=1955,
+)
+
+_NOTESEQUENCE_PITCHBEND = _descriptor.Descriptor(
+  name=&#39;PitchBend&#39;,
+  full_name=&#39;magenta.NoteSequence.PitchBend&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.PitchBend.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;bend&#39;, full_name=&#39;magenta.NoteSequence.PitchBend.bend&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;instrument&#39;, full_name=&#39;magenta.NoteSequence.PitchBend.instrument&#39;, index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;program&#39;, full_name=&#39;magenta.NoteSequence.PitchBend.program&#39;, index=3,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;is_drum&#39;, full_name=&#39;magenta.NoteSequence.PitchBend.is_drum&#39;, index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1957,
+  serialized_end=2050,
+)
+
+_NOTESEQUENCE_CONTROLCHANGE = _descriptor.Descriptor(
+  name=&#39;ControlChange&#39;,
+  full_name=&#39;magenta.NoteSequence.ControlChange&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;quantized_step&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.quantized_step&#39;, index=1,
+      number=7, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;control_number&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.control_number&#39;, index=2,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;control_value&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.control_value&#39;, index=3,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;instrument&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.instrument&#39;, index=4,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;program&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.program&#39;, index=5,
+      number=5, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;is_drum&#39;, full_name=&#39;magenta.NoteSequence.ControlChange.is_drum&#39;, index=6,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2053,
+  serialized_end=2207,
+)
+
+_NOTESEQUENCE_PARTINFO = _descriptor.Descriptor(
+  name=&#39;PartInfo&#39;,
+  full_name=&#39;magenta.NoteSequence.PartInfo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;part&#39;, full_name=&#39;magenta.NoteSequence.PartInfo.part&#39;, index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;name&#39;, full_name=&#39;magenta.NoteSequence.PartInfo.name&#39;, index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2209,
+  serialized_end=2247,
+)
+
+_NOTESEQUENCE_INSTRUMENTINFO = _descriptor.Descriptor(
+  name=&#39;InstrumentInfo&#39;,
+  full_name=&#39;magenta.NoteSequence.InstrumentInfo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;instrument&#39;, full_name=&#39;magenta.NoteSequence.InstrumentInfo.instrument&#39;, index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;name&#39;, full_name=&#39;magenta.NoteSequence.InstrumentInfo.name&#39;, index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2249,
+  serialized_end=2299,
+)
+
+_NOTESEQUENCE_SOURCEINFO = _descriptor.Descriptor(
+  name=&#39;SourceInfo&#39;,
+  full_name=&#39;magenta.NoteSequence.SourceInfo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;source_type&#39;, full_name=&#39;magenta.NoteSequence.SourceInfo.source_type&#39;, index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;encoding_type&#39;, full_name=&#39;magenta.NoteSequence.SourceInfo.encoding_type&#39;, index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;parser&#39;, full_name=&#39;magenta.NoteSequence.SourceInfo.parser&#39;, index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _NOTESEQUENCE_SOURCEINFO_SOURCETYPE,
+    _NOTESEQUENCE_SOURCEINFO_ENCODINGTYPE,
+    _NOTESEQUENCE_SOURCEINFO_PARSER,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2302,
+  serialized_end=2825,
+)
+
+_NOTESEQUENCE_TEXTANNOTATION = _descriptor.Descriptor(
+  name=&#39;TextAnnotation&#39;,
+  full_name=&#39;magenta.NoteSequence.TextAnnotation&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.TextAnnotation.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;quantized_step&#39;, full_name=&#39;magenta.NoteSequence.TextAnnotation.quantized_step&#39;, index=1,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;text&#39;, full_name=&#39;magenta.NoteSequence.TextAnnotation.text&#39;, index=2,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;annotation_type&#39;, full_name=&#39;magenta.NoteSequence.TextAnnotation.annotation_type&#39;, index=3,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _NOTESEQUENCE_TEXTANNOTATION_TEXTANNOTATIONTYPE,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2828,
+  serialized_end=3041,
+)
+
+_NOTESEQUENCE_QUANTIZATIONINFO = _descriptor.Descriptor(
+  name=&#39;QuantizationInfo&#39;,
+  full_name=&#39;magenta.NoteSequence.QuantizationInfo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;steps_per_quarter&#39;, full_name=&#39;magenta.NoteSequence.QuantizationInfo.steps_per_quarter&#39;, index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;steps_per_second&#39;, full_name=&#39;magenta.NoteSequence.QuantizationInfo.steps_per_second&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name=&#39;resolution&#39;, full_name=&#39;magenta.NoteSequence.QuantizationInfo.resolution&#39;,
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=3043,
+  serialized_end=3132,
+)
+
+_NOTESEQUENCE_SUBSEQUENCEINFO = _descriptor.Descriptor(
+  name=&#39;SubsequenceInfo&#39;,
+  full_name=&#39;magenta.NoteSequence.SubsequenceInfo&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;start_time_offset&#39;, full_name=&#39;magenta.NoteSequence.SubsequenceInfo.start_time_offset&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;end_time_offset&#39;, full_name=&#39;magenta.NoteSequence.SubsequenceInfo.end_time_offset&#39;, index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3134,
+  serialized_end=3203,
+)
+
+_NOTESEQUENCE_SECTIONANNOTATION = _descriptor.Descriptor(
+  name=&#39;SectionAnnotation&#39;,
+  full_name=&#39;magenta.NoteSequence.SectionAnnotation&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;time&#39;, full_name=&#39;magenta.NoteSequence.SectionAnnotation.time&#39;, index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;section_id&#39;, full_name=&#39;magenta.NoteSequence.SectionAnnotation.section_id&#39;, index=1,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3205,
+  serialized_end=3258,
+)
+
+_NOTESEQUENCE_SECTION = _descriptor.Descriptor(
+  name=&#39;Section&#39;,
+  full_name=&#39;magenta.NoteSequence.Section&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;section_id&#39;, full_name=&#39;magenta.NoteSequence.Section.section_id&#39;, index=0,
+      number=1, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;section_group&#39;, full_name=&#39;magenta.NoteSequence.Section.section_group&#39;, index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name=&#39;section_type&#39;, full_name=&#39;magenta.NoteSequence.Section.section_type&#39;,
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=3260,
+  serialized_end=3368,
+)
+
+_NOTESEQUENCE_SECTIONGROUP = _descriptor.Descriptor(
+  name=&#39;SectionGroup&#39;,
+  full_name=&#39;magenta.NoteSequence.SectionGroup&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;sections&#39;, full_name=&#39;magenta.NoteSequence.SectionGroup.sections&#39;, index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;num_times&#39;, full_name=&#39;magenta.NoteSequence.SectionGroup.num_times&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3370,
+  serialized_end=3452,
+)
+
+_NOTESEQUENCE = _descriptor.Descriptor(
+  name=&#39;NoteSequence&#39;,
+  full_name=&#39;magenta.NoteSequence&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;id&#39;, full_name=&#39;magenta.NoteSequence.id&#39;, index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;filename&#39;, full_name=&#39;magenta.NoteSequence.filename&#39;, index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;reference_number&#39;, full_name=&#39;magenta.NoteSequence.reference_number&#39;, index=2,
+      number=18, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;collection_name&#39;, full_name=&#39;magenta.NoteSequence.collection_name&#39;, index=3,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;ticks_per_quarter&#39;, full_name=&#39;magenta.NoteSequence.ticks_per_quarter&#39;, index=4,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;time_signatures&#39;, full_name=&#39;magenta.NoteSequence.time_signatures&#39;, index=5,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;key_signatures&#39;, full_name=&#39;magenta.NoteSequence.key_signatures&#39;, index=6,
+      number=6, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;tempos&#39;, full_name=&#39;magenta.NoteSequence.tempos&#39;, index=7,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;notes&#39;, full_name=&#39;magenta.NoteSequence.notes&#39;, index=8,
+      number=8, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;total_time&#39;, full_name=&#39;magenta.NoteSequence.total_time&#39;, index=9,
+      number=9, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;total_quantized_steps&#39;, full_name=&#39;magenta.NoteSequence.total_quantized_steps&#39;, index=10,
+      number=16, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;pitch_bends&#39;, full_name=&#39;magenta.NoteSequence.pitch_bends&#39;, index=11,
+      number=10, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;control_changes&#39;, full_name=&#39;magenta.NoteSequence.control_changes&#39;, index=12,
+      number=11, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;part_infos&#39;, full_name=&#39;magenta.NoteSequence.part_infos&#39;, index=13,
+      number=12, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;source_info&#39;, full_name=&#39;magenta.NoteSequence.source_info&#39;, index=14,
+      number=13, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;text_annotations&#39;, full_name=&#39;magenta.NoteSequence.text_annotations&#39;, index=15,
+      number=14, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;section_annotations&#39;, full_name=&#39;magenta.NoteSequence.section_annotations&#39;, index=16,
+      number=20, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;section_groups&#39;, full_name=&#39;magenta.NoteSequence.section_groups&#39;, index=17,
+      number=21, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;quantization_info&#39;, full_name=&#39;magenta.NoteSequence.quantization_info&#39;, index=18,
+      number=15, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;subsequence_info&#39;, full_name=&#39;magenta.NoteSequence.subsequence_info&#39;, index=19,
+      number=17, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;sequence_metadata&#39;, full_name=&#39;magenta.NoteSequence.sequence_metadata&#39;, index=20,
+      number=19, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;instrument_infos&#39;, full_name=&#39;magenta.NoteSequence.instrument_infos&#39;, index=21,
+      number=23, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_NOTESEQUENCE_NOTE, _NOTESEQUENCE_TIMESIGNATURE, _NOTESEQUENCE_KEYSIGNATURE, _NOTESEQUENCE_TEMPO, _NOTESEQUENCE_PITCHBEND, _NOTESEQUENCE_CONTROLCHANGE, _NOTESEQUENCE_PARTINFO, _NOTESEQUENCE_INSTRUMENTINFO, _NOTESEQUENCE_SOURCEINFO, _NOTESEQUENCE_TEXTANNOTATION, _NOTESEQUENCE_QUANTIZATIONINFO, _NOTESEQUENCE_SUBSEQUENCEINFO, _NOTESEQUENCE_SECTIONANNOTATION, _NOTESEQUENCE_SECTION, _NOTESEQUENCE_SECTIONGROUP, ],
+  enum_types=[
+    _NOTESEQUENCE_PITCHNAME,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=43,
+  serialized_end=3966,
+)
+
+
+_SEQUENCEMETADATA = _descriptor.Descriptor(
+  name=&#39;SequenceMetadata&#39;,
+  full_name=&#39;magenta.SequenceMetadata&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;title&#39;, full_name=&#39;magenta.SequenceMetadata.title&#39;, index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;artist&#39;, full_name=&#39;magenta.SequenceMetadata.artist&#39;, index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(&#34;&#34;).decode(&#39;utf-8&#39;),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;genre&#39;, full_name=&#39;magenta.SequenceMetadata.genre&#39;, index=2,
+      number=3, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;composers&#39;, full_name=&#39;magenta.SequenceMetadata.composers&#39;, index=3,
+      number=4, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3968,
+  serialized_end=4051,
+)
+
+
+_VELOCITYRANGE = _descriptor.Descriptor(
+  name=&#39;VelocityRange&#39;,
+  full_name=&#39;magenta.VelocityRange&#39;,
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name=&#39;min&#39;, full_name=&#39;magenta.VelocityRange.min&#39;, index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name=&#39;max&#39;, full_name=&#39;magenta.VelocityRange.max&#39;, index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax=&#39;proto3&#39;,
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4053,
+  serialized_end=4094,
+)
+
+_NOTESEQUENCE_NOTE.fields_by_name[&#39;pitch_name&#39;].enum_type = _NOTESEQUENCE_PITCHNAME
+_NOTESEQUENCE_NOTE.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_TIMESIGNATURE.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_KEYSIGNATURE.fields_by_name[&#39;key&#39;].enum_type = _NOTESEQUENCE_KEYSIGNATURE_KEY
+_NOTESEQUENCE_KEYSIGNATURE.fields_by_name[&#39;mode&#39;].enum_type = _NOTESEQUENCE_KEYSIGNATURE_MODE
+_NOTESEQUENCE_KEYSIGNATURE.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_KEYSIGNATURE_KEY.containing_type = _NOTESEQUENCE_KEYSIGNATURE
+_NOTESEQUENCE_KEYSIGNATURE_MODE.containing_type = _NOTESEQUENCE_KEYSIGNATURE
+_NOTESEQUENCE_TEMPO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_PITCHBEND.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_CONTROLCHANGE.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_PARTINFO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_INSTRUMENTINFO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_SOURCEINFO.fields_by_name[&#39;source_type&#39;].enum_type = _NOTESEQUENCE_SOURCEINFO_SOURCETYPE
+_NOTESEQUENCE_SOURCEINFO.fields_by_name[&#39;encoding_type&#39;].enum_type = _NOTESEQUENCE_SOURCEINFO_ENCODINGTYPE
+_NOTESEQUENCE_SOURCEINFO.fields_by_name[&#39;parser&#39;].enum_type = _NOTESEQUENCE_SOURCEINFO_PARSER
+_NOTESEQUENCE_SOURCEINFO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_SOURCEINFO_SOURCETYPE.containing_type = _NOTESEQUENCE_SOURCEINFO
+_NOTESEQUENCE_SOURCEINFO_ENCODINGTYPE.containing_type = _NOTESEQUENCE_SOURCEINFO
+_NOTESEQUENCE_SOURCEINFO_PARSER.containing_type = _NOTESEQUENCE_SOURCEINFO
+_NOTESEQUENCE_TEXTANNOTATION.fields_by_name[&#39;annotation_type&#39;].enum_type = _NOTESEQUENCE_TEXTANNOTATION_TEXTANNOTATIONTYPE
+_NOTESEQUENCE_TEXTANNOTATION.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_TEXTANNOTATION_TEXTANNOTATIONTYPE.containing_type = _NOTESEQUENCE_TEXTANNOTATION
+_NOTESEQUENCE_QUANTIZATIONINFO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_QUANTIZATIONINFO.oneofs_by_name[&#39;resolution&#39;].fields.append(
+  _NOTESEQUENCE_QUANTIZATIONINFO.fields_by_name[&#39;steps_per_quarter&#39;])
+_NOTESEQUENCE_QUANTIZATIONINFO.fields_by_name[&#39;steps_per_quarter&#39;].containing_oneof = _NOTESEQUENCE_QUANTIZATIONINFO.oneofs_by_name[&#39;resolution&#39;]
+_NOTESEQUENCE_QUANTIZATIONINFO.oneofs_by_name[&#39;resolution&#39;].fields.append(
+  _NOTESEQUENCE_QUANTIZATIONINFO.fields_by_name[&#39;steps_per_second&#39;])
+_NOTESEQUENCE_QUANTIZATIONINFO.fields_by_name[&#39;steps_per_second&#39;].containing_oneof = _NOTESEQUENCE_QUANTIZATIONINFO.oneofs_by_name[&#39;resolution&#39;]
+_NOTESEQUENCE_SUBSEQUENCEINFO.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_SECTIONANNOTATION.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_SECTION.fields_by_name[&#39;section_group&#39;].message_type = _NOTESEQUENCE_SECTIONGROUP
+_NOTESEQUENCE_SECTION.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE_SECTION.oneofs_by_name[&#39;section_type&#39;].fields.append(
+  _NOTESEQUENCE_SECTION.fields_by_name[&#39;section_id&#39;])
+_NOTESEQUENCE_SECTION.fields_by_name[&#39;section_id&#39;].containing_oneof = _NOTESEQUENCE_SECTION.oneofs_by_name[&#39;section_type&#39;]
+_NOTESEQUENCE_SECTION.oneofs_by_name[&#39;section_type&#39;].fields.append(
+  _NOTESEQUENCE_SECTION.fields_by_name[&#39;section_group&#39;])
+_NOTESEQUENCE_SECTION.fields_by_name[&#39;section_group&#39;].containing_oneof = _NOTESEQUENCE_SECTION.oneofs_by_name[&#39;section_type&#39;]
+_NOTESEQUENCE_SECTIONGROUP.fields_by_name[&#39;sections&#39;].message_type = _NOTESEQUENCE_SECTION
+_NOTESEQUENCE_SECTIONGROUP.containing_type = _NOTESEQUENCE
+_NOTESEQUENCE.fields_by_name[&#39;time_signatures&#39;].message_type = _NOTESEQUENCE_TIMESIGNATURE
+_NOTESEQUENCE.fields_by_name[&#39;key_signatures&#39;].message_type = _NOTESEQUENCE_KEYSIGNATURE
+_NOTESEQUENCE.fields_by_name[&#39;tempos&#39;].message_type = _NOTESEQUENCE_TEMPO
+_NOTESEQUENCE.fields_by_name[&#39;notes&#39;].message_type = _NOTESEQUENCE_NOTE
+_NOTESEQUENCE.fields_by_name[&#39;pitch_bends&#39;].message_type = _NOTESEQUENCE_PITCHBEND
+_NOTESEQUENCE.fields_by_name[&#39;control_changes&#39;].message_type = _NOTESEQUENCE_CONTROLCHANGE
+_NOTESEQUENCE.fields_by_name[&#39;part_infos&#39;].message_type = _NOTESEQUENCE_PARTINFO
+_NOTESEQUENCE.fields_by_name[&#39;source_info&#39;].message_type = _NOTESEQUENCE_SOURCEINFO
+_NOTESEQUENCE.fields_by_name[&#39;text_annotations&#39;].message_type = _NOTESEQUENCE_TEXTANNOTATION
+_NOTESEQUENCE.fields_by_name[&#39;section_annotations&#39;].message_type = _NOTESEQUENCE_SECTIONANNOTATION
+_NOTESEQUENCE.fields_by_name[&#39;section_groups&#39;].message_type = _NOTESEQUENCE_SECTIONGROUP
+_NOTESEQUENCE.fields_by_name[&#39;quantization_info&#39;].message_type = _NOTESEQUENCE_QUANTIZATIONINFO
+_NOTESEQUENCE.fields_by_name[&#39;subsequence_info&#39;].message_type = _NOTESEQUENCE_SUBSEQUENCEINFO
+_NOTESEQUENCE.fields_by_name[&#39;sequence_metadata&#39;].message_type = _SEQUENCEMETADATA
+_NOTESEQUENCE.fields_by_name[&#39;instrument_infos&#39;].message_type = _NOTESEQUENCE_INSTRUMENTINFO
+_NOTESEQUENCE_PITCHNAME.containing_type = _NOTESEQUENCE
+DESCRIPTOR.message_types_by_name[&#39;NoteSequence&#39;] = _NOTESEQUENCE
+DESCRIPTOR.message_types_by_name[&#39;SequenceMetadata&#39;] = _SEQUENCEMETADATA
+DESCRIPTOR.message_types_by_name[&#39;VelocityRange&#39;] = _VELOCITYRANGE
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
+NoteSequence = _reflection.GeneratedProtocolMessageType(&#39;NoteSequence&#39;, (_message.Message,), dict(
+
+  Note = _reflection.GeneratedProtocolMessageType(&#39;Note&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_NOTE,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.Note)
+    ))
+  ,
+
+  TimeSignature = _reflection.GeneratedProtocolMessageType(&#39;TimeSignature&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_TIMESIGNATURE,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.TimeSignature)
+    ))
+  ,
+
+  KeySignature = _reflection.GeneratedProtocolMessageType(&#39;KeySignature&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_KEYSIGNATURE,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.KeySignature)
+    ))
+  ,
+
+  Tempo = _reflection.GeneratedProtocolMessageType(&#39;Tempo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_TEMPO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.Tempo)
+    ))
+  ,
+
+  PitchBend = _reflection.GeneratedProtocolMessageType(&#39;PitchBend&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_PITCHBEND,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.PitchBend)
+    ))
+  ,
+
+  ControlChange = _reflection.GeneratedProtocolMessageType(&#39;ControlChange&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_CONTROLCHANGE,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.ControlChange)
+    ))
+  ,
+
+  PartInfo = _reflection.GeneratedProtocolMessageType(&#39;PartInfo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_PARTINFO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.PartInfo)
+    ))
+  ,
+
+  InstrumentInfo = _reflection.GeneratedProtocolMessageType(&#39;InstrumentInfo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_INSTRUMENTINFO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.InstrumentInfo)
+    ))
+  ,
+
+  SourceInfo = _reflection.GeneratedProtocolMessageType(&#39;SourceInfo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_SOURCEINFO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.SourceInfo)
+    ))
+  ,
+
+  TextAnnotation = _reflection.GeneratedProtocolMessageType(&#39;TextAnnotation&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_TEXTANNOTATION,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.TextAnnotation)
+    ))
+  ,
+
+  QuantizationInfo = _reflection.GeneratedProtocolMessageType(&#39;QuantizationInfo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_QUANTIZATIONINFO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.QuantizationInfo)
+    ))
+  ,
+
+  SubsequenceInfo = _reflection.GeneratedProtocolMessageType(&#39;SubsequenceInfo&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_SUBSEQUENCEINFO,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.SubsequenceInfo)
+    ))
+  ,
+
+  SectionAnnotation = _reflection.GeneratedProtocolMessageType(&#39;SectionAnnotation&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_SECTIONANNOTATION,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.SectionAnnotation)
+    ))
+  ,
+
+  Section = _reflection.GeneratedProtocolMessageType(&#39;Section&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_SECTION,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.Section)
+    ))
+  ,
+
+  SectionGroup = _reflection.GeneratedProtocolMessageType(&#39;SectionGroup&#39;, (_message.Message,), dict(
+    DESCRIPTOR = _NOTESEQUENCE_SECTIONGROUP,
+    __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+    # @@protoc_insertion_point(class_scope:magenta.NoteSequence.SectionGroup)
+    ))
+  ,
+  DESCRIPTOR = _NOTESEQUENCE,
+  __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.NoteSequence)
+  ))
+_sym_db.RegisterMessage(NoteSequence)
+_sym_db.RegisterMessage(NoteSequence.Note)
+_sym_db.RegisterMessage(NoteSequence.TimeSignature)
+_sym_db.RegisterMessage(NoteSequence.KeySignature)
+_sym_db.RegisterMessage(NoteSequence.Tempo)
+_sym_db.RegisterMessage(NoteSequence.PitchBend)
+_sym_db.RegisterMessage(NoteSequence.ControlChange)
+_sym_db.RegisterMessage(NoteSequence.PartInfo)
+_sym_db.RegisterMessage(NoteSequence.InstrumentInfo)
+_sym_db.RegisterMessage(NoteSequence.SourceInfo)
+_sym_db.RegisterMessage(NoteSequence.TextAnnotation)
+_sym_db.RegisterMessage(NoteSequence.QuantizationInfo)
+_sym_db.RegisterMessage(NoteSequence.SubsequenceInfo)
+_sym_db.RegisterMessage(NoteSequence.SectionAnnotation)
+_sym_db.RegisterMessage(NoteSequence.Section)
+_sym_db.RegisterMessage(NoteSequence.SectionGroup)
+
+SequenceMetadata = _reflection.GeneratedProtocolMessageType(&#39;SequenceMetadata&#39;, (_message.Message,), dict(
+  DESCRIPTOR = _SEQUENCEMETADATA,
+  __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.SequenceMetadata)
+  ))
+_sym_db.RegisterMessage(SequenceMetadata)
+
+VelocityRange = _reflection.GeneratedProtocolMessageType(&#39;VelocityRange&#39;, (_message.Message,), dict(
+  DESCRIPTOR = _VELOCITYRANGE,
+  __module__ = &#39;note_seq.protobuf.music_pb2&#39;
+  # @@protoc_insertion_point(class_scope:magenta.VelocityRange)
+  ))
+_sym_db.RegisterMessage(VelocityRange)
+
+
+_NOTESEQUENCE_KEYSIGNATURE_KEY._options = None
+# @@protoc_insertion_point(module_scope)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence"><code class="flex name class">
+<span>class <span class="ident">NoteSequence</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.A"><code class="name">var <span class="ident">A</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.A_FLAT"><code class="name">var <span class="ident">A_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.A_FLAT_FLAT"><code class="name">var <span class="ident">A_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.A_SHARP"><code class="name">var <span class="ident">A_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.A_SHARP_SHARP"><code class="name">var <span class="ident">A_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.B"><code class="name">var <span class="ident">B</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.B_FLAT"><code class="name">var <span class="ident">B_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.B_FLAT_FLAT"><code class="name">var <span class="ident">B_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.B_SHARP"><code class="name">var <span class="ident">B_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.B_SHARP_SHARP"><code class="name">var <span class="ident">B_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.C"><code class="name">var <span class="ident">C</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.C_FLAT"><code class="name">var <span class="ident">C_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.C_FLAT_FLAT"><code class="name">var <span class="ident">C_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.C_SHARP"><code class="name">var <span class="ident">C_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.C_SHARP_SHARP"><code class="name">var <span class="ident">C_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.ControlChange"><code class="name">var <span class="ident">ControlChange</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.D"><code class="name">var <span class="ident">D</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.D_FLAT"><code class="name">var <span class="ident">D_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.D_FLAT_FLAT"><code class="name">var <span class="ident">D_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.D_SHARP"><code class="name">var <span class="ident">D_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.D_SHARP_SHARP"><code class="name">var <span class="ident">D_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.E"><code class="name">var <span class="ident">E</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.E_FLAT"><code class="name">var <span class="ident">E_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.E_FLAT_FLAT"><code class="name">var <span class="ident">E_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.E_SHARP"><code class="name">var <span class="ident">E_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.E_SHARP_SHARP"><code class="name">var <span class="ident">E_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.F"><code class="name">var <span class="ident">F</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.F_FLAT"><code class="name">var <span class="ident">F_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.F_FLAT_FLAT"><code class="name">var <span class="ident">F_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.F_SHARP"><code class="name">var <span class="ident">F_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.F_SHARP_SHARP"><code class="name">var <span class="ident">F_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.G"><code class="name">var <span class="ident">G</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.G_FLAT"><code class="name">var <span class="ident">G_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.G_FLAT_FLAT"><code class="name">var <span class="ident">G_FLAT_FLAT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.G_SHARP"><code class="name">var <span class="ident">G_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.G_SHARP_SHARP"><code class="name">var <span class="ident">G_SHARP_SHARP</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.InstrumentInfo"><code class="name">var <span class="ident">InstrumentInfo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.KeySignature"><code class="name">var <span class="ident">KeySignature</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.Note"><code class="name">var <span class="ident">Note</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.PartInfo"><code class="name">var <span class="ident">PartInfo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.PitchBend"><code class="name">var <span class="ident">PitchBend</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.PitchName"><code class="name">var <span class="ident">PitchName</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.QuantizationInfo"><code class="name">var <span class="ident">QuantizationInfo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.Section"><code class="name">var <span class="ident">Section</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.SectionAnnotation"><code class="name">var <span class="ident">SectionAnnotation</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.SectionGroup"><code class="name">var <span class="ident">SectionGroup</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.SourceInfo"><code class="name">var <span class="ident">SourceInfo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.SubsequenceInfo"><code class="name">var <span class="ident">SubsequenceInfo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.Tempo"><code class="name">var <span class="ident">Tempo</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.TextAnnotation"><code class="name">var <span class="ident">TextAnnotation</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.TimeSignature"><code class="name">var <span class="ident">TimeSignature</span></code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.UNKNOWN_PITCH_NAME"><code class="name">var <span class="ident">UNKNOWN_PITCH_NAME</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.collection_name"><code class="name">var <span class="ident">collection_name</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.collection_name</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.control_changes"><code class="name">var <span class="ident">control_changes</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.control_changes</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.filename"><code class="name">var <span class="ident">filename</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.filename</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.id"><code class="name">var <span class="ident">id</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.id</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.instrument_infos"><code class="name">var <span class="ident">instrument_infos</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.instrument_infos</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.key_signatures"><code class="name">var <span class="ident">key_signatures</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.key_signatures</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.notes"><code class="name">var <span class="ident">notes</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.notes</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.part_infos"><code class="name">var <span class="ident">part_infos</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.part_infos</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.pitch_bends"><code class="name">var <span class="ident">pitch_bends</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.pitch_bends</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.quantization_info"><code class="name">var <span class="ident">quantization_info</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.quantization_info</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.reference_number"><code class="name">var <span class="ident">reference_number</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.reference_number</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.section_annotations"><code class="name">var <span class="ident">section_annotations</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.section_annotations</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.section_groups"><code class="name">var <span class="ident">section_groups</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.section_groups</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.sequence_metadata"><code class="name">var <span class="ident">sequence_metadata</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.sequence_metadata</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.source_info"><code class="name">var <span class="ident">source_info</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.source_info</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.subsequence_info"><code class="name">var <span class="ident">subsequence_info</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.subsequence_info</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.tempos"><code class="name">var <span class="ident">tempos</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.tempos</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.text_annotations"><code class="name">var <span class="ident">text_annotations</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.text_annotations</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.ticks_per_quarter"><code class="name">var <span class="ident">ticks_per_quarter</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.ticks_per_quarter</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.time_signatures"><code class="name">var <span class="ident">time_signatures</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.time_signatures</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.total_quantized_steps"><code class="name">var <span class="ident">total_quantized_steps</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.total_quantized_steps</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.NoteSequence.total_time"><code class="name">var <span class="ident">total_time</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.NoteSequence.total_time</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata"><code class="flex name class">
+<span>class <span class="ident">SequenceMetadata</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata.artist"><code class="name">var <span class="ident">artist</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.SequenceMetadata.artist</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata.composers"><code class="name">var <span class="ident">composers</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.SequenceMetadata.composers</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata.genre"><code class="name">var <span class="ident">genre</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.SequenceMetadata.genre</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.SequenceMetadata.title"><code class="name">var <span class="ident">title</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.SequenceMetadata.title</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.VelocityRange"><code class="flex name class">
+<span>class <span class="ident">VelocityRange</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A ProtocolMessage</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>google.protobuf.pyext._message.CMessage</li>
+<li>google.protobuf.message.Message</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.VelocityRange.DESCRIPTOR"><code class="name">var <span class="ident">DESCRIPTOR</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.protobuf.music_pb2.VelocityRange.max"><code class="name">var <span class="ident">max</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.VelocityRange.max</p></div>
+</dd>
+<dt id="note_seq.protobuf.music_pb2.VelocityRange.min"><code class="name">var <span class="ident">min</span></code></dt>
+<dd>
+<div class="desc"><p>Field magenta.VelocityRange.min</p></div>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq.protobuf" href="index.html">note_seq.protobuf</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.protobuf.music_pb2.NoteSequence" href="#note_seq.protobuf.music_pb2.NoteSequence">NoteSequence</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.A" href="#note_seq.protobuf.music_pb2.NoteSequence.A">A</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.A_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.A_FLAT">A_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.A_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.A_FLAT_FLAT">A_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.A_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.A_SHARP">A_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.A_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.A_SHARP_SHARP">A_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.B" href="#note_seq.protobuf.music_pb2.NoteSequence.B">B</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.B_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.B_FLAT">B_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.B_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.B_FLAT_FLAT">B_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.B_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.B_SHARP">B_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.B_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.B_SHARP_SHARP">B_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.C" href="#note_seq.protobuf.music_pb2.NoteSequence.C">C</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.C_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.C_FLAT">C_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.C_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.C_FLAT_FLAT">C_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.C_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.C_SHARP">C_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.C_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.C_SHARP_SHARP">C_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.ControlChange" href="#note_seq.protobuf.music_pb2.NoteSequence.ControlChange">ControlChange</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.D" href="#note_seq.protobuf.music_pb2.NoteSequence.D">D</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.DESCRIPTOR" href="#note_seq.protobuf.music_pb2.NoteSequence.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.D_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.D_FLAT">D_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.D_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.D_FLAT_FLAT">D_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.D_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.D_SHARP">D_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.D_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.D_SHARP_SHARP">D_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.E" href="#note_seq.protobuf.music_pb2.NoteSequence.E">E</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.E_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.E_FLAT">E_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.E_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.E_FLAT_FLAT">E_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.E_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.E_SHARP">E_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.E_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.E_SHARP_SHARP">E_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.F" href="#note_seq.protobuf.music_pb2.NoteSequence.F">F</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.F_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.F_FLAT">F_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.F_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.F_FLAT_FLAT">F_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.F_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.F_SHARP">F_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.F_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.F_SHARP_SHARP">F_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.G" href="#note_seq.protobuf.music_pb2.NoteSequence.G">G</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.G_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.G_FLAT">G_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.G_FLAT_FLAT" href="#note_seq.protobuf.music_pb2.NoteSequence.G_FLAT_FLAT">G_FLAT_FLAT</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.G_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.G_SHARP">G_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.G_SHARP_SHARP" href="#note_seq.protobuf.music_pb2.NoteSequence.G_SHARP_SHARP">G_SHARP_SHARP</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.InstrumentInfo" href="#note_seq.protobuf.music_pb2.NoteSequence.InstrumentInfo">InstrumentInfo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.KeySignature" href="#note_seq.protobuf.music_pb2.NoteSequence.KeySignature">KeySignature</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.Note" href="#note_seq.protobuf.music_pb2.NoteSequence.Note">Note</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.PartInfo" href="#note_seq.protobuf.music_pb2.NoteSequence.PartInfo">PartInfo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.PitchBend" href="#note_seq.protobuf.music_pb2.NoteSequence.PitchBend">PitchBend</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.PitchName" href="#note_seq.protobuf.music_pb2.NoteSequence.PitchName">PitchName</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.QuantizationInfo" href="#note_seq.protobuf.music_pb2.NoteSequence.QuantizationInfo">QuantizationInfo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.Section" href="#note_seq.protobuf.music_pb2.NoteSequence.Section">Section</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.SectionAnnotation" href="#note_seq.protobuf.music_pb2.NoteSequence.SectionAnnotation">SectionAnnotation</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.SectionGroup" href="#note_seq.protobuf.music_pb2.NoteSequence.SectionGroup">SectionGroup</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.SourceInfo" href="#note_seq.protobuf.music_pb2.NoteSequence.SourceInfo">SourceInfo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.SubsequenceInfo" href="#note_seq.protobuf.music_pb2.NoteSequence.SubsequenceInfo">SubsequenceInfo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.Tempo" href="#note_seq.protobuf.music_pb2.NoteSequence.Tempo">Tempo</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.TextAnnotation" href="#note_seq.protobuf.music_pb2.NoteSequence.TextAnnotation">TextAnnotation</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.TimeSignature" href="#note_seq.protobuf.music_pb2.NoteSequence.TimeSignature">TimeSignature</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.UNKNOWN_PITCH_NAME" href="#note_seq.protobuf.music_pb2.NoteSequence.UNKNOWN_PITCH_NAME">UNKNOWN_PITCH_NAME</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.collection_name" href="#note_seq.protobuf.music_pb2.NoteSequence.collection_name">collection_name</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.control_changes" href="#note_seq.protobuf.music_pb2.NoteSequence.control_changes">control_changes</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.filename" href="#note_seq.protobuf.music_pb2.NoteSequence.filename">filename</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.id" href="#note_seq.protobuf.music_pb2.NoteSequence.id">id</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.instrument_infos" href="#note_seq.protobuf.music_pb2.NoteSequence.instrument_infos">instrument_infos</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.key_signatures" href="#note_seq.protobuf.music_pb2.NoteSequence.key_signatures">key_signatures</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.notes" href="#note_seq.protobuf.music_pb2.NoteSequence.notes">notes</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.part_infos" href="#note_seq.protobuf.music_pb2.NoteSequence.part_infos">part_infos</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.pitch_bends" href="#note_seq.protobuf.music_pb2.NoteSequence.pitch_bends">pitch_bends</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.quantization_info" href="#note_seq.protobuf.music_pb2.NoteSequence.quantization_info">quantization_info</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.reference_number" href="#note_seq.protobuf.music_pb2.NoteSequence.reference_number">reference_number</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.section_annotations" href="#note_seq.protobuf.music_pb2.NoteSequence.section_annotations">section_annotations</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.section_groups" href="#note_seq.protobuf.music_pb2.NoteSequence.section_groups">section_groups</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.sequence_metadata" href="#note_seq.protobuf.music_pb2.NoteSequence.sequence_metadata">sequence_metadata</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.source_info" href="#note_seq.protobuf.music_pb2.NoteSequence.source_info">source_info</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.subsequence_info" href="#note_seq.protobuf.music_pb2.NoteSequence.subsequence_info">subsequence_info</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.tempos" href="#note_seq.protobuf.music_pb2.NoteSequence.tempos">tempos</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.text_annotations" href="#note_seq.protobuf.music_pb2.NoteSequence.text_annotations">text_annotations</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.ticks_per_quarter" href="#note_seq.protobuf.music_pb2.NoteSequence.ticks_per_quarter">ticks_per_quarter</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.time_signatures" href="#note_seq.protobuf.music_pb2.NoteSequence.time_signatures">time_signatures</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.total_quantized_steps" href="#note_seq.protobuf.music_pb2.NoteSequence.total_quantized_steps">total_quantized_steps</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.NoteSequence.total_time" href="#note_seq.protobuf.music_pb2.NoteSequence.total_time">total_time</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata" href="#note_seq.protobuf.music_pb2.SequenceMetadata">SequenceMetadata</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata.DESCRIPTOR" href="#note_seq.protobuf.music_pb2.SequenceMetadata.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata.artist" href="#note_seq.protobuf.music_pb2.SequenceMetadata.artist">artist</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata.composers" href="#note_seq.protobuf.music_pb2.SequenceMetadata.composers">composers</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata.genre" href="#note_seq.protobuf.music_pb2.SequenceMetadata.genre">genre</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.SequenceMetadata.title" href="#note_seq.protobuf.music_pb2.SequenceMetadata.title">title</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.protobuf.music_pb2.VelocityRange" href="#note_seq.protobuf.music_pb2.VelocityRange">VelocityRange</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.protobuf.music_pb2.VelocityRange.DESCRIPTOR" href="#note_seq.protobuf.music_pb2.VelocityRange.DESCRIPTOR">DESCRIPTOR</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.VelocityRange.max" href="#note_seq.protobuf.music_pb2.VelocityRange.max">max</a></code></li>
+<li><code><a title="note_seq.protobuf.music_pb2.VelocityRange.min" href="#note_seq.protobuf.music_pb2.VelocityRange.min">min</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/sequences_lib.html
+++ b/docs/sequences_lib.html
@@ -1,0 +1,5168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.sequences_lib API documentation</title>
+<meta name="description" content="Defines sequence of notes objects for creating datasets." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.sequences_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Defines sequence of notes objects for creating datasets.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Defines sequence of notes objects for creating datasets.&#34;&#34;&#34;
+
+import collections
+import copy
+import itertools
+import math
+import operator
+import random
+
+from absl import logging
+from note_seq import chord_symbols_lib
+from note_seq import constants
+from note_seq.protobuf import music_pb2
+import numpy as np
+import pretty_midi
+
+# Set the quantization cutoff.
+# Note events before this cutoff are rounded down to nearest step. Notes
+# above this cutoff are rounded up to nearest step. The cutoff is given as a
+# fraction of a step.
+# For example, with quantize_cutoff = 0.75 using 0-based indexing,
+# if .75 &lt; event &lt;= 1.75, it will be quantized to step 1.
+# If 1.75 &lt; event &lt;= 2.75 it will be quantized to step 2.
+# A number close to 1.0 gives less wiggle room for notes that start early,
+# and they will be snapped to the previous step.
+QUANTIZE_CUTOFF = 0.5
+
+# Shortcut to text annotation types.
+BEAT = music_pb2.NoteSequence.TextAnnotation.BEAT
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+UNKNOWN_PITCH_NAME = music_pb2.NoteSequence.UNKNOWN_PITCH_NAME
+
+# The amount to upweight note-on events vs note-off events.
+ONSET_UPWEIGHT = 5.0
+
+# The size of the frame extension for onset event.
+# Frames in [onset_frame-ONSET_WINDOW, onset_frame+ONSET_WINDOW]
+# are considered to contain onset events.
+ONSET_WINDOW = 1
+
+
+class BadTimeSignatureError(Exception):
+  pass
+
+
+class MultipleTimeSignatureError(Exception):
+  pass
+
+
+class MultipleTempoError(Exception):
+  pass
+
+
+class NegativeTimeError(Exception):
+  pass
+
+
+class QuantizationStatusError(Exception):
+  &#34;&#34;&#34;Exception for when a sequence was unexpectedly quantized or unquantized.
+
+  Should not happen during normal operation and likely indicates a programming
+  error.
+  &#34;&#34;&#34;
+  pass
+
+
+class InvalidTimeAdjustmentError(Exception):
+  pass
+
+
+class RectifyBeatsError(Exception):
+  pass
+
+
+def trim_note_sequence(sequence, start_time, end_time):
+  &#34;&#34;&#34;Trim notes from a NoteSequence to lie within a specified time range.
+
+  Notes starting before `start_time` are not included. Notes ending after
+  `end_time` are truncated.
+
+  Args:
+    sequence: The NoteSequence for which to trim notes.
+    start_time: The float time in seconds after which all notes should begin.
+    end_time: The float time in seconds before which all notes should end.
+
+  Returns:
+    A copy of `sequence` with all notes trimmed to lie between `start_time` and
+    `end_time`.
+
+  Raises:
+    QuantizationStatusError: If the sequence has already been quantized.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Can only trim notes and chords for unquantized NoteSequence.&#39;)
+
+  subsequence = music_pb2.NoteSequence()
+  subsequence.CopyFrom(sequence)
+
+  del subsequence.notes[:]
+  for note in sequence.notes:
+    if note.start_time &lt; start_time or note.start_time &gt;= end_time:
+      continue
+    new_note = subsequence.notes.add()
+    new_note.CopyFrom(note)
+    new_note.end_time = min(note.end_time, end_time)
+
+  subsequence.total_time = min(sequence.total_time, end_time)
+
+  return subsequence
+
+
+DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS = (
+    64,  # sustain
+    66,  # sostenuto
+    67,  # una corda
+)
+
+
+def _extract_subsequences(sequence, split_times,
+                          preserve_control_numbers=None):
+  &#34;&#34;&#34;Extracts multiple subsequences from a NoteSequence.
+
+  Args:
+    sequence: The NoteSequence to extract subsequences from.
+    split_times: A Python list of subsequence boundary times. The first
+      subsequence will start at `split_times[0]` and end at `split_times[1]`,
+      the next subsequence will start at `split_times[1]` and end at
+      `split_times[2]`, and so on with the last subsequence ending at
+      `split_times[-1]`.
+    preserve_control_numbers: List of control change numbers to preserve as
+      pedal events. The most recent event before the beginning of the
+      subsequence will be inserted at the beginning of the subsequence.
+      If None, will use DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS.
+
+  Returns:
+    A Python list of new NoteSequence containing the subsequences of `sequence`.
+
+  Raises:
+    QuantizationStatusError: If the sequence has already been quantized.
+    ValueError: If there are fewer than 2 split times, or the split times are
+        unsorted, or if any of the subsequences would start past the end of the
+        sequence.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Can only extract subsequences from unquantized NoteSequence.&#39;)
+
+  if len(split_times) &lt; 2:
+    raise ValueError(&#39;Must provide at least a start and end time.&#39;)
+  if any(t1 &gt; t2 for t1, t2 in zip(split_times[:-1], split_times[1:])):
+    raise ValueError(&#39;Split times must be sorted.&#39;)
+  if any(time &gt;= sequence.total_time for time in split_times[:-1]):
+    raise ValueError(&#39;Cannot extract subsequence past end of sequence.&#39;)
+
+  if preserve_control_numbers is None:
+    preserve_control_numbers = DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS
+
+  subsequence = music_pb2.NoteSequence()
+  subsequence.CopyFrom(sequence)
+
+  subsequence.total_time = 0.0
+
+  del subsequence.notes[:]
+  del subsequence.time_signatures[:]
+  del subsequence.key_signatures[:]
+  del subsequence.tempos[:]
+  del subsequence.text_annotations[:]
+  del subsequence.control_changes[:]
+  del subsequence.pitch_bends[:]
+
+  subsequences = [
+      copy.deepcopy(subsequence) for _ in range(len(split_times) - 1)
+  ]
+
+  # Extract notes into subsequences.
+  subsequence_index = -1
+  for note in sorted(sequence.notes, key=lambda note: note.start_time):
+    if note.start_time &lt; split_times[0]:
+      continue
+    while (subsequence_index &lt; len(split_times) - 1 and
+           note.start_time &gt;= split_times[subsequence_index + 1]):
+      subsequence_index += 1
+    if subsequence_index == len(split_times) - 1:
+      break
+    subsequences[subsequence_index].notes.extend([note])
+    subsequences[subsequence_index].notes[-1].start_time -= (
+        split_times[subsequence_index])
+    subsequences[subsequence_index].notes[-1].end_time = min(
+        note.end_time,
+        split_times[subsequence_index + 1]) - split_times[subsequence_index]
+    if (subsequences[subsequence_index].notes[-1].end_time &gt;
+        subsequences[subsequence_index].total_time):
+      subsequences[subsequence_index].total_time = (
+          subsequences[subsequence_index].notes[-1].end_time)
+
+  # Extract time signatures, key signatures, tempos, and chord changes (beats
+  # are handled below, other text annotations and pitch bends are deleted).
+  # Additional state events will be added to the beginning of each subsequence.
+
+  events_by_type = [
+      sequence.time_signatures, sequence.key_signatures, sequence.tempos,
+      [
+          annotation for annotation in sequence.text_annotations
+          if annotation.annotation_type == CHORD_SYMBOL
+      ]
+  ]
+  new_event_containers = [[s.time_signatures for s in subsequences],
+                          [s.key_signatures for s in subsequences],
+                          [s.tempos for s in subsequences],
+                          [s.text_annotations for s in subsequences]]
+
+  for events, containers in zip(events_by_type, new_event_containers):
+    previous_event = None
+    subsequence_index = -1
+    for event in sorted(events, key=lambda event: event.time):
+      if event.time &lt;= split_times[0]:
+        previous_event = event
+        continue
+      while (subsequence_index &lt; len(split_times) - 1 and
+             event.time &gt; split_times[subsequence_index + 1]):
+        subsequence_index += 1
+        if subsequence_index == len(split_times) - 1:
+          break
+        if previous_event is not None:
+          # Add state event to the beginning of the subsequence.
+          containers[subsequence_index].extend([previous_event])
+          containers[subsequence_index][-1].time = 0.0
+      if subsequence_index == len(split_times) - 1:
+        break
+      # Only add the event if it&#39;s actually inside the subsequence (and not on
+      # the boundary with the next one).
+      if event.time &lt; split_times[subsequence_index + 1]:
+        containers[subsequence_index].extend([event])
+        containers[subsequence_index][-1].time -= split_times[subsequence_index]
+      previous_event = event
+    # Add final state event to the beginning of all remaining subsequences.
+    while subsequence_index &lt; len(split_times) - 2:
+      subsequence_index += 1
+      if previous_event is not None:
+        containers[subsequence_index].extend([previous_event])
+        containers[subsequence_index][-1].time = 0.0
+
+  # Copy stateless events to subsequences. Unlike the stateful events above,
+  # stateless events do not have an effect outside of the subsequence in which
+  # they occur.
+  stateless_events_by_type = [[
+      annotation for annotation in sequence.text_annotations
+      if annotation.annotation_type in (BEAT,)
+  ]]
+  new_stateless_event_containers = [[s.text_annotations for s in subsequences]]
+  for events, containers in zip(stateless_events_by_type,
+                                new_stateless_event_containers):
+    subsequence_index = -1
+    for event in sorted(events, key=lambda event: event.time):
+      if event.time &lt; split_times[0]:
+        continue
+      while (subsequence_index &lt; len(split_times) - 1 and
+             event.time &gt;= split_times[subsequence_index + 1]):
+        subsequence_index += 1
+      if subsequence_index == len(split_times) - 1:
+        break
+      containers[subsequence_index].extend([event])
+      containers[subsequence_index][-1].time -= split_times[subsequence_index]
+
+  # Extract piano pedal events (other control changes are deleted). Pedal state
+  # is maintained per-instrument and added to the beginning of each
+  # subsequence.
+  pedal_events = [
+      cc for cc in sequence.control_changes
+      if cc.control_number in preserve_control_numbers
+  ]
+  previous_pedal_events = {}
+  subsequence_index = -1
+  for pedal_event in sorted(pedal_events, key=lambda event: event.time):
+    if pedal_event.time &lt;= split_times[0]:
+      previous_pedal_events[
+          (pedal_event.instrument, pedal_event.control_number)] = pedal_event
+      continue
+    while (subsequence_index &lt; len(split_times) - 1 and
+           pedal_event.time &gt; split_times[subsequence_index + 1]):
+      subsequence_index += 1
+      if subsequence_index == len(split_times) - 1:
+        break
+      # Add the current pedal pedal state to the beginning of the subsequence.
+      for previous_pedal_event in previous_pedal_events.values():
+        subsequences[subsequence_index].control_changes.extend(
+            [previous_pedal_event])
+        subsequences[subsequence_index].control_changes[-1].time = 0.0
+    if subsequence_index == len(split_times) - 1:
+      break
+    # Only add the pedal event if it&#39;s actually inside the subsequence (and
+    # not on the boundary with the next one).
+    if pedal_event.time &lt; split_times[subsequence_index + 1]:
+      subsequences[subsequence_index].control_changes.extend([pedal_event])
+      subsequences[subsequence_index].control_changes[-1].time -= (
+          split_times[subsequence_index])
+    previous_pedal_events[
+        (pedal_event.instrument, pedal_event.control_number)] = pedal_event
+  # Add final pedal pedal state to the beginning of all remaining
+  # subsequences.
+  while subsequence_index &lt; len(split_times) - 2:
+    subsequence_index += 1
+    for previous_pedal_event in previous_pedal_events.values():
+      subsequences[subsequence_index].control_changes.extend(
+          [previous_pedal_event])
+      subsequences[subsequence_index].control_changes[-1].time = 0.0
+
+  # Set subsequence info for all subsequences.
+  for subsequence, start_time in zip(subsequences, split_times[:-1]):
+    subsequence.subsequence_info.start_time_offset = start_time
+    subsequence.subsequence_info.end_time_offset = (
+        sequence.total_time - start_time - subsequence.total_time)
+
+  return subsequences
+
+
+def extract_subsequence(sequence,
+                        start_time,
+                        end_time,
+                        preserve_control_numbers=None):
+  &#34;&#34;&#34;Extracts a subsequence from a NoteSequence.
+
+  Notes starting before `start_time` are not included. Notes ending after
+  `end_time` are truncated. Time signature, tempo, key signature, chord changes,
+  and sustain pedal events outside the specified time range are removed;
+  however, the most recent event of each of these types prior to `start_time` is
+  included at `start_time`. This means that e.g. if a time signature of 3/4 is
+  specified in the original sequence prior to `start_time` (and is not followed
+  by a different time signature), the extracted subsequence will include a 3/4
+  time signature event at `start_time`. Pitch bends and control changes other
+  than sustain are removed entirely.
+
+  The extracted subsequence is shifted to start at time zero.
+
+  Args:
+    sequence: The NoteSequence to extract a subsequence from.
+    start_time: The float time in seconds to start the subsequence.
+    end_time: The float time in seconds to end the subsequence.
+    preserve_control_numbers: List of control change numbers to preserve as
+      pedal events. The most recent event before the beginning of the
+      subsequence will be inserted at the beginning of the subsequence.
+      If None, will use DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS.
+
+
+  Returns:
+    A new NoteSequence containing the subsequence of `sequence` from the
+    specified time range.
+
+  Raises:
+    QuantizationStatusError: If the sequence has already been quantized.
+    ValueError: If `start_time` is past the end of `sequence`.
+  &#34;&#34;&#34;
+  return _extract_subsequences(
+      sequence,
+      split_times=[start_time, end_time],
+      preserve_control_numbers=preserve_control_numbers)[0]
+
+
+def shift_sequence_times(sequence, shift_seconds):
+  &#34;&#34;&#34;Shifts times in a notesequence.
+
+  Only forward shifts are supported.
+
+  Args:
+    sequence: The NoteSequence to shift.
+    shift_seconds: The amount to shift.
+
+  Returns:
+    A new NoteSequence with shifted times.
+
+  Raises:
+    ValueError: If the shift amount is invalid.
+    QuantizationStatusError: If the sequence has already been quantized.
+  &#34;&#34;&#34;
+  if shift_seconds &lt;= 0:
+    raise ValueError(&#39;Invalid shift amount: {}&#39;.format(shift_seconds))
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Can shift only unquantized NoteSequences.&#39;)
+
+  shifted = music_pb2.NoteSequence()
+  shifted.CopyFrom(sequence)
+
+  # Delete subsequence_info because our frame of reference has shifted.
+  shifted.ClearField(&#39;subsequence_info&#39;)
+
+  # Shift notes.
+  for note in shifted.notes:
+    note.start_time += shift_seconds
+    note.end_time += shift_seconds
+
+  events_to_shift = [
+      shifted.time_signatures, shifted.key_signatures, shifted.tempos,
+      shifted.pitch_bends, shifted.control_changes, shifted.text_annotations,
+      shifted.section_annotations
+  ]
+
+  for event in itertools.chain(*events_to_shift):
+    event.time += shift_seconds
+
+  shifted.total_time += shift_seconds
+
+  return shifted
+
+
+def remove_redundant_data(sequence):
+  &#34;&#34;&#34;Returns a copy of the sequence with redundant data removed.
+
+  An event is considered redundant if it is a time signature, a key signature,
+  or a tempo that differs from the previous event of the same type only by time.
+  For example, a tempo mark of 120 qpm at 5 seconds would be considered
+  redundant if it followed a tempo mark of 120 qpm and 4 seconds.
+
+  Fields in sequence_metadata are considered redundant if the same string is
+  repeated.
+
+  Args:
+    sequence: The sequence to process.
+
+  Returns:
+    A new sequence with redundant events removed.
+  &#34;&#34;&#34;
+  fixed_sequence = copy.deepcopy(sequence)
+  for events in [
+      fixed_sequence.time_signatures, fixed_sequence.key_signatures,
+      fixed_sequence.tempos
+  ]:
+    events.sort(key=lambda e: e.time)
+    for i in range(len(events) - 1, 0, -1):
+      tmp_ts = copy.deepcopy(events[i])
+      tmp_ts.time = events[i - 1].time
+      # If the only difference between the two events is time, then delete the
+      # second one.
+      if tmp_ts == events[i - 1]:
+        del events[i]
+
+  if fixed_sequence.HasField(&#39;sequence_metadata&#39;):
+    # Add composers and genres, preserving order, but dropping duplicates.
+    del fixed_sequence.sequence_metadata.composers[:]
+    added_composer = set()
+    for composer in sequence.sequence_metadata.composers:
+      if composer not in added_composer:
+        fixed_sequence.sequence_metadata.composers.append(composer)
+        added_composer.add(composer)
+
+    del fixed_sequence.sequence_metadata.genre[:]
+    added_genre = set()
+    for genre in sequence.sequence_metadata.genre:
+      if genre not in added_genre:
+        fixed_sequence.sequence_metadata.genre.append(genre)
+        added_genre.add(genre)
+
+  return fixed_sequence
+
+
+def concatenate_sequences(sequences, sequence_durations=None):
+  &#34;&#34;&#34;Concatenate a series of NoteSequences together.
+
+  Individual sequences will be shifted using shift_sequence_times and then
+  merged together using the protobuf MergeFrom method. This means that any
+  global values (e.g., ticks_per_quarter) will be overwritten by each sequence
+  and only the final value will be used. After this, redundant data will be
+  removed with remove_redundant_data.
+
+  Args:
+    sequences: A list of sequences to concatenate.
+    sequence_durations: An optional list of sequence durations to use. If not
+      specified, the total_time value will be used. Specifying durations is
+      useful if the sequences to be concatenated are effectively longer than
+      their total_time (e.g., a sequence that ends with a rest).
+
+  Returns:
+    A new sequence that is the result of concatenating *sequences.
+
+  Raises:
+    ValueError: If the length of sequences and sequence_durations do not match
+        or if a specified duration is less than the total_time of the sequence.
+  &#34;&#34;&#34;
+  if sequence_durations and len(sequences) != len(sequence_durations):
+    raise ValueError(
+        &#39;sequences and sequence_durations must be the same length.&#39;)
+  current_total_time = 0
+  cat_seq = music_pb2.NoteSequence()
+  for i in range(len(sequences)):
+    sequence = sequences[i]
+    if sequence_durations and sequence_durations[i] &lt; sequence.total_time:
+      raise ValueError(
+          &#39;Specified sequence duration ({}) must not be less than the &#39;
+          &#39;total_time of the sequence ({})&#39;.format(sequence_durations[i],
+                                                   sequence.total_time))
+    if current_total_time &gt; 0:
+      cat_seq.MergeFrom(shift_sequence_times(sequence, current_total_time))
+    else:
+      cat_seq.MergeFrom(sequence)
+
+    if sequence_durations:
+      current_total_time += sequence_durations[i]
+    else:
+      current_total_time = cat_seq.total_time
+
+  # Delete subsequence_info because we&#39;ve joined several subsequences.
+  cat_seq.ClearField(&#39;subsequence_info&#39;)
+
+  return remove_redundant_data(cat_seq)
+
+
+def repeat_sequence_to_duration(sequence, duration, sequence_duration=None):
+  &#34;&#34;&#34;Repeat a sequence until it is a given duration, trimming any extra.
+
+  Args:
+    sequence: the sequence to repeat
+    duration: the desired duration
+    sequence_duration: If provided, will be used instead of sequence.total_time
+
+  Returns:
+    The repeated and possibly trimmed sequence.
+  &#34;&#34;&#34;
+  if not sequence_duration:
+    sequence_duration = sequence.total_time
+  num_repeats = int(math.ceil(duration / sequence_duration))
+  repeated_ns = concatenate_sequences(
+      [sequence] * num_repeats,
+      sequence_durations=[sequence_duration] * num_repeats)
+
+  trimmed = extract_subsequence(repeated_ns, start_time=0, end_time=duration)
+  trimmed.ClearField(&#39;subsequence_info&#39;)  # Not relevant in this case.
+  return trimmed
+
+
+def expand_section_groups(sequence):
+  &#34;&#34;&#34;Expands a NoteSequence based on its section_groups.
+
+  Args:
+    sequence: The sequence to expand.
+
+  Returns:
+    A copy of the original sequence, expanded based on its section_groups. If
+    the sequence has no section_groups, a copy of the original sequence will be
+    returned.
+  &#34;&#34;&#34;
+  if not sequence.section_groups:
+    return copy.deepcopy(sequence)
+
+  sections = {}
+  section_durations = {}
+  for i in range(len(sequence.section_annotations)):
+    section_id = sequence.section_annotations[i].section_id
+    start_time = sequence.section_annotations[i].time
+    if i &lt; len(sequence.section_annotations) - 1:
+      end_time = sequence.section_annotations[i + 1].time
+    else:
+      end_time = sequence.total_time
+
+    subsequence = extract_subsequence(sequence, start_time, end_time)
+    # This is a subsequence, so the section_groups no longer make sense.
+    del subsequence.section_groups[:]
+    # This subsequence contains only 1 section and it has been shifted to time
+    # 0.
+    del subsequence.section_annotations[:]
+    subsequence.section_annotations.add(time=0, section_id=section_id)
+
+    sections[section_id] = subsequence
+    section_durations[section_id] = end_time - start_time
+
+  # Recursively expand section_groups.
+  def sections_in_group(section_group):
+    sections = []
+    for section in section_group.sections:
+      field = section.WhichOneof(&#39;section_type&#39;)
+      if field == &#39;section_id&#39;:
+        sections.append(section.section_id)
+      elif field == &#39;section_group&#39;:
+        sections.extend(sections_in_group(section.section_group))
+    return sections * section_group.num_times
+
+  sections_to_concat = []
+  for section_group in sequence.section_groups:
+    sections_to_concat.extend(sections_in_group(section_group))
+
+  return concatenate_sequences(
+      [sections[i] for i in sections_to_concat],
+      [section_durations[i] for i in sections_to_concat])
+
+
+def _is_power_of_2(x):
+  return x and not x &amp; (x - 1)
+
+
+def is_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether or not a NoteSequence proto has been quantized.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_quarter or
+  # steps_per_second, assume that the proto has been quantized.
+  return (note_sequence.quantization_info.steps_per_quarter &gt; 0 or
+          note_sequence.quantization_info.steps_per_second &gt; 0)
+
+
+def is_relative_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether a NoteSequence proto has been quantized relative to tempo.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized relative to tempo, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_quarter, assume
+  # that the proto has been quantized relative to tempo.
+  return note_sequence.quantization_info.steps_per_quarter &gt; 0
+
+
+def is_absolute_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether a NoteSequence proto has been quantized by absolute time.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized by absolute time, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_second, assume
+  # that the proto has been quantized by absolute time.
+  return note_sequence.quantization_info.steps_per_second &gt; 0
+
+
+def assert_is_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that the given NoteSequence proto has been quantized.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized.
+  &#34;&#34;&#34;
+  if not is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized.&#39; % note_sequence.id)
+
+
+def assert_is_relative_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that a NoteSequence proto has been quantized relative to tempo.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized relative to
+        tempo.
+  &#34;&#34;&#34;
+  if not is_relative_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized or is &#39;
+        &#39;quantized based on absolute timing.&#39; % note_sequence.id)
+
+
+def assert_is_absolute_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that a NoteSequence proto has been quantized by absolute time.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized by absolute
+    time.
+  &#34;&#34;&#34;
+  if not is_absolute_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized or is &#39;
+        &#39;quantized based on relative timing.&#39; % note_sequence.id)
+
+
+def steps_per_bar_in_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Calculates steps per bar in a NoteSequence that has been quantized.
+
+  Args:
+    note_sequence: The NoteSequence to examine.
+
+  Returns:
+    Steps per bar as a floating point number.
+  &#34;&#34;&#34;
+  assert_is_relative_quantized_sequence(note_sequence)
+
+  quarters_per_beat = 4.0 / note_sequence.time_signatures[0].denominator
+  quarters_per_bar = (
+      quarters_per_beat * note_sequence.time_signatures[0].numerator)
+  steps_per_bar_float = (
+      note_sequence.quantization_info.steps_per_quarter * quarters_per_bar)
+  return steps_per_bar_float
+
+
+def split_note_sequence(note_sequence,
+                        hop_size_seconds,
+                        skip_splits_inside_notes=False):
+  &#34;&#34;&#34;Split one NoteSequence into many at specified time intervals.
+
+  If `hop_size_seconds` is a scalar, this function splits a NoteSequence into
+  multiple NoteSequences, all of fixed size (unless `split_notes` is False, in
+  which case splits that would have truncated notes will be skipped; i.e. each
+  split will either happen at a multiple of `hop_size_seconds` or not at all).
+  Each of the resulting NoteSequences is shifted to start at time zero.
+
+  If `hop_size_seconds` is a list, the NoteSequence will be split at each time
+  in the list (unless `split_notes` is False as above).
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    hop_size_seconds: The hop size, in seconds, at which the NoteSequence will
+      be split. Alternatively, this can be a Python list of times in seconds at
+      which to split the NoteSequence.
+    skip_splits_inside_notes: If False, the NoteSequence will be split at all
+      hop positions, regardless of whether or not any notes are sustained across
+      the potential split time, thus sustained notes will be truncated. If True,
+      the NoteSequence will not be split at positions that occur within
+      sustained notes.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+  note_idx = 0
+  notes_crossing_split = []
+
+  if isinstance(hop_size_seconds, list):
+    split_times = sorted(hop_size_seconds)
+  else:
+    split_times = np.arange(hop_size_seconds, note_sequence.total_time,
+                            hop_size_seconds)
+
+  valid_split_times = [0.0]
+
+  for split_time in split_times:
+    # Update notes crossing potential split.
+    while (note_idx &lt; len(notes_by_start_time) and
+           notes_by_start_time[note_idx].start_time &lt; split_time):
+      notes_crossing_split.append(notes_by_start_time[note_idx])
+      note_idx += 1
+    notes_crossing_split = [
+        note for note in notes_crossing_split if note.end_time &gt; split_time
+    ]
+
+    if not (skip_splits_inside_notes and notes_crossing_split):
+      valid_split_times.append(split_time)
+
+  # Handle the final subsequence.
+  if note_sequence.total_time &gt; valid_split_times[-1]:
+    valid_split_times.append(note_sequence.total_time)
+
+  if len(valid_split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, valid_split_times)
+  else:
+    return []
+
+
+def split_note_sequence_on_time_changes(note_sequence,
+                                        skip_splits_inside_notes=False):
+  &#34;&#34;&#34;Split one NoteSequence into many around time signature and tempo changes.
+
+  This function splits a NoteSequence into multiple NoteSequences, each of which
+  contains only a single time signature and tempo, unless `split_notes` is False
+  in which case all time signature and tempo changes occur within sustained
+  notes. Each of the resulting NoteSequences is shifted to start at time zero.
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    skip_splits_inside_notes: If False, the NoteSequence will be split at all
+      time changes, regardless of whether or not any notes are sustained across
+      the time change. If True, the NoteSequence will not be split at time
+      changes that occur within sustained notes.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  current_numerator = 4
+  current_denominator = 4
+  current_qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  time_signatures_and_tempos = sorted(
+      list(note_sequence.time_signatures) + list(note_sequence.tempos),
+      key=lambda t: t.time)
+  time_signatures_and_tempos = [
+      t for t in time_signatures_and_tempos if t.time &lt; note_sequence.total_time
+  ]
+
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+  note_idx = 0
+  notes_crossing_split = []
+
+  valid_split_times = [0.0]
+
+  for time_change in time_signatures_and_tempos:
+    if isinstance(time_change, music_pb2.NoteSequence.TimeSignature):
+      if (time_change.numerator == current_numerator and
+          time_change.denominator == current_denominator):
+        # Time signature didn&#39;t actually change.
+        continue
+    else:
+      if time_change.qpm == current_qpm:
+        # Tempo didn&#39;t actually change.
+        continue
+
+    # Update notes crossing potential split.
+    while (note_idx &lt; len(notes_by_start_time) and
+           notes_by_start_time[note_idx].start_time &lt; time_change.time):
+      notes_crossing_split.append(notes_by_start_time[note_idx])
+      note_idx += 1
+    notes_crossing_split = [
+        note for note in notes_crossing_split
+        if note.end_time &gt; time_change.time
+    ]
+
+    if time_change.time &gt; valid_split_times[-1]:
+      if not (skip_splits_inside_notes and notes_crossing_split):
+        valid_split_times.append(time_change.time)
+
+    # Even if we didn&#39;t split here, update the current time signature or tempo.
+    if isinstance(time_change, music_pb2.NoteSequence.TimeSignature):
+      current_numerator = time_change.numerator
+      current_denominator = time_change.denominator
+    else:
+      current_qpm = time_change.qpm
+
+  # Handle the final subsequence.
+  if note_sequence.total_time &gt; valid_split_times[-1]:
+    valid_split_times.append(note_sequence.total_time)
+
+  if len(valid_split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, valid_split_times)
+  else:
+    return []
+
+
+def split_note_sequence_on_silence(note_sequence, gap_seconds=3.0):
+  &#34;&#34;&#34;Split one NoteSequence into many around gaps of silence.
+
+  This function splits a NoteSequence into multiple NoteSequences, each of which
+  contains no gaps of silence longer than `gap_seconds`. Each of the resulting
+  NoteSequences is shifted such that the first note starts at time zero.
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    gap_seconds: The maximum amount of contiguous silence to allow within a
+        NoteSequence, in seconds.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+
+  split_times = [0.0]
+  last_active_time = 0.0
+
+  for note in notes_by_start_time:
+    if note.start_time &gt; last_active_time + gap_seconds:
+      split_times.append(note.start_time)
+    last_active_time = max(last_active_time, note.end_time)
+
+  if note_sequence.total_time &gt; split_times[-1]:
+    split_times.append(note_sequence.total_time)
+
+  if len(split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, split_times)
+  else:
+    return []
+
+
+def quantize_to_step(unquantized_seconds,
+                     steps_per_second,
+                     quantize_cutoff=QUANTIZE_CUTOFF):
+  &#34;&#34;&#34;Quantizes seconds to the nearest step, given steps_per_second.
+
+  See the comments above `QUANTIZE_CUTOFF` for details on how the quantizing
+  algorithm works.
+
+  Args:
+    unquantized_seconds: Seconds to quantize.
+    steps_per_second: Quantizing resolution.
+    quantize_cutoff: Value to use for quantizing cutoff.
+
+  Returns:
+    The input value quantized to the nearest step.
+  &#34;&#34;&#34;
+  unquantized_steps = unquantized_seconds * steps_per_second
+  return int(unquantized_steps + (1 - quantize_cutoff))
+
+
+def steps_per_quarter_to_steps_per_second(steps_per_quarter, qpm):
+  &#34;&#34;&#34;Calculates steps per second given steps_per_quarter and a qpm.&#34;&#34;&#34;
+  return steps_per_quarter * qpm / 60.0
+
+
+def _quantize_notes(note_sequence, steps_per_second):
+  &#34;&#34;&#34;Quantize the notes and chords of a NoteSequence proto in place.
+
+  Note start and end times, and chord times are snapped to a nearby quantized
+  step, and the resulting times are stored in a separate field (e.g.,
+  quantized_start_step). See the comments above `QUANTIZE_CUTOFF` for details on
+  how the quantizing algorithm works.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence protocol buffer. Will be modified in
+      place.
+    steps_per_second: Each second will be divided into this many quantized time
+      steps.
+
+  Raises:
+    NegativeTimeError: If a note or chord occurs at a negative time.
+  &#34;&#34;&#34;
+  for note in note_sequence.notes:
+    # Quantize the start and end times of the note.
+    note.quantized_start_step = quantize_to_step(note.start_time,
+                                                 steps_per_second)
+    note.quantized_end_step = quantize_to_step(note.end_time, steps_per_second)
+    if note.quantized_end_step == note.quantized_start_step:
+      note.quantized_end_step += 1
+
+    # Do not allow notes to start or end in negative time.
+    if note.quantized_start_step &lt; 0 or note.quantized_end_step &lt; 0:
+      raise NegativeTimeError(
+          &#39;Got negative note time: start_step = %s, end_step = %s&#39; %
+          (note.quantized_start_step, note.quantized_end_step))
+
+    # Extend quantized sequence if necessary.
+    if note.quantized_end_step &gt; note_sequence.total_quantized_steps:
+      note_sequence.total_quantized_steps = note.quantized_end_step
+
+  # Also quantize control changes and text annotations.
+  for event in itertools.chain(note_sequence.control_changes,
+                               note_sequence.text_annotations):
+    # Quantize the event time, disallowing negative time.
+    event.quantized_step = quantize_to_step(event.time, steps_per_second)
+    if event.quantized_step &lt; 0:
+      raise NegativeTimeError(
+          &#39;Got negative event time: step = %s&#39; % event.quantized_step)
+
+
+def quantize_note_sequence(note_sequence, steps_per_quarter):
+  &#34;&#34;&#34;Quantize a NoteSequence proto relative to tempo.
+
+  The input NoteSequence is copied and quantization-related fields are
+  populated. Sets the `steps_per_quarter` field in the `quantization_info`
+  message in the NoteSequence.
+
+  Note start and end times, and chord times are snapped to a nearby quantized
+  step, and the resulting times are stored in a separate field (e.g.,
+  quantized_start_step). See the comments above `QUANTIZE_CUTOFF` for details on
+  how the quantizing algorithm works.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence protocol buffer.
+    steps_per_quarter: Each quarter note of music will be divided into this many
+      quantized time steps.
+
+  Returns:
+    A copy of the original NoteSequence, with quantized times added.
+
+  Raises:
+    MultipleTimeSignatureError: If there is a change in time signature
+        in `note_sequence`.
+    MultipleTempoError: If there is a change in tempo in `note_sequence`.
+    BadTimeSignatureError: If the time signature found in `note_sequence`
+        has a 0 numerator or a denominator which is not a power of 2.
+    NegativeTimeError: If a note or chord occurs at a negative time.
+  &#34;&#34;&#34;
+  qns = copy.deepcopy(note_sequence)
+
+  qns.quantization_info.steps_per_quarter = steps_per_quarter
+
+  if qns.time_signatures:
+    time_signatures = sorted(qns.time_signatures, key=lambda ts: ts.time)
+    # There is an implicit 4/4 time signature at 0 time. So if the first time
+    # signature is something other than 4/4 and it&#39;s at a time other than 0,
+    # that&#39;s an implicit time signature change.
+    if time_signatures[0].time != 0 and not (
+        time_signatures[0].numerator == 4 and
+        time_signatures[0].denominator == 4):
+      raise MultipleTimeSignatureError(
+          &#39;NoteSequence has an implicit change from initial 4/4 time &#39;
+          &#39;signature to %d/%d at %.2f seconds.&#39; %
+          (time_signatures[0].numerator, time_signatures[0].denominator,
+           time_signatures[0].time))
+
+    for time_signature in time_signatures[1:]:
+      if (time_signature.numerator != qns.time_signatures[0].numerator or
+          time_signature.denominator != qns.time_signatures[0].denominator):
+        raise MultipleTimeSignatureError(
+            &#39;NoteSequence has at least one time signature change from %d/%d to &#39;
+            &#39;%d/%d at %.2f seconds.&#39; %
+            (time_signatures[0].numerator, time_signatures[0].denominator,
+             time_signature.numerator, time_signature.denominator,
+             time_signature.time))
+
+    # Make it clear that there is only 1 time signature and it starts at the
+    # beginning.
+    qns.time_signatures[0].time = 0
+    del qns.time_signatures[1:]
+  else:
+    time_signature = qns.time_signatures.add()
+    time_signature.numerator = 4
+    time_signature.denominator = 4
+    time_signature.time = 0
+
+  if not _is_power_of_2(qns.time_signatures[0].denominator):
+    raise BadTimeSignatureError(
+        &#39;Denominator is not a power of 2. Time signature: %d/%d&#39; %
+        (qns.time_signatures[0].numerator, qns.time_signatures[0].denominator))
+
+  if qns.time_signatures[0].numerator == 0:
+    raise BadTimeSignatureError(
+        &#39;Numerator is 0. Time signature: %d/%d&#39; %
+        (qns.time_signatures[0].numerator, qns.time_signatures[0].denominator))
+
+  if qns.tempos:
+    tempos = sorted(qns.tempos, key=lambda t: t.time)
+    # There is an implicit 120.0 qpm tempo at 0 time. So if the first tempo is
+    # something other that 120.0 and it&#39;s at a time other than 0, that&#39;s an
+    # implicit tempo change.
+    if tempos[0].time != 0 and (tempos[0].qpm !=
+                                constants.DEFAULT_QUARTERS_PER_MINUTE):
+      raise MultipleTempoError(
+          &#39;NoteSequence has an implicit tempo change from initial %.1f qpm to &#39;
+          &#39;%.1f qpm at %.2f seconds.&#39; % (constants.DEFAULT_QUARTERS_PER_MINUTE,
+                                         tempos[0].qpm, tempos[0].time))
+
+    for tempo in tempos[1:]:
+      if tempo.qpm != qns.tempos[0].qpm:
+        raise MultipleTempoError(
+            &#39;NoteSequence has at least one tempo change from %.1f qpm to %.1f &#39;
+            &#39;qpm at %.2f seconds.&#39; % (tempos[0].qpm, tempo.qpm, tempo.time))
+
+    # Make it clear that there is only 1 tempo and it starts at the beginning.
+    qns.tempos[0].time = 0
+    del qns.tempos[1:]
+  else:
+    tempo = qns.tempos.add()
+    tempo.qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+    tempo.time = 0
+
+  # Compute quantization steps per second.
+  steps_per_second = steps_per_quarter_to_steps_per_second(
+      steps_per_quarter, qns.tempos[0].qpm)
+
+  qns.total_quantized_steps = quantize_to_step(qns.total_time, steps_per_second)
+  _quantize_notes(qns, steps_per_second)
+
+  return qns
+
+
+def quantize_note_sequence_absolute(note_sequence, steps_per_second):
+  &#34;&#34;&#34;Quantize a NoteSequence proto using absolute event times.
+
+  The input NoteSequence is copied and quantization-related fields are
+  populated. Sets the `steps_per_second` field in the `quantization_info`
+  message in the NoteSequence.
+
+  Note start and end times, and chord times are snapped to a nearby quantized
+  step, and the resulting times are stored in a separate field (e.g.,
+  quantized_start_step). See the comments above `QUANTIZE_CUTOFF` for details on
+  how the quantizing algorithm works.
+
+  Tempos and time signatures will be copied but ignored.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence protocol buffer.
+    steps_per_second: Each second will be divided into this many quantized time
+      steps.
+
+  Returns:
+    A copy of the original NoteSequence, with quantized times added.
+
+  Raises:
+    NegativeTimeError: If a note or chord occurs at a negative time.
+  &#34;&#34;&#34;
+  qns = copy.deepcopy(note_sequence)
+  qns.quantization_info.steps_per_second = steps_per_second
+
+  qns.total_quantized_steps = quantize_to_step(qns.total_time, steps_per_second)
+  _quantize_notes(qns, steps_per_second)
+
+  return qns
+
+
+def transpose_note_sequence(ns,
+                            amount,
+                            min_allowed_pitch=constants.MIN_MIDI_PITCH,
+                            max_allowed_pitch=constants.MAX_MIDI_PITCH,
+                            transpose_chords=True,
+                            in_place=False):
+  &#34;&#34;&#34;Transposes note sequence specified amount, deleting out-of-bound notes.
+
+  Args:
+    ns: The NoteSequence proto to be transposed.
+    amount: Number of half-steps to transpose up or down.
+    min_allowed_pitch: Minimum pitch allowed in transposed NoteSequence. Notes
+      assigned lower pitches will be deleted.
+    max_allowed_pitch: Maximum pitch allowed in transposed NoteSequence. Notes
+      assigned higher pitches will be deleted.
+    transpose_chords: If True, also transpose chord symbol text annotations. If
+      False, chord symbols will be removed.
+    in_place: If True, the input note_sequence is edited directly.
+
+  Returns:
+    The transposed NoteSequence and a count of how many notes were deleted.
+
+  Raises:
+    ChordSymbolError: If a chord symbol is unable to be transposed.
+  &#34;&#34;&#34;
+  if not in_place:
+    new_ns = music_pb2.NoteSequence()
+    new_ns.CopyFrom(ns)
+    ns = new_ns
+
+  new_note_list = []
+  deleted_note_count = 0
+  end_time = 0
+
+  for note in ns.notes:
+    new_pitch = note.pitch + amount
+    if (min_allowed_pitch &lt;= new_pitch &lt;= max_allowed_pitch) or note.is_drum:
+      end_time = max(end_time, note.end_time)
+
+      if not note.is_drum:
+        note.pitch += amount
+
+        # The pitch name, if present, will no longer be valid.
+        note.pitch_name = UNKNOWN_PITCH_NAME
+
+      new_note_list.append(note)
+    else:
+      deleted_note_count += 1
+
+  if deleted_note_count &gt; 0:
+    del ns.notes[:]
+    ns.notes.extend(new_note_list)
+
+  # Since notes were deleted, we may need to update the total time.
+  ns.total_time = end_time
+
+  if transpose_chords:
+    # Also update the chord symbol text annotations. This can raise a
+    # ChordSymbolError if a chord symbol cannot be interpreted.
+    for ta in ns.text_annotations:
+      if ta.annotation_type == CHORD_SYMBOL and ta.text != constants.NO_CHORD:
+        ta.text = chord_symbols_lib.transpose_chord_symbol(ta.text, amount)
+  else:
+    # Remove chord symbol text annotations.
+    text_annotations_to_keep = []
+    for ta in ns.text_annotations:
+      if ta.annotation_type != CHORD_SYMBOL:
+        text_annotations_to_keep.append(ta)
+    if len(text_annotations_to_keep) &lt; len(ns.text_annotations):
+      del ns.text_annotations[:]
+      ns.text_annotations.extend(text_annotations_to_keep)
+
+  # Also transpose key signatures.
+  for ks in ns.key_signatures:
+    ks.key = (ks.key + amount) % 12
+
+  return ns, deleted_note_count
+
+
+def _clamp_transpose(transpose_amount, ns_min_pitch, ns_max_pitch,
+                     min_allowed_pitch, max_allowed_pitch):
+  &#34;&#34;&#34;Clamps the specified transpose amount to keep a ns in the desired bounds.
+
+  Args:
+    transpose_amount: Number of steps to transpose up or down.
+    ns_min_pitch: The lowest pitch in the target note sequence.
+    ns_max_pitch: The highest pitch in the target note sequence.
+    min_allowed_pitch: The lowest pitch that should be allowed in the transposed
+      note sequence.
+    max_allowed_pitch: The highest pitch that should be allowed in the
+      transposed note sequence.
+
+  Returns:
+    A new transpose amount that, if applied to the target note sequence, will
+    keep all notes within the range [MIN_PITCH, MAX_PITCH]
+  &#34;&#34;&#34;
+  if transpose_amount &lt; 0:
+    transpose_amount = -min(ns_min_pitch - min_allowed_pitch,
+                            abs(transpose_amount))
+  else:
+    transpose_amount = min(max_allowed_pitch - ns_max_pitch, transpose_amount)
+  return transpose_amount
+
+
+def augment_note_sequence(ns,
+                          min_stretch_factor,
+                          max_stretch_factor,
+                          min_transpose,
+                          max_transpose,
+                          min_allowed_pitch=constants.MIN_MIDI_PITCH,
+                          max_allowed_pitch=constants.MAX_MIDI_PITCH,
+                          delete_out_of_range_notes=False):
+  &#34;&#34;&#34;Modifed a NoteSequence with random stretching and transposition.
+
+  This method can be used to augment a dataset for training neural nets.
+  Note that the provided ns is modified in place.
+
+  Args:
+    ns: A NoteSequence proto to be augmented.
+    min_stretch_factor: Minimum amount to stretch/compress the NoteSequence.
+    max_stretch_factor: Maximum amount to stretch/compress the NoteSequence.
+    min_transpose: Minimum number of steps to transpose the NoteSequence.
+    max_transpose: Maximum number of steps to transpose the NoteSequence.
+    min_allowed_pitch: The lowest pitch permitted (ie, for regular piano this
+      should be set to 21.)
+    max_allowed_pitch: The highest pitch permitted (ie, for regular piano this
+      should be set to 108.)
+    delete_out_of_range_notes: If true, a transposition amount will be chosen on
+      the interval [min_transpose, max_transpose], and any out-of-bounds notes
+      will be deleted. If false, the interval [min_transpose, max_transpose]
+      will be truncated such that no out-of-bounds notes will ever be created.
+  TODO(dei): Add support for specifying custom distributions over possible
+    values of note stretch and transposition amount.
+
+  Returns:
+    The randomly augmented NoteSequence.
+
+  Raises:
+    ValueError: If mins in ranges are larger than maxes.
+  &#34;&#34;&#34;
+  if min_stretch_factor &gt; max_stretch_factor:
+    raise ValueError(&#39;min_stretch_factor should be &lt;= max_stretch_factor&#39;)
+  if min_allowed_pitch &gt; max_allowed_pitch:
+    raise ValueError(&#39;min_allowed_pitch should be &lt;= max_allowed_pitch&#39;)
+  if min_transpose &gt; max_transpose:
+    raise ValueError(&#39;min_transpose should be &lt;= max_transpose&#39;)
+
+  if ns.notes:
+    # Choose random factor by which to stretch or compress note sequence.
+    stretch_factor = random.uniform(min_stretch_factor, max_stretch_factor)
+    ns = stretch_note_sequence(ns, stretch_factor, in_place=True)
+
+    # Choose amount by which to translate the note sequence.
+    if delete_out_of_range_notes:
+      # If transposition takes a note outside of the allowed note bounds,
+      # we will just delete it.
+      transposition_amount = random.randint(min_transpose, max_transpose)
+    else:
+      # Prevent transposition from taking a note outside of the allowed note
+      # bounds by clamping the range we sample from.
+      ns_min_pitch = min(ns.notes, key=lambda note: note.pitch).pitch
+      ns_max_pitch = max(ns.notes, key=lambda note: note.pitch).pitch
+
+      if ns_min_pitch &lt; min_allowed_pitch:
+        logging.warn(
+            &#39;A note sequence has some pitch=%d, which is less &#39;
+            &#39;than min_allowed_pitch=%d&#39;, ns_min_pitch, min_allowed_pitch)
+      if ns_max_pitch &gt; max_allowed_pitch:
+        logging.warn(
+            &#39;A note sequence has some pitch=%d, which is greater &#39;
+            &#39;than max_allowed_pitch=%d&#39;, ns_max_pitch, max_allowed_pitch)
+
+      min_transpose = _clamp_transpose(min_transpose, ns_min_pitch,
+                                       ns_max_pitch, min_allowed_pitch,
+                                       max_allowed_pitch)
+      max_transpose = _clamp_transpose(max_transpose, ns_min_pitch,
+                                       ns_max_pitch, min_allowed_pitch,
+                                       max_allowed_pitch)
+      transposition_amount = random.randint(min_transpose, max_transpose)
+
+    ns, _ = transpose_note_sequence(
+        ns,
+        transposition_amount,
+        min_allowed_pitch,
+        max_allowed_pitch,
+        in_place=True)
+
+  return ns
+
+
+def stretch_note_sequence(note_sequence, stretch_factor, in_place=False):
+  &#34;&#34;&#34;Apply a constant temporal stretch to a NoteSequence proto.
+
+  Args:
+    note_sequence: The NoteSequence to stretch.
+    stretch_factor: How much to stretch the NoteSequence. Values greater than
+      one increase the length of the NoteSequence (making it &#34;slower&#34;). Values
+      less than one decrease the length of the NoteSequence (making it
+      &#34;faster&#34;).
+    in_place: If True, the input note_sequence is edited directly.
+
+  Returns:
+    A stretched copy of the original NoteSequence.
+
+  Raises:
+    QuantizationStatusError: If the `note_sequence` is quantized. Only
+        unquantized NoteSequences can be stretched.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;Can only stretch unquantized NoteSequence.&#39;)
+
+  if in_place:
+    stretched_sequence = note_sequence
+  else:
+    stretched_sequence = music_pb2.NoteSequence()
+    stretched_sequence.CopyFrom(note_sequence)
+
+  if stretch_factor == 1.0:
+    return stretched_sequence
+
+  # Stretch all notes.
+  for note in stretched_sequence.notes:
+    note.start_time *= stretch_factor
+    note.end_time *= stretch_factor
+  stretched_sequence.total_time *= stretch_factor
+
+  # Stretch all other event times.
+  events = itertools.chain(
+      stretched_sequence.time_signatures, stretched_sequence.key_signatures,
+      stretched_sequence.tempos, stretched_sequence.pitch_bends,
+      stretched_sequence.control_changes, stretched_sequence.text_annotations)
+  for event in events:
+    event.time *= stretch_factor
+
+  # Stretch tempos.
+  for tempo in stretched_sequence.tempos:
+    tempo.qpm /= stretch_factor
+
+  return stretched_sequence
+
+
+def adjust_notesequence_times(ns, time_func, minimum_duration=None):
+  &#34;&#34;&#34;Adjusts notesequence timings given an adjustment function.
+
+  Note that only notes, control changes, and pitch bends are adjusted. All other
+  events are ignored.
+
+  If the adjusted version of a note ends before or at the same time it begins,
+  it will be skipped.
+
+  Args:
+    ns: The NoteSequence to adjust.
+    time_func: A function that takes a time (in seconds) and returns an adjusted
+        version of that time. This function is expected to be monotonic, i.e. if
+        `t1 &lt;= t2` then `time_func(t1) &lt;= time_func(t2)`. In addition, if
+        `t &gt;= 0` then it should also be true that `time_func(t) &gt;= 0`. The
+        monotonicity property is not checked for all pairs of event times, only
+        the start and end times of each note, but you may get strange results if
+        `time_func` is non-monotonic.
+    minimum_duration: If time_func results in a duration of 0, instead
+        substitute this duration and do not increment the skipped_notes counter.
+        If None, the note will be skipped.
+
+  Raises:
+    InvalidTimeAdjustmentError: If a note has an adjusted end time that is
+        before its start time, or if any event times are shifted before zero.
+
+  Returns:
+    adjusted_ns: A new NoteSequence with adjusted times.
+    skipped_notes: A count of how many notes were skipped.
+  &#34;&#34;&#34;
+  adjusted_ns = copy.deepcopy(ns)
+
+  # Iterate through the original NoteSequence notes to make it easier to drop
+  # skipped notes from the adjusted NoteSequence.
+  adjusted_ns.total_time = 0
+  skipped_notes = 0
+  del adjusted_ns.notes[:]
+  for note in ns.notes:
+    start_time = time_func(note.start_time)
+    end_time = time_func(note.end_time)
+
+    if start_time == end_time:
+      if minimum_duration:
+        logging.warn(
+            &#39;Adjusting note duration of 0 to new minimum duration of %f. &#39;
+            &#39;Original start: %f, end %f. New start %f, end %f.&#39;,
+            minimum_duration, note.start_time, note.end_time, start_time,
+            end_time)
+        end_time += minimum_duration
+      else:
+        logging.warn(
+            &#39;Skipping note that ends before or at the same time it begins. &#39;
+            &#39;Original start: %f, end %f. New start %f, end %f.&#39;,
+            note.start_time, note.end_time, start_time, end_time)
+        skipped_notes += 1
+        continue
+
+    if end_time &lt; start_time:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust end time to before start time. &#39;
+          &#39;Original start: %f, end %f. New start %f, end %f.&#39; %
+          (note.start_time, note.end_time, start_time, end_time))
+
+    if start_time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust note start time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (note.start_time, start_time))
+
+    if end_time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust note end time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (note.end_time, end_time))
+
+    if end_time &gt; adjusted_ns.total_time:
+      adjusted_ns.total_time = end_time
+
+    adjusted_note = adjusted_ns.notes.add()
+    adjusted_note.MergeFrom(note)
+    adjusted_note.start_time = start_time
+    adjusted_note.end_time = end_time
+
+  events = itertools.chain(
+      adjusted_ns.control_changes,
+      adjusted_ns.pitch_bends,
+      adjusted_ns.time_signatures,
+      adjusted_ns.key_signatures,
+      adjusted_ns.text_annotations
+  )
+
+  for event in events:
+    time = time_func(event.time)
+    if time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust event time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (event.time, time))
+    event.time = time
+
+  # Adjusting tempos to accommodate arbitrary time adjustments is too
+  # complicated. Just delete them.
+  del adjusted_ns.tempos[:]
+
+  return adjusted_ns, skipped_notes
+
+
+def rectify_beats(sequence, beats_per_minute):
+  &#34;&#34;&#34;Warps a NoteSequence so that beats happen at regular intervals.
+
+  Args:
+    sequence: The source NoteSequence. Will not be modified.
+    beats_per_minute: Desired BPM of the rectified sequence.
+
+  Returns:
+    rectified_sequence: A copy of `sequence` with times adjusted so that beats
+        occur at regular intervals with BPM `beats_per_minute`.
+    alignment: An N-by-2 array where each row contains the original and
+        rectified times for a beat.
+
+  Raises:
+    QuantizationStatusError: If `sequence` is quantized.
+    RectifyBeatsError: If `sequence` has no beat annotations.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Cannot rectify beat times for quantized NoteSequence.&#39;)
+
+  beat_times = [
+      ta.time for ta in sequence.text_annotations
+      if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.BEAT
+      and ta.time &lt;= sequence.total_time
+  ]
+
+  if not beat_times:
+    raise RectifyBeatsError(&#39;No beats in NoteSequence.&#39;)
+
+  # Add a beat at the very beginning and end of the sequence and dedupe.
+  sorted_beat_times = [0.0] + sorted(beat_times) + [sequence.total_time]
+  unique_beat_times = np.array([
+      sorted_beat_times[i] for i in range(len(sorted_beat_times))
+      if i == 0 or sorted_beat_times[i] &gt; sorted_beat_times[i - 1]
+  ])
+  num_beats = len(unique_beat_times)
+
+  # Use linear interpolation to map original times to rectified times.
+  seconds_per_beat = 60.0 / beats_per_minute
+  rectified_beat_times = seconds_per_beat * np.arange(num_beats)
+  def time_func(t):
+    return np.interp(t, unique_beat_times, rectified_beat_times,
+                     left=0.0, right=sequence.total_time)
+
+  rectified_sequence, _ = adjust_notesequence_times(sequence, time_func)
+
+  # Sequence probably shouldn&#39;t have time signatures but delete them just to be
+  # sure, and add a single tempo.
+  del rectified_sequence.time_signatures[:]
+  rectified_sequence.tempos.add(qpm=beats_per_minute)
+
+  return rectified_sequence, np.array([unique_beat_times,
+                                       rectified_beat_times]).T
+
+
+# Constants for processing the note/sustain stream.
+# The order here matters because we we want to process &#39;on&#39; events before we
+# process &#39;off&#39; events, and we want to process sustain events before note
+# events.
+_SUSTAIN_ON = 0
+_SUSTAIN_OFF = 1
+_NOTE_ON = 2
+_NOTE_OFF = 3
+
+
+def apply_sustain_control_changes(note_sequence, sustain_control_number=64):
+  &#34;&#34;&#34;Returns a new NoteSequence with sustain pedal control changes applied.
+
+  Extends each note within a sustain to either the beginning of the next note of
+  the same pitch or the end of the sustain period, whichever happens first. This
+  is done on a per instrument basis, so notes are only affected by sustain
+  events for the same instrument.
+
+  Drum notes will not be modified.
+
+  Args:
+    note_sequence: The NoteSequence for which to apply sustain. This object will
+      not be modified.
+    sustain_control_number: The MIDI control number for sustain pedal. Control
+      events with this number and value 0-63 will be treated as sustain pedal
+      OFF events, and control events with this number and value 64-127 will be
+      treated as sustain pedal ON events.
+
+  Returns:
+    A copy of `note_sequence` but with note end times extended to account for
+    sustain.
+
+  Raises:
+    QuantizationStatusError: If `note_sequence` is quantized. Sustain can
+        only be applied to unquantized note sequences.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;Can only apply sustain to unquantized NoteSequence.&#39;)
+
+  sequence = copy.deepcopy(note_sequence)
+
+  # Sort all note on/off and sustain on/off events.
+  events = []
+  events.extend([(note.start_time, _NOTE_ON, note) for note in sequence.notes
+                 if not note.is_drum])
+  events.extend([(note.end_time, _NOTE_OFF, note) for note in sequence.notes
+                 if not note.is_drum])
+
+  for cc in sequence.control_changes:
+    if cc.control_number != sustain_control_number:
+      continue
+    value = cc.control_value
+    if value &lt; 0 or value &gt; 127:
+      logging.warn(&#39;Sustain control change has out of range value: %d&#39;, value)
+    if value &gt;= 64:
+      events.append((cc.time, _SUSTAIN_ON, cc))
+    elif value &lt; 64:
+      events.append((cc.time, _SUSTAIN_OFF, cc))
+
+  # Sort, using the time and event type constants to ensure the order events are
+  # processed.
+  events.sort(key=operator.itemgetter(0, 1))
+
+  # Lists of active notes, keyed by instrument.
+  active_notes = collections.defaultdict(list)
+  # Whether sustain is active for a given instrument.
+  sus_active = collections.defaultdict(lambda: False)
+
+  # Iterate through all sustain on/off and note on/off events in order.
+  time = 0
+  for time, event_type, event in events:
+    if event_type == _SUSTAIN_ON:
+      sus_active[event.instrument] = True
+    elif event_type == _SUSTAIN_OFF:
+      sus_active[event.instrument] = False
+      # End all notes for the instrument that were being extended.
+      new_active_notes = []
+      for note in active_notes[event.instrument]:
+        if note.end_time &lt; time:
+          # This note was being extended because of sustain.
+          # Update the end time and don&#39;t keep it in the list.
+          note.end_time = time
+          if time &gt; sequence.total_time:
+            sequence.total_time = time
+        else:
+          # This note is actually still active, keep it.
+          new_active_notes.append(note)
+      active_notes[event.instrument] = new_active_notes
+    elif event_type == _NOTE_ON:
+      if sus_active[event.instrument]:
+        # If sustain is on, end all previous notes with the same pitch.
+        new_active_notes = []
+        for note in active_notes[event.instrument]:
+          if note.pitch == event.pitch:
+            note.end_time = time
+            if note.start_time == note.end_time:
+              # This note now has no duration because another note of the same
+              # pitch started at the same time. Only one of these notes should
+              # be preserved, so delete this one.
+              # TODO(fjord): A more correct solution would probably be to
+              # preserve both notes and make the same duration, but that is a
+              # little more complicated to implement. Will keep this solution
+              # until we find that we need the more complex one.
+              sequence.notes.remove(note)
+          else:
+            new_active_notes.append(note)
+        active_notes[event.instrument] = new_active_notes
+      # Add this new note to the list of active notes.
+      active_notes[event.instrument].append(event)
+    elif event_type == _NOTE_OFF:
+      if sus_active[event.instrument]:
+        # Note continues until another note of the same pitch or sustain ends.
+        pass
+      else:
+        # Remove this particular note from the active list.
+        # It may have already been removed if a note of the same pitch was
+        # played when sustain was active.
+        if event in active_notes[event.instrument]:
+          active_notes[event.instrument].remove(event)
+    else:
+      raise AssertionError(&#39;Invalid event_type: %s&#39; % event_type)
+
+  # End any notes that were still active due to sustain.
+  for instrument in active_notes.values():
+    for note in instrument:
+      note.end_time = time
+      sequence.total_time = time
+
+  return sequence
+
+
+def infer_dense_chords_for_sequence(sequence,
+                                    instrument=None,
+                                    min_notes_per_chord=3):
+  &#34;&#34;&#34;Infers chords for a NoteSequence and adds them as TextAnnotations.
+
+  For each set of simultaneously-active notes in a NoteSequence (optionally for
+  only one instrument), infers a chord symbol and adds it to NoteSequence as a
+  TextAnnotation. Every change in the set of active notes will result in a new
+  chord symbol unless the new set is smaller than `min_notes_per_chord`.
+
+  If `sequence` is quantized, simultaneity will be determined by quantized steps
+  instead of time.
+
+  Not to be confused with the chord inference in note_sequence.chord_inference
+  that attempts to infer a more natural chord sequence with changes at regular
+  metric intervals.
+
+  Args:
+    sequence: The NoteSequence for which chords will be inferred. Will be
+      modified in place.
+    instrument: The instrument number whose notes will be used for chord
+      inference. If None, all instruments will be used.
+    min_notes_per_chord: The minimum number of simultaneous notes for which to
+      infer a chord.
+
+  Raises:
+    ChordSymbolError: If a chord cannot be determined for a set of
+    simultaneous notes in `sequence`.
+  &#34;&#34;&#34;
+  notes = [
+      note for note in sequence.notes if not note.is_drum and
+      (instrument is None or note.instrument == instrument)
+  ]
+  sorted_notes = sorted(notes, key=lambda note: note.start_time)
+
+  # If the sequence is quantized, use quantized steps instead of time.
+  if is_quantized_sequence(sequence):
+    note_start = lambda note: note.quantized_start_step
+    note_end = lambda note: note.quantized_end_step
+  else:
+    note_start = lambda note: note.start_time
+    note_end = lambda note: note.end_time
+
+  # Sort all note start and end events.
+  onsets = [
+      (note_start(note), idx, False) for idx, note in enumerate(sorted_notes)
+  ]
+  offsets = [
+      (note_end(note), idx, True) for idx, note in enumerate(sorted_notes)
+  ]
+  events = sorted(onsets + offsets)
+
+  current_time = 0
+  current_figure = constants.NO_CHORD
+  active_notes = set()
+
+  for time, idx, is_offset in events:
+    if time &gt; current_time:
+      active_pitches = set(sorted_notes[idx].pitch for idx in active_notes)
+      if len(active_pitches) &gt;= min_notes_per_chord:
+        # Infer a chord symbol for the active pitches.
+        figure = chord_symbols_lib.pitches_to_chord_symbol(active_pitches)
+
+        if figure != current_figure:
+          # Add a text annotation to the sequence.
+          text_annotation = sequence.text_annotations.add()
+          text_annotation.text = figure
+          text_annotation.annotation_type = CHORD_SYMBOL
+          if is_quantized_sequence(sequence):
+            text_annotation.time = (
+                current_time * sequence.quantization_info.steps_per_quarter)
+            text_annotation.quantized_step = current_time
+          else:
+            text_annotation.time = current_time
+
+        current_figure = figure
+
+    current_time = time
+    if is_offset:
+      active_notes.remove(idx)
+    else:
+      active_notes.add(idx)
+
+  assert not active_notes
+
+
+Pianoroll = collections.namedtuple(  # pylint:disable=invalid-name
+    &#39;Pianoroll&#39;,
+    [&#39;active&#39;, &#39;weights&#39;, &#39;onsets&#39;, &#39;onset_velocities&#39;, &#39;active_velocities&#39;,
+     &#39;offsets&#39;, &#39;control_changes&#39;])
+
+
+def sequence_to_pianoroll(
+    sequence,
+    frames_per_second,
+    min_pitch,
+    max_pitch,
+    # pylint: disable=unused-argument
+    min_velocity=constants.MIN_MIDI_VELOCITY,
+    # pylint: enable=unused-argument
+    max_velocity=constants.MAX_MIDI_VELOCITY,
+    add_blank_frame_before_onset=False,
+    onset_upweight=ONSET_UPWEIGHT,
+    onset_window=ONSET_WINDOW,
+    onset_length_ms=0,
+    offset_length_ms=0,
+    onset_mode=&#39;window&#39;,
+    onset_delay_ms=0.0,
+    min_frame_occupancy_for_label=0.0,
+    onset_overlap=True):
+  &#34;&#34;&#34;Transforms a NoteSequence to a pianoroll assuming a single instrument.
+
+  This function uses floating point internally and may return different results
+  on different platforms or with different compiler settings or with
+  different compilers.
+
+  Args:
+    sequence: The NoteSequence to convert.
+    frames_per_second: How many frames per second.
+    min_pitch: pitches in the sequence below this will be ignored.
+    max_pitch: pitches in the sequence above this will be ignored.
+    min_velocity: minimum velocity for the track, currently unused.
+    max_velocity: maximum velocity for the track, not just the local sequence,
+      used to globally normalize the velocities between [0, 1].
+    add_blank_frame_before_onset: Always have a blank frame before onsets.
+    onset_upweight: Factor by which to increase the weight assigned to onsets.
+    onset_window: Fixed window size to activate around onsets in `onsets` and
+      `onset_velocities`. Used only if `onset_mode` is &#39;window&#39;.
+    onset_length_ms: Length in milliseconds for the onset. Used only if
+      onset_mode is &#39;length_ms&#39;.
+    offset_length_ms: Length in milliseconds for the offset. Used only if
+      offset_mode is &#39;length_ms&#39;.
+    onset_mode: Either &#39;window&#39;, to use onset_window, or &#39;length_ms&#39; to use
+      onset_length_ms.
+    onset_delay_ms: Number of milliseconds to delay the onset. Can be negative.
+    min_frame_occupancy_for_label: floating point value in range [0, 1] a note
+      must occupy at least this percentage of a frame, for the frame to be given
+      a label with the note.
+    onset_overlap: Whether or not the onsets overlap with the frames.
+
+  Raises:
+    ValueError: When an unknown onset_mode is supplied.
+
+  Returns:
+    active: Active note pianoroll as a 2D array..
+    weights: Weights to be used when calculating loss against roll.
+    onsets: An onset-only pianoroll as a 2D array.
+    onset_velocities: Velocities of onsets scaled from [0, 1].
+    active_velocities: Velocities of active notes scaled from [0, 1].
+    offsets: An offset-only pianoroll as a 2D array.
+    control_changes: Control change onsets as a 2D array (time, control number)
+      with 0 when there is no onset and (control_value + 1) when there is.
+  &#34;&#34;&#34;
+  roll = np.zeros((int(sequence.total_time * frames_per_second + 1),
+                   max_pitch - min_pitch + 1),
+                  dtype=np.float32)
+
+  roll_weights = np.ones_like(roll)
+
+  onsets = np.zeros_like(roll)
+  offsets = np.zeros_like(roll)
+
+  control_changes = np.zeros(
+      (int(sequence.total_time * frames_per_second + 1), 128), dtype=np.int32)
+
+  def frames_from_times(start_time, end_time):
+    &#34;&#34;&#34;Converts start/end times to start/end frames.&#34;&#34;&#34;
+    # Will round down because note may start or end in the middle of the frame.
+    start_frame = int(start_time * frames_per_second)
+    start_frame_occupancy = (start_frame + 1 - start_time * frames_per_second)
+    # check for &gt; 0.0 to avoid possible numerical issues
+    if (min_frame_occupancy_for_label &gt; 0.0 and
+        start_frame_occupancy &lt; min_frame_occupancy_for_label):
+      start_frame += 1
+
+    end_frame = int(math.ceil(end_time * frames_per_second))
+    end_frame_occupancy = end_time * frames_per_second - start_frame - 1
+    if (min_frame_occupancy_for_label &gt; 0.0 and
+        end_frame_occupancy &lt; min_frame_occupancy_for_label):
+      end_frame -= 1
+
+    # Ensure that every note fills at least one frame.
+    end_frame = max(start_frame + 1, end_frame)
+
+    return start_frame, end_frame
+
+  velocities_roll = np.zeros_like(roll, dtype=np.float32)
+
+  for note in sorted(sequence.notes, key=lambda n: n.start_time):
+    if note.pitch &lt; min_pitch or note.pitch &gt; max_pitch:
+      logging.warn(&#39;Skipping out of range pitch: %d&#39;, note.pitch)
+      continue
+    start_frame, end_frame = frames_from_times(note.start_time, note.end_time)
+
+    # label onset events. Use a window size of onset_window to account of
+    # rounding issue in the start_frame computation.
+    onset_start_time = note.start_time + onset_delay_ms / 1000.
+    onset_end_time = note.end_time + onset_delay_ms / 1000.
+    if onset_mode == &#39;window&#39;:
+      onset_start_frame_without_window, _ = frames_from_times(
+          onset_start_time, onset_end_time)
+
+      onset_start_frame = max(0,
+                              onset_start_frame_without_window - onset_window)
+      onset_end_frame = min(onsets.shape[0],
+                            onset_start_frame_without_window + onset_window + 1)
+    elif onset_mode == &#39;length_ms&#39;:
+      onset_end_time = min(onset_end_time,
+                           onset_start_time + onset_length_ms / 1000.)
+      onset_start_frame, onset_end_frame = frames_from_times(
+          onset_start_time, onset_end_time)
+    else:
+      raise ValueError(&#39;Unknown onset mode: {}&#39;.format(onset_mode))
+
+    # label offset events.
+    offset_start_time = min(note.end_time,
+                            sequence.total_time - offset_length_ms / 1000.)
+    offset_end_time = offset_start_time + offset_length_ms / 1000.
+    offset_start_frame, offset_end_frame = frames_from_times(
+        offset_start_time, offset_end_time)
+    offset_end_frame = max(offset_end_frame, offset_start_frame + 1)
+
+    if not onset_overlap:
+      start_frame = onset_end_frame
+      end_frame = max(start_frame + 1, end_frame)
+
+    offsets[offset_start_frame:offset_end_frame, note.pitch - min_pitch] = 1.0
+    onsets[onset_start_frame:onset_end_frame, note.pitch - min_pitch] = 1.0
+    roll[start_frame:end_frame, note.pitch - min_pitch] = 1.0
+
+    if note.velocity &gt; max_velocity:
+      raise ValueError(&#39;Note velocity exceeds max velocity: %d &gt; %d&#39; %
+                       (note.velocity, max_velocity))
+
+    velocities_roll[start_frame:end_frame, note.pitch -
+                    min_pitch] = note.velocity / max_velocity
+    roll_weights[onset_start_frame:onset_end_frame, note.pitch - min_pitch] = (
+        onset_upweight)
+    roll_weights[onset_end_frame:end_frame, note.pitch - min_pitch] = [
+        onset_upweight / x for x in range(1, end_frame - onset_end_frame + 1)
+    ]
+
+    if add_blank_frame_before_onset:
+      if start_frame &gt; 0:
+        roll[start_frame - 1, note.pitch - min_pitch] = 0.0
+        roll_weights[start_frame - 1, note.pitch - min_pitch] = 1.0
+
+  for cc in sequence.control_changes:
+    frame, _ = frames_from_times(cc.time, 0)
+    if frame &lt; len(control_changes):
+      control_changes[frame, cc.control_number] = cc.control_value + 1
+
+  return Pianoroll(
+      active=roll,
+      weights=roll_weights,
+      onsets=onsets,
+      onset_velocities=velocities_roll * onsets,
+      active_velocities=velocities_roll,
+      offsets=offsets,
+      control_changes=control_changes)
+
+
+def _unscale_velocity(velocity, scale, bias):
+  &#34;&#34;&#34;Translates a velocity estimate to a MIDI velocity value.
+
+  Note that this scaling is totally arbitrary and was chosen only because it
+  sounded decent when synthesized.
+
+  Args:
+    velocity: Velocity estimate. Should be in [0, 1].
+    scale: Scale to use for conversion to MIDI velocity.
+    bias: Bias to use for conversion to MIDI velocity.
+
+  Returns:
+    MIDI velocity value.
+  &#34;&#34;&#34;
+  unscaled = max(min(velocity, 1.), 0) * scale + bias
+  if math.isnan(unscaled):
+    return 0
+  return int(unscaled)
+
+
+def pianoroll_to_note_sequence(frames,
+                               frames_per_second,
+                               min_duration_ms,
+                               velocity=70,
+                               instrument=0,
+                               program=0,
+                               qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                               min_midi_pitch=constants.MIN_MIDI_PITCH,
+                               onset_predictions=None,
+                               offset_predictions=None,
+                               velocity_values=None,
+                               velocity_scale=80,
+                               velocity_bias=10):
+  &#34;&#34;&#34;Convert frames (with optional onsets, offsets, velocities) to NoteSequence.
+
+  Args:
+    frames: Numpy array of active frames. Expected shape is (time, pitch).
+    frames_per_second: Frames per second.
+    min_duration_ms: Notes active for less than this duration will be ignored.
+    velocity: Default note velocity if velocity_values is not provided.
+    instrument: Instrument for the note sequence.
+    program: Program for the note sequence.
+    qpm: QPM for the note sequence.
+    min_midi_pitch: MIDI pitch offset.
+    onset_predictions: Numpy array of onset predictions. If specified, a new
+      note will not start unless it is active in this array.
+    offset_predictions: Numpy array of onset predictions. If specified, notes
+      will end no later than when these offsets are predicted.
+    velocity_values: Numpy array of floats representing velocities.
+    velocity_scale: Scale to use for conversion to MIDI velocity.
+    velocity_bias: Bias to use for conversion to MIDI velocity.
+
+  Returns:
+    Generated NoteSequence proto.
+  &#34;&#34;&#34;
+  frame_length_seconds = 1 / frames_per_second
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = constants.STANDARD_PPQ
+
+  pitch_start_step = {}
+  onset_velocities = np.zeros(constants.MAX_MIDI_PITCH+1, dtype=np.int32)
+
+  # Add silent frame at the end so we can do a final loop and terminate any
+  # notes that are still active.
+  frames = np.append(frames, [np.zeros(frames[0].shape)], 0)
+
+  if onset_predictions is not None:
+    onset_predictions = np.append(onset_predictions,
+                                  [np.zeros(onset_predictions[0].shape)], 0)
+    # Ensure that any frame with an onset prediction is considered active.
+    frames = np.logical_or(frames, onset_predictions)
+
+  if offset_predictions is not None:
+    offset_predictions = np.append(offset_predictions,
+                                   [np.zeros(offset_predictions[0].shape)], 0)
+    # If the frame and offset are both on, then turn it off
+    frames[np.where(np.logical_and(frames &gt; 0, offset_predictions &gt; 0))] = 0
+
+  def end_pitch(pitch, end_frame):
+    &#34;&#34;&#34;End an active pitch.&#34;&#34;&#34;
+    start_time = pitch_start_step[pitch] * frame_length_seconds
+    end_time = end_frame * frame_length_seconds
+
+    if (end_time - start_time) * 1000 &gt;= min_duration_ms:
+      note = sequence.notes.add()
+      note.start_time = start_time
+      note.end_time = end_time
+      note.pitch = pitch + min_midi_pitch
+      note.velocity = onset_velocities[pitch]
+      note.instrument = instrument
+      note.program = program
+
+    del pitch_start_step[pitch]
+
+  def process_active_pitch(pitch, i):
+    &#34;&#34;&#34;Process a pitch being active in a given frame.&#34;&#34;&#34;
+    if pitch not in pitch_start_step:
+      if onset_predictions is not None:
+        # If onset predictions were supplied, only allow a new note to start
+        # if we&#39;ve predicted an onset.
+        if onset_predictions[i, pitch]:
+          pitch_start_step[pitch] = i
+          if velocity_values is not None:
+            onset_velocities[pitch] = _unscale_velocity(
+                velocity_values[i, pitch],
+                scale=velocity_scale,
+                bias=velocity_bias)
+          else:
+            onset_velocities[pitch] = velocity
+        else:
+          # Even though the frame is active, the onset predictor doesn&#39;t
+          # say there should be an onset, so ignore it.
+          pass
+      else:
+        pitch_start_step[pitch] = i
+    else:
+      if onset_predictions is not None:
+        # pitch is already active, but if this is a new onset, we should end
+        # the note and start a new one.
+        if (onset_predictions[i, pitch] and
+            not onset_predictions[i - 1, pitch]):
+          end_pitch(pitch, i)
+          pitch_start_step[pitch] = i
+          if velocity_values is not None:
+            onset_velocities[pitch] = _unscale_velocity(
+                velocity_values[i, pitch],
+                scale=velocity_scale,
+                bias=velocity_bias)
+          else:
+            onset_velocities[pitch] = velocity
+
+  for i, frame in enumerate(frames):
+    for pitch, active in enumerate(frame):
+      if active:
+        process_active_pitch(pitch, i)
+      elif pitch in pitch_start_step:
+        end_pitch(pitch, i)
+
+  sequence.total_time = len(frames) * frame_length_seconds
+  if sequence.notes:
+    assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+  return sequence
+
+
+def pianoroll_onsets_to_note_sequence(onsets,
+                                      frames_per_second,
+                                      note_duration_seconds=0.05,
+                                      velocity=70,
+                                      instrument=0,
+                                      program=0,
+                                      qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                                      min_midi_pitch=constants.MIN_MIDI_PITCH,
+                                      velocity_values=None,
+                                      velocity_scale=80,
+                                      velocity_bias=10):
+  &#34;&#34;&#34;Convert onsets to a NoteSequence.
+
+  This converts an matrix of onsets into a NoteSequence. Every active onset
+  is considered to be a new note with a fixed duration of note_duration_seconds.
+  This is different from pianoroll_to_note_sequence, which considers onsets in
+  consecutive frames to represent a single new note.
+
+
+  Args:
+    onsets: Numpy array of onsets.
+    frames_per_second: Frames per second.
+    note_duration_seconds: Fixed length of every note.
+    velocity: Default note velocity if velocity_values is not provided.
+    instrument: Instrument for the note sequence.
+    program: Program for the note sequence.
+    qpm: QPM for the note sequence.
+    min_midi_pitch: MIDI pitch offset.
+    velocity_values: Numpy array of floats representing velocities.
+    velocity_scale: Scale to use for conversion to MIDI velocity.
+    velocity_bias: Bias to use for conversion to MIDI velocity.
+
+  Returns:
+    Generated NoteSequence proto.
+  &#34;&#34;&#34;
+  frame_length_seconds = 1 / frames_per_second
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = constants.STANDARD_PPQ
+
+  if velocity_values is None:
+    velocity_values = velocity * np.ones_like(onsets, dtype=np.int32)
+
+  for frame, pitch in zip(*np.nonzero(onsets)):
+    start_time = frame * frame_length_seconds
+    end_time = start_time + note_duration_seconds
+
+    note = sequence.notes.add()
+    note.start_time = start_time
+    note.end_time = end_time
+    note.pitch = pitch + min_midi_pitch
+    note.velocity = _unscale_velocity(
+        velocity_values[frame, pitch],
+        scale=velocity_scale,
+        bias=velocity_bias)
+    note.instrument = instrument
+    note.program = program
+
+  sequence.total_time = (
+      len(onsets) * frame_length_seconds + note_duration_seconds)
+  if sequence.notes:
+    assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+  return sequence
+
+
+def sequence_to_valued_intervals(note_sequence,
+                                 min_midi_pitch=constants.MIN_MIDI_PITCH,
+                                 max_midi_pitch=constants.MAX_MIDI_PITCH,
+                                 restrict_to_pitch=None):
+  &#34;&#34;&#34;Convert a NoteSequence to valued intervals.
+
+  Value intervals are intended to be used with mir_eval metrics methods.
+
+  Args:
+    note_sequence: sequence to convert.
+    min_midi_pitch: notes lower than this will be discarded.
+    max_midi_pitch: notes higher than this will be discarded.
+    restrict_to_pitch: notes that are not this pitch will be discarded.
+
+  Returns:
+    intervals: start and end times
+    pitches: pitches in Hz.
+    velocities: MIDI velocities.
+  &#34;&#34;&#34;
+  intervals = []
+  pitches = []
+  velocities = []
+
+  for note in note_sequence.notes:
+    if restrict_to_pitch and restrict_to_pitch != note.pitch:
+      continue
+    if note.pitch &lt; min_midi_pitch or note.pitch &gt; max_midi_pitch:
+      continue
+    # mir_eval does not allow notes that start and end at the same time.
+    if note.end_time == note.start_time:
+      continue
+    intervals.append((note.start_time, note.end_time))
+    pitches.append(note.pitch)
+    velocities.append(note.velocity)
+
+  # Reshape intervals to ensure that the second dim is 2, even if the list is
+  # of size 0. mir_eval functions will complain if intervals is not shaped
+  # appropriately.
+  intervals = np.array(intervals).reshape((-1, 2))
+  pitches = np.array(pitches)
+  pitches = pretty_midi.note_number_to_hz(pitches)
+  velocities = np.array(velocities)
+  return intervals, pitches, velocities</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.sequences_lib.adjust_notesequence_times"><code class="name flex">
+<span>def <span class="ident">adjust_notesequence_times</span></span>(<span>ns, time_func, minimum_duration=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adjusts notesequence timings given an adjustment function.</p>
+<p>Note that only notes, control changes, and pitch bends are adjusted. All other
+events are ignored.</p>
+<p>If the adjusted version of a note ends before or at the same time it begins,
+it will be skipped.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>ns</code></strong></dt>
+<dd>The NoteSequence to adjust.</dd>
+<dt><strong><code>time_func</code></strong></dt>
+<dd>A function that takes a time (in seconds) and returns an adjusted
+version of that time. This function is expected to be monotonic, i.e. if
+<code>t1 &lt;= t2</code> then <code>time_func(t1) &lt;= time_func(t2)</code>. In addition, if
+<code>t &gt;= 0</code> then it should also be true that <code>time_func(t) &gt;= 0</code>. The
+monotonicity property is not checked for all pairs of event times, only
+the start and end times of each note, but you may get strange results if
+<code>time_func</code> is non-monotonic.</dd>
+<dt><strong><code>minimum_duration</code></strong></dt>
+<dd>If time_func results in a duration of 0, instead
+substitute this duration and do not increment the skipped_notes counter.
+If None, the note will be skipped.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.InvalidTimeAdjustmentError" href="#note_seq.sequences_lib.InvalidTimeAdjustmentError">InvalidTimeAdjustmentError</a></code></dt>
+<dd>If a note has an adjusted end time that is
+before its start time, or if any event times are shifted before zero.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>adjusted_ns</code></dt>
+<dd>A new NoteSequence with adjusted times.</dd>
+<dt><code>skipped_notes</code></dt>
+<dd>A count of how many notes were skipped.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def adjust_notesequence_times(ns, time_func, minimum_duration=None):
+  &#34;&#34;&#34;Adjusts notesequence timings given an adjustment function.
+
+  Note that only notes, control changes, and pitch bends are adjusted. All other
+  events are ignored.
+
+  If the adjusted version of a note ends before or at the same time it begins,
+  it will be skipped.
+
+  Args:
+    ns: The NoteSequence to adjust.
+    time_func: A function that takes a time (in seconds) and returns an adjusted
+        version of that time. This function is expected to be monotonic, i.e. if
+        `t1 &lt;= t2` then `time_func(t1) &lt;= time_func(t2)`. In addition, if
+        `t &gt;= 0` then it should also be true that `time_func(t) &gt;= 0`. The
+        monotonicity property is not checked for all pairs of event times, only
+        the start and end times of each note, but you may get strange results if
+        `time_func` is non-monotonic.
+    minimum_duration: If time_func results in a duration of 0, instead
+        substitute this duration and do not increment the skipped_notes counter.
+        If None, the note will be skipped.
+
+  Raises:
+    InvalidTimeAdjustmentError: If a note has an adjusted end time that is
+        before its start time, or if any event times are shifted before zero.
+
+  Returns:
+    adjusted_ns: A new NoteSequence with adjusted times.
+    skipped_notes: A count of how many notes were skipped.
+  &#34;&#34;&#34;
+  adjusted_ns = copy.deepcopy(ns)
+
+  # Iterate through the original NoteSequence notes to make it easier to drop
+  # skipped notes from the adjusted NoteSequence.
+  adjusted_ns.total_time = 0
+  skipped_notes = 0
+  del adjusted_ns.notes[:]
+  for note in ns.notes:
+    start_time = time_func(note.start_time)
+    end_time = time_func(note.end_time)
+
+    if start_time == end_time:
+      if minimum_duration:
+        logging.warn(
+            &#39;Adjusting note duration of 0 to new minimum duration of %f. &#39;
+            &#39;Original start: %f, end %f. New start %f, end %f.&#39;,
+            minimum_duration, note.start_time, note.end_time, start_time,
+            end_time)
+        end_time += minimum_duration
+      else:
+        logging.warn(
+            &#39;Skipping note that ends before or at the same time it begins. &#39;
+            &#39;Original start: %f, end %f. New start %f, end %f.&#39;,
+            note.start_time, note.end_time, start_time, end_time)
+        skipped_notes += 1
+        continue
+
+    if end_time &lt; start_time:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust end time to before start time. &#39;
+          &#39;Original start: %f, end %f. New start %f, end %f.&#39; %
+          (note.start_time, note.end_time, start_time, end_time))
+
+    if start_time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust note start time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (note.start_time, start_time))
+
+    if end_time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust note end time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (note.end_time, end_time))
+
+    if end_time &gt; adjusted_ns.total_time:
+      adjusted_ns.total_time = end_time
+
+    adjusted_note = adjusted_ns.notes.add()
+    adjusted_note.MergeFrom(note)
+    adjusted_note.start_time = start_time
+    adjusted_note.end_time = end_time
+
+  events = itertools.chain(
+      adjusted_ns.control_changes,
+      adjusted_ns.pitch_bends,
+      adjusted_ns.time_signatures,
+      adjusted_ns.key_signatures,
+      adjusted_ns.text_annotations
+  )
+
+  for event in events:
+    time = time_func(event.time)
+    if time &lt; 0:
+      raise InvalidTimeAdjustmentError(
+          &#39;Tried to adjust event time to before 0 &#39;
+          &#39;(original: %f, adjusted: %f)&#39; % (event.time, time))
+    event.time = time
+
+  # Adjusting tempos to accommodate arbitrary time adjustments is too
+  # complicated. Just delete them.
+  del adjusted_ns.tempos[:]
+
+  return adjusted_ns, skipped_notes</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.apply_sustain_control_changes"><code class="name flex">
+<span>def <span class="ident">apply_sustain_control_changes</span></span>(<span>note_sequence, sustain_control_number=64)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a new NoteSequence with sustain pedal control changes applied.</p>
+<p>Extends each note within a sustain to either the beginning of the next note of
+the same pitch or the end of the sustain period, whichever happens first. This
+is done on a per instrument basis, so notes are only affected by sustain
+events for the same instrument.</p>
+<p>Drum notes will not be modified.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence for which to apply sustain. This object will
+not be modified.</dd>
+<dt><strong><code>sustain_control_number</code></strong></dt>
+<dd>The MIDI control number for sustain pedal. Control
+events with this number and value 0-63 will be treated as sustain pedal
+OFF events, and control events with this number and value 64-127 will be
+treated as sustain pedal ON events.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A copy of <code>note_sequence</code> but with note end times extended to account for
+sustain.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If <code>note_sequence</code> is quantized. Sustain can
+only be applied to unquantized note sequences.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def apply_sustain_control_changes(note_sequence, sustain_control_number=64):
+  &#34;&#34;&#34;Returns a new NoteSequence with sustain pedal control changes applied.
+
+  Extends each note within a sustain to either the beginning of the next note of
+  the same pitch or the end of the sustain period, whichever happens first. This
+  is done on a per instrument basis, so notes are only affected by sustain
+  events for the same instrument.
+
+  Drum notes will not be modified.
+
+  Args:
+    note_sequence: The NoteSequence for which to apply sustain. This object will
+      not be modified.
+    sustain_control_number: The MIDI control number for sustain pedal. Control
+      events with this number and value 0-63 will be treated as sustain pedal
+      OFF events, and control events with this number and value 64-127 will be
+      treated as sustain pedal ON events.
+
+  Returns:
+    A copy of `note_sequence` but with note end times extended to account for
+    sustain.
+
+  Raises:
+    QuantizationStatusError: If `note_sequence` is quantized. Sustain can
+        only be applied to unquantized note sequences.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;Can only apply sustain to unquantized NoteSequence.&#39;)
+
+  sequence = copy.deepcopy(note_sequence)
+
+  # Sort all note on/off and sustain on/off events.
+  events = []
+  events.extend([(note.start_time, _NOTE_ON, note) for note in sequence.notes
+                 if not note.is_drum])
+  events.extend([(note.end_time, _NOTE_OFF, note) for note in sequence.notes
+                 if not note.is_drum])
+
+  for cc in sequence.control_changes:
+    if cc.control_number != sustain_control_number:
+      continue
+    value = cc.control_value
+    if value &lt; 0 or value &gt; 127:
+      logging.warn(&#39;Sustain control change has out of range value: %d&#39;, value)
+    if value &gt;= 64:
+      events.append((cc.time, _SUSTAIN_ON, cc))
+    elif value &lt; 64:
+      events.append((cc.time, _SUSTAIN_OFF, cc))
+
+  # Sort, using the time and event type constants to ensure the order events are
+  # processed.
+  events.sort(key=operator.itemgetter(0, 1))
+
+  # Lists of active notes, keyed by instrument.
+  active_notes = collections.defaultdict(list)
+  # Whether sustain is active for a given instrument.
+  sus_active = collections.defaultdict(lambda: False)
+
+  # Iterate through all sustain on/off and note on/off events in order.
+  time = 0
+  for time, event_type, event in events:
+    if event_type == _SUSTAIN_ON:
+      sus_active[event.instrument] = True
+    elif event_type == _SUSTAIN_OFF:
+      sus_active[event.instrument] = False
+      # End all notes for the instrument that were being extended.
+      new_active_notes = []
+      for note in active_notes[event.instrument]:
+        if note.end_time &lt; time:
+          # This note was being extended because of sustain.
+          # Update the end time and don&#39;t keep it in the list.
+          note.end_time = time
+          if time &gt; sequence.total_time:
+            sequence.total_time = time
+        else:
+          # This note is actually still active, keep it.
+          new_active_notes.append(note)
+      active_notes[event.instrument] = new_active_notes
+    elif event_type == _NOTE_ON:
+      if sus_active[event.instrument]:
+        # If sustain is on, end all previous notes with the same pitch.
+        new_active_notes = []
+        for note in active_notes[event.instrument]:
+          if note.pitch == event.pitch:
+            note.end_time = time
+            if note.start_time == note.end_time:
+              # This note now has no duration because another note of the same
+              # pitch started at the same time. Only one of these notes should
+              # be preserved, so delete this one.
+              # TODO(fjord): A more correct solution would probably be to
+              # preserve both notes and make the same duration, but that is a
+              # little more complicated to implement. Will keep this solution
+              # until we find that we need the more complex one.
+              sequence.notes.remove(note)
+          else:
+            new_active_notes.append(note)
+        active_notes[event.instrument] = new_active_notes
+      # Add this new note to the list of active notes.
+      active_notes[event.instrument].append(event)
+    elif event_type == _NOTE_OFF:
+      if sus_active[event.instrument]:
+        # Note continues until another note of the same pitch or sustain ends.
+        pass
+      else:
+        # Remove this particular note from the active list.
+        # It may have already been removed if a note of the same pitch was
+        # played when sustain was active.
+        if event in active_notes[event.instrument]:
+          active_notes[event.instrument].remove(event)
+    else:
+      raise AssertionError(&#39;Invalid event_type: %s&#39; % event_type)
+
+  # End any notes that were still active due to sustain.
+  for instrument in active_notes.values():
+    for note in instrument:
+      note.end_time = time
+      sequence.total_time = time
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.assert_is_absolute_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">assert_is_absolute_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Confirms that a NoteSequence proto has been quantized by absolute time.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence is not quantized by absolute</dd>
+</dl>
+<p>time.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assert_is_absolute_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that a NoteSequence proto has been quantized by absolute time.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized by absolute
+    time.
+  &#34;&#34;&#34;
+  if not is_absolute_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized or is &#39;
+        &#39;quantized based on relative timing.&#39; % note_sequence.id)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.assert_is_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">assert_is_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Confirms that the given NoteSequence proto has been quantized.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence is not quantized.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assert_is_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that the given NoteSequence proto has been quantized.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized.
+  &#34;&#34;&#34;
+  if not is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized.&#39; % note_sequence.id)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.assert_is_relative_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">assert_is_relative_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Confirms that a NoteSequence proto has been quantized relative to tempo.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence is not quantized relative to
+tempo.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assert_is_relative_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Confirms that a NoteSequence proto has been quantized relative to tempo.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Raises:
+    QuantizationStatusError: If the sequence is not quantized relative to
+        tempo.
+  &#34;&#34;&#34;
+  if not is_relative_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;NoteSequence %s is not quantized or is &#39;
+        &#39;quantized based on absolute timing.&#39; % note_sequence.id)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.augment_note_sequence"><code class="name flex">
+<span>def <span class="ident">augment_note_sequence</span></span>(<span>ns, min_stretch_factor, max_stretch_factor, min_transpose, max_transpose, min_allowed_pitch=0, max_allowed_pitch=127, delete_out_of_range_notes=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Modifed a NoteSequence with random stretching and transposition.</p>
+<p>This method can be used to augment a dataset for training neural nets.
+Note that the provided ns is modified in place.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>ns</code></strong></dt>
+<dd>A NoteSequence proto to be augmented.</dd>
+<dt><strong><code>min_stretch_factor</code></strong></dt>
+<dd>Minimum amount to stretch/compress the NoteSequence.</dd>
+<dt><strong><code>max_stretch_factor</code></strong></dt>
+<dd>Maximum amount to stretch/compress the NoteSequence.</dd>
+<dt><strong><code>min_transpose</code></strong></dt>
+<dd>Minimum number of steps to transpose the NoteSequence.</dd>
+<dt><strong><code>max_transpose</code></strong></dt>
+<dd>Maximum number of steps to transpose the NoteSequence.</dd>
+<dt><strong><code>min_allowed_pitch</code></strong></dt>
+<dd>The lowest pitch permitted (ie, for regular piano this
+should be set to 21.)</dd>
+<dt><strong><code>max_allowed_pitch</code></strong></dt>
+<dd>The highest pitch permitted (ie, for regular piano this
+should be set to 108.)</dd>
+<dt><strong><code>delete_out_of_range_notes</code></strong></dt>
+<dd>If true, a transposition amount will be chosen on
+the interval [min_transpose, max_transpose], and any out-of-bounds notes
+will be deleted. If false, the interval [min_transpose, max_transpose]
+will be truncated such that no out-of-bounds notes will ever be created.</dd>
+</dl>
+<p>TODO(dei): Add support for specifying custom distributions over possible
+values of note stretch and transposition amount.</p>
+<h2 id="returns">Returns</h2>
+<p>The randomly augmented NoteSequence.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If mins in ranges are larger than maxes.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def augment_note_sequence(ns,
+                          min_stretch_factor,
+                          max_stretch_factor,
+                          min_transpose,
+                          max_transpose,
+                          min_allowed_pitch=constants.MIN_MIDI_PITCH,
+                          max_allowed_pitch=constants.MAX_MIDI_PITCH,
+                          delete_out_of_range_notes=False):
+  &#34;&#34;&#34;Modifed a NoteSequence with random stretching and transposition.
+
+  This method can be used to augment a dataset for training neural nets.
+  Note that the provided ns is modified in place.
+
+  Args:
+    ns: A NoteSequence proto to be augmented.
+    min_stretch_factor: Minimum amount to stretch/compress the NoteSequence.
+    max_stretch_factor: Maximum amount to stretch/compress the NoteSequence.
+    min_transpose: Minimum number of steps to transpose the NoteSequence.
+    max_transpose: Maximum number of steps to transpose the NoteSequence.
+    min_allowed_pitch: The lowest pitch permitted (ie, for regular piano this
+      should be set to 21.)
+    max_allowed_pitch: The highest pitch permitted (ie, for regular piano this
+      should be set to 108.)
+    delete_out_of_range_notes: If true, a transposition amount will be chosen on
+      the interval [min_transpose, max_transpose], and any out-of-bounds notes
+      will be deleted. If false, the interval [min_transpose, max_transpose]
+      will be truncated such that no out-of-bounds notes will ever be created.
+  TODO(dei): Add support for specifying custom distributions over possible
+    values of note stretch and transposition amount.
+
+  Returns:
+    The randomly augmented NoteSequence.
+
+  Raises:
+    ValueError: If mins in ranges are larger than maxes.
+  &#34;&#34;&#34;
+  if min_stretch_factor &gt; max_stretch_factor:
+    raise ValueError(&#39;min_stretch_factor should be &lt;= max_stretch_factor&#39;)
+  if min_allowed_pitch &gt; max_allowed_pitch:
+    raise ValueError(&#39;min_allowed_pitch should be &lt;= max_allowed_pitch&#39;)
+  if min_transpose &gt; max_transpose:
+    raise ValueError(&#39;min_transpose should be &lt;= max_transpose&#39;)
+
+  if ns.notes:
+    # Choose random factor by which to stretch or compress note sequence.
+    stretch_factor = random.uniform(min_stretch_factor, max_stretch_factor)
+    ns = stretch_note_sequence(ns, stretch_factor, in_place=True)
+
+    # Choose amount by which to translate the note sequence.
+    if delete_out_of_range_notes:
+      # If transposition takes a note outside of the allowed note bounds,
+      # we will just delete it.
+      transposition_amount = random.randint(min_transpose, max_transpose)
+    else:
+      # Prevent transposition from taking a note outside of the allowed note
+      # bounds by clamping the range we sample from.
+      ns_min_pitch = min(ns.notes, key=lambda note: note.pitch).pitch
+      ns_max_pitch = max(ns.notes, key=lambda note: note.pitch).pitch
+
+      if ns_min_pitch &lt; min_allowed_pitch:
+        logging.warn(
+            &#39;A note sequence has some pitch=%d, which is less &#39;
+            &#39;than min_allowed_pitch=%d&#39;, ns_min_pitch, min_allowed_pitch)
+      if ns_max_pitch &gt; max_allowed_pitch:
+        logging.warn(
+            &#39;A note sequence has some pitch=%d, which is greater &#39;
+            &#39;than max_allowed_pitch=%d&#39;, ns_max_pitch, max_allowed_pitch)
+
+      min_transpose = _clamp_transpose(min_transpose, ns_min_pitch,
+                                       ns_max_pitch, min_allowed_pitch,
+                                       max_allowed_pitch)
+      max_transpose = _clamp_transpose(max_transpose, ns_min_pitch,
+                                       ns_max_pitch, min_allowed_pitch,
+                                       max_allowed_pitch)
+      transposition_amount = random.randint(min_transpose, max_transpose)
+
+    ns, _ = transpose_note_sequence(
+        ns,
+        transposition_amount,
+        min_allowed_pitch,
+        max_allowed_pitch,
+        in_place=True)
+
+  return ns</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.concatenate_sequences"><code class="name flex">
+<span>def <span class="ident">concatenate_sequences</span></span>(<span>sequences, sequence_durations=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Concatenate a series of NoteSequences together.</p>
+<p>Individual sequences will be shifted using shift_sequence_times and then
+merged together using the protobuf MergeFrom method. This means that any
+global values (e.g., ticks_per_quarter) will be overwritten by each sequence
+and only the final value will be used. After this, redundant data will be
+removed with remove_redundant_data.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequences</code></strong></dt>
+<dd>A list of sequences to concatenate.</dd>
+<dt><strong><code>sequence_durations</code></strong></dt>
+<dd>An optional list of sequence durations to use. If not
+specified, the total_time value will be used. Specifying durations is
+useful if the sequences to be concatenated are effectively longer than
+their total_time (e.g., a sequence that ends with a rest).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A new sequence that is the result of concatenating *sequences.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If the length of sequences and sequence_durations do not match
+or if a specified duration is less than the total_time of the sequence.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def concatenate_sequences(sequences, sequence_durations=None):
+  &#34;&#34;&#34;Concatenate a series of NoteSequences together.
+
+  Individual sequences will be shifted using shift_sequence_times and then
+  merged together using the protobuf MergeFrom method. This means that any
+  global values (e.g., ticks_per_quarter) will be overwritten by each sequence
+  and only the final value will be used. After this, redundant data will be
+  removed with remove_redundant_data.
+
+  Args:
+    sequences: A list of sequences to concatenate.
+    sequence_durations: An optional list of sequence durations to use. If not
+      specified, the total_time value will be used. Specifying durations is
+      useful if the sequences to be concatenated are effectively longer than
+      their total_time (e.g., a sequence that ends with a rest).
+
+  Returns:
+    A new sequence that is the result of concatenating *sequences.
+
+  Raises:
+    ValueError: If the length of sequences and sequence_durations do not match
+        or if a specified duration is less than the total_time of the sequence.
+  &#34;&#34;&#34;
+  if sequence_durations and len(sequences) != len(sequence_durations):
+    raise ValueError(
+        &#39;sequences and sequence_durations must be the same length.&#39;)
+  current_total_time = 0
+  cat_seq = music_pb2.NoteSequence()
+  for i in range(len(sequences)):
+    sequence = sequences[i]
+    if sequence_durations and sequence_durations[i] &lt; sequence.total_time:
+      raise ValueError(
+          &#39;Specified sequence duration ({}) must not be less than the &#39;
+          &#39;total_time of the sequence ({})&#39;.format(sequence_durations[i],
+                                                   sequence.total_time))
+    if current_total_time &gt; 0:
+      cat_seq.MergeFrom(shift_sequence_times(sequence, current_total_time))
+    else:
+      cat_seq.MergeFrom(sequence)
+
+    if sequence_durations:
+      current_total_time += sequence_durations[i]
+    else:
+      current_total_time = cat_seq.total_time
+
+  # Delete subsequence_info because we&#39;ve joined several subsequences.
+  cat_seq.ClearField(&#39;subsequence_info&#39;)
+
+  return remove_redundant_data(cat_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.expand_section_groups"><code class="name flex">
+<span>def <span class="ident">expand_section_groups</span></span>(<span>sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Expands a NoteSequence based on its section_groups.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The sequence to expand.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A copy of the original sequence, expanded based on its section_groups. If
+the sequence has no section_groups, a copy of the original sequence will be
+returned.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def expand_section_groups(sequence):
+  &#34;&#34;&#34;Expands a NoteSequence based on its section_groups.
+
+  Args:
+    sequence: The sequence to expand.
+
+  Returns:
+    A copy of the original sequence, expanded based on its section_groups. If
+    the sequence has no section_groups, a copy of the original sequence will be
+    returned.
+  &#34;&#34;&#34;
+  if not sequence.section_groups:
+    return copy.deepcopy(sequence)
+
+  sections = {}
+  section_durations = {}
+  for i in range(len(sequence.section_annotations)):
+    section_id = sequence.section_annotations[i].section_id
+    start_time = sequence.section_annotations[i].time
+    if i &lt; len(sequence.section_annotations) - 1:
+      end_time = sequence.section_annotations[i + 1].time
+    else:
+      end_time = sequence.total_time
+
+    subsequence = extract_subsequence(sequence, start_time, end_time)
+    # This is a subsequence, so the section_groups no longer make sense.
+    del subsequence.section_groups[:]
+    # This subsequence contains only 1 section and it has been shifted to time
+    # 0.
+    del subsequence.section_annotations[:]
+    subsequence.section_annotations.add(time=0, section_id=section_id)
+
+    sections[section_id] = subsequence
+    section_durations[section_id] = end_time - start_time
+
+  # Recursively expand section_groups.
+  def sections_in_group(section_group):
+    sections = []
+    for section in section_group.sections:
+      field = section.WhichOneof(&#39;section_type&#39;)
+      if field == &#39;section_id&#39;:
+        sections.append(section.section_id)
+      elif field == &#39;section_group&#39;:
+        sections.extend(sections_in_group(section.section_group))
+    return sections * section_group.num_times
+
+  sections_to_concat = []
+  for section_group in sequence.section_groups:
+    sections_to_concat.extend(sections_in_group(section_group))
+
+  return concatenate_sequences(
+      [sections[i] for i in sections_to_concat],
+      [section_durations[i] for i in sections_to_concat])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.extract_subsequence"><code class="name flex">
+<span>def <span class="ident">extract_subsequence</span></span>(<span>sequence, start_time, end_time, preserve_control_numbers=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Extracts a subsequence from a NoteSequence.</p>
+<p>Notes starting before <code>start_time</code> are not included. Notes ending after
+<code>end_time</code> are truncated. Time signature, tempo, key signature, chord changes,
+and sustain pedal events outside the specified time range are removed;
+however, the most recent event of each of these types prior to <code>start_time</code> is
+included at <code>start_time</code>. This means that e.g. if a time signature of 3/4 is
+specified in the original sequence prior to <code>start_time</code> (and is not followed
+by a different time signature), the extracted subsequence will include a 3/4
+time signature event at <code>start_time</code>. Pitch bends and control changes other
+than sustain are removed entirely.</p>
+<p>The extracted subsequence is shifted to start at time zero.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence to extract a subsequence from.</dd>
+<dt><strong><code>start_time</code></strong></dt>
+<dd>The float time in seconds to start the subsequence.</dd>
+<dt><strong><code>end_time</code></strong></dt>
+<dd>The float time in seconds to end the subsequence.</dd>
+<dt><strong><code>preserve_control_numbers</code></strong></dt>
+<dd>List of control change numbers to preserve as
+pedal events. The most recent event before the beginning of the
+subsequence will be inserted at the beginning of the subsequence.
+If None, will use DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A new NoteSequence containing the subsequence of <code>sequence</code> from the
+specified time range.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence has already been quantized.</dd>
+<dt><code>ValueError</code></dt>
+<dd>If <code>start_time</code> is past the end of <code>sequence</code>.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def extract_subsequence(sequence,
+                        start_time,
+                        end_time,
+                        preserve_control_numbers=None):
+  &#34;&#34;&#34;Extracts a subsequence from a NoteSequence.
+
+  Notes starting before `start_time` are not included. Notes ending after
+  `end_time` are truncated. Time signature, tempo, key signature, chord changes,
+  and sustain pedal events outside the specified time range are removed;
+  however, the most recent event of each of these types prior to `start_time` is
+  included at `start_time`. This means that e.g. if a time signature of 3/4 is
+  specified in the original sequence prior to `start_time` (and is not followed
+  by a different time signature), the extracted subsequence will include a 3/4
+  time signature event at `start_time`. Pitch bends and control changes other
+  than sustain are removed entirely.
+
+  The extracted subsequence is shifted to start at time zero.
+
+  Args:
+    sequence: The NoteSequence to extract a subsequence from.
+    start_time: The float time in seconds to start the subsequence.
+    end_time: The float time in seconds to end the subsequence.
+    preserve_control_numbers: List of control change numbers to preserve as
+      pedal events. The most recent event before the beginning of the
+      subsequence will be inserted at the beginning of the subsequence.
+      If None, will use DEFAULT_SUBSEQUENCE_PRESERVE_CONTROL_NUMBERS.
+
+
+  Returns:
+    A new NoteSequence containing the subsequence of `sequence` from the
+    specified time range.
+
+  Raises:
+    QuantizationStatusError: If the sequence has already been quantized.
+    ValueError: If `start_time` is past the end of `sequence`.
+  &#34;&#34;&#34;
+  return _extract_subsequences(
+      sequence,
+      split_times=[start_time, end_time],
+      preserve_control_numbers=preserve_control_numbers)[0]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.infer_dense_chords_for_sequence"><code class="name flex">
+<span>def <span class="ident">infer_dense_chords_for_sequence</span></span>(<span>sequence, instrument=None, min_notes_per_chord=3)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Infers chords for a NoteSequence and adds them as TextAnnotations.</p>
+<p>For each set of simultaneously-active notes in a NoteSequence (optionally for
+only one instrument), infers a chord symbol and adds it to NoteSequence as a
+TextAnnotation. Every change in the set of active notes will result in a new
+chord symbol unless the new set is smaller than <code>min_notes_per_chord</code>.</p>
+<p>If <code>sequence</code> is quantized, simultaneity will be determined by quantized steps
+instead of time.</p>
+<p>Not to be confused with the chord inference in note_sequence.chord_inference
+that attempts to infer a more natural chord sequence with changes at regular
+metric intervals.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which chords will be inferred. Will be
+modified in place.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>The instrument number whose notes will be used for chord
+inference. If None, all instruments will be used.</dd>
+<dt><strong><code>min_notes_per_chord</code></strong></dt>
+<dd>The minimum number of simultaneous notes for which to
+infer a chord.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ChordSymbolError</code></dt>
+<dd>If a chord cannot be determined for a set of</dd>
+</dl>
+<p>simultaneous notes in <code>sequence</code>.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def infer_dense_chords_for_sequence(sequence,
+                                    instrument=None,
+                                    min_notes_per_chord=3):
+  &#34;&#34;&#34;Infers chords for a NoteSequence and adds them as TextAnnotations.
+
+  For each set of simultaneously-active notes in a NoteSequence (optionally for
+  only one instrument), infers a chord symbol and adds it to NoteSequence as a
+  TextAnnotation. Every change in the set of active notes will result in a new
+  chord symbol unless the new set is smaller than `min_notes_per_chord`.
+
+  If `sequence` is quantized, simultaneity will be determined by quantized steps
+  instead of time.
+
+  Not to be confused with the chord inference in note_sequence.chord_inference
+  that attempts to infer a more natural chord sequence with changes at regular
+  metric intervals.
+
+  Args:
+    sequence: The NoteSequence for which chords will be inferred. Will be
+      modified in place.
+    instrument: The instrument number whose notes will be used for chord
+      inference. If None, all instruments will be used.
+    min_notes_per_chord: The minimum number of simultaneous notes for which to
+      infer a chord.
+
+  Raises:
+    ChordSymbolError: If a chord cannot be determined for a set of
+    simultaneous notes in `sequence`.
+  &#34;&#34;&#34;
+  notes = [
+      note for note in sequence.notes if not note.is_drum and
+      (instrument is None or note.instrument == instrument)
+  ]
+  sorted_notes = sorted(notes, key=lambda note: note.start_time)
+
+  # If the sequence is quantized, use quantized steps instead of time.
+  if is_quantized_sequence(sequence):
+    note_start = lambda note: note.quantized_start_step
+    note_end = lambda note: note.quantized_end_step
+  else:
+    note_start = lambda note: note.start_time
+    note_end = lambda note: note.end_time
+
+  # Sort all note start and end events.
+  onsets = [
+      (note_start(note), idx, False) for idx, note in enumerate(sorted_notes)
+  ]
+  offsets = [
+      (note_end(note), idx, True) for idx, note in enumerate(sorted_notes)
+  ]
+  events = sorted(onsets + offsets)
+
+  current_time = 0
+  current_figure = constants.NO_CHORD
+  active_notes = set()
+
+  for time, idx, is_offset in events:
+    if time &gt; current_time:
+      active_pitches = set(sorted_notes[idx].pitch for idx in active_notes)
+      if len(active_pitches) &gt;= min_notes_per_chord:
+        # Infer a chord symbol for the active pitches.
+        figure = chord_symbols_lib.pitches_to_chord_symbol(active_pitches)
+
+        if figure != current_figure:
+          # Add a text annotation to the sequence.
+          text_annotation = sequence.text_annotations.add()
+          text_annotation.text = figure
+          text_annotation.annotation_type = CHORD_SYMBOL
+          if is_quantized_sequence(sequence):
+            text_annotation.time = (
+                current_time * sequence.quantization_info.steps_per_quarter)
+            text_annotation.quantized_step = current_time
+          else:
+            text_annotation.time = current_time
+
+        current_figure = figure
+
+    current_time = time
+    if is_offset:
+      active_notes.remove(idx)
+    else:
+      active_notes.add(idx)
+
+  assert not active_notes</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.is_absolute_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">is_absolute_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether a NoteSequence proto has been quantized by absolute time.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>True if <code>note_sequence</code> is quantized by absolute time, otherwise False.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_absolute_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether a NoteSequence proto has been quantized by absolute time.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized by absolute time, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_second, assume
+  # that the proto has been quantized by absolute time.
+  return note_sequence.quantization_info.steps_per_second &gt; 0</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.is_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">is_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether or not a NoteSequence proto has been quantized.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>True if <code>note_sequence</code> is quantized, otherwise False.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether or not a NoteSequence proto has been quantized.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_quarter or
+  # steps_per_second, assume that the proto has been quantized.
+  return (note_sequence.quantization_info.steps_per_quarter &gt; 0 or
+          note_sequence.quantization_info.steps_per_second &gt; 0)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.is_relative_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">is_relative_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether a NoteSequence proto has been quantized relative to tempo.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence proto.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>True if <code>note_sequence</code> is quantized relative to tempo, otherwise False.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_relative_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Returns whether a NoteSequence proto has been quantized relative to tempo.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence proto.
+
+  Returns:
+    True if `note_sequence` is quantized relative to tempo, otherwise False.
+  &#34;&#34;&#34;
+  # If the QuantizationInfo message has a non-zero steps_per_quarter, assume
+  # that the proto has been quantized relative to tempo.
+  return note_sequence.quantization_info.steps_per_quarter &gt; 0</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.pianoroll_onsets_to_note_sequence"><code class="name flex">
+<span>def <span class="ident">pianoroll_onsets_to_note_sequence</span></span>(<span>onsets, frames_per_second, note_duration_seconds=0.05, velocity=70, instrument=0, program=0, qpm=120.0, min_midi_pitch=0, velocity_values=None, velocity_scale=80, velocity_bias=10)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert onsets to a NoteSequence.</p>
+<p>This converts an matrix of onsets into a NoteSequence. Every active onset
+is considered to be a new note with a fixed duration of note_duration_seconds.
+This is different from pianoroll_to_note_sequence, which considers onsets in
+consecutive frames to represent a single new note.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>onsets</code></strong></dt>
+<dd>Numpy array of onsets.</dd>
+<dt><strong><code>frames_per_second</code></strong></dt>
+<dd>Frames per second.</dd>
+<dt><strong><code>note_duration_seconds</code></strong></dt>
+<dd>Fixed length of every note.</dd>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Default note velocity if velocity_values is not provided.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Instrument for the note sequence.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>Program for the note sequence.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>QPM for the note sequence.</dd>
+<dt><strong><code>min_midi_pitch</code></strong></dt>
+<dd>MIDI pitch offset.</dd>
+<dt><strong><code>velocity_values</code></strong></dt>
+<dd>Numpy array of floats representing velocities.</dd>
+<dt><strong><code>velocity_scale</code></strong></dt>
+<dd>Scale to use for conversion to MIDI velocity.</dd>
+<dt><strong><code>velocity_bias</code></strong></dt>
+<dd>Bias to use for conversion to MIDI velocity.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Generated NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def pianoroll_onsets_to_note_sequence(onsets,
+                                      frames_per_second,
+                                      note_duration_seconds=0.05,
+                                      velocity=70,
+                                      instrument=0,
+                                      program=0,
+                                      qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                                      min_midi_pitch=constants.MIN_MIDI_PITCH,
+                                      velocity_values=None,
+                                      velocity_scale=80,
+                                      velocity_bias=10):
+  &#34;&#34;&#34;Convert onsets to a NoteSequence.
+
+  This converts an matrix of onsets into a NoteSequence. Every active onset
+  is considered to be a new note with a fixed duration of note_duration_seconds.
+  This is different from pianoroll_to_note_sequence, which considers onsets in
+  consecutive frames to represent a single new note.
+
+
+  Args:
+    onsets: Numpy array of onsets.
+    frames_per_second: Frames per second.
+    note_duration_seconds: Fixed length of every note.
+    velocity: Default note velocity if velocity_values is not provided.
+    instrument: Instrument for the note sequence.
+    program: Program for the note sequence.
+    qpm: QPM for the note sequence.
+    min_midi_pitch: MIDI pitch offset.
+    velocity_values: Numpy array of floats representing velocities.
+    velocity_scale: Scale to use for conversion to MIDI velocity.
+    velocity_bias: Bias to use for conversion to MIDI velocity.
+
+  Returns:
+    Generated NoteSequence proto.
+  &#34;&#34;&#34;
+  frame_length_seconds = 1 / frames_per_second
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = constants.STANDARD_PPQ
+
+  if velocity_values is None:
+    velocity_values = velocity * np.ones_like(onsets, dtype=np.int32)
+
+  for frame, pitch in zip(*np.nonzero(onsets)):
+    start_time = frame * frame_length_seconds
+    end_time = start_time + note_duration_seconds
+
+    note = sequence.notes.add()
+    note.start_time = start_time
+    note.end_time = end_time
+    note.pitch = pitch + min_midi_pitch
+    note.velocity = _unscale_velocity(
+        velocity_values[frame, pitch],
+        scale=velocity_scale,
+        bias=velocity_bias)
+    note.instrument = instrument
+    note.program = program
+
+  sequence.total_time = (
+      len(onsets) * frame_length_seconds + note_duration_seconds)
+  if sequence.notes:
+    assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.pianoroll_to_note_sequence"><code class="name flex">
+<span>def <span class="ident">pianoroll_to_note_sequence</span></span>(<span>frames, frames_per_second, min_duration_ms, velocity=70, instrument=0, program=0, qpm=120.0, min_midi_pitch=0, onset_predictions=None, offset_predictions=None, velocity_values=None, velocity_scale=80, velocity_bias=10)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert frames (with optional onsets, offsets, velocities) to NoteSequence.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>frames</code></strong></dt>
+<dd>Numpy array of active frames. Expected shape is (time, pitch).</dd>
+<dt><strong><code>frames_per_second</code></strong></dt>
+<dd>Frames per second.</dd>
+<dt><strong><code>min_duration_ms</code></strong></dt>
+<dd>Notes active for less than this duration will be ignored.</dd>
+<dt><strong><code>velocity</code></strong></dt>
+<dd>Default note velocity if velocity_values is not provided.</dd>
+<dt><strong><code>instrument</code></strong></dt>
+<dd>Instrument for the note sequence.</dd>
+<dt><strong><code>program</code></strong></dt>
+<dd>Program for the note sequence.</dd>
+<dt><strong><code>qpm</code></strong></dt>
+<dd>QPM for the note sequence.</dd>
+<dt><strong><code>min_midi_pitch</code></strong></dt>
+<dd>MIDI pitch offset.</dd>
+<dt><strong><code>onset_predictions</code></strong></dt>
+<dd>Numpy array of onset predictions. If specified, a new
+note will not start unless it is active in this array.</dd>
+<dt><strong><code>offset_predictions</code></strong></dt>
+<dd>Numpy array of onset predictions. If specified, notes
+will end no later than when these offsets are predicted.</dd>
+<dt><strong><code>velocity_values</code></strong></dt>
+<dd>Numpy array of floats representing velocities.</dd>
+<dt><strong><code>velocity_scale</code></strong></dt>
+<dd>Scale to use for conversion to MIDI velocity.</dd>
+<dt><strong><code>velocity_bias</code></strong></dt>
+<dd>Bias to use for conversion to MIDI velocity.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Generated NoteSequence proto.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def pianoroll_to_note_sequence(frames,
+                               frames_per_second,
+                               min_duration_ms,
+                               velocity=70,
+                               instrument=0,
+                               program=0,
+                               qpm=constants.DEFAULT_QUARTERS_PER_MINUTE,
+                               min_midi_pitch=constants.MIN_MIDI_PITCH,
+                               onset_predictions=None,
+                               offset_predictions=None,
+                               velocity_values=None,
+                               velocity_scale=80,
+                               velocity_bias=10):
+  &#34;&#34;&#34;Convert frames (with optional onsets, offsets, velocities) to NoteSequence.
+
+  Args:
+    frames: Numpy array of active frames. Expected shape is (time, pitch).
+    frames_per_second: Frames per second.
+    min_duration_ms: Notes active for less than this duration will be ignored.
+    velocity: Default note velocity if velocity_values is not provided.
+    instrument: Instrument for the note sequence.
+    program: Program for the note sequence.
+    qpm: QPM for the note sequence.
+    min_midi_pitch: MIDI pitch offset.
+    onset_predictions: Numpy array of onset predictions. If specified, a new
+      note will not start unless it is active in this array.
+    offset_predictions: Numpy array of onset predictions. If specified, notes
+      will end no later than when these offsets are predicted.
+    velocity_values: Numpy array of floats representing velocities.
+    velocity_scale: Scale to use for conversion to MIDI velocity.
+    velocity_bias: Bias to use for conversion to MIDI velocity.
+
+  Returns:
+    Generated NoteSequence proto.
+  &#34;&#34;&#34;
+  frame_length_seconds = 1 / frames_per_second
+
+  sequence = music_pb2.NoteSequence()
+  sequence.tempos.add().qpm = qpm
+  sequence.ticks_per_quarter = constants.STANDARD_PPQ
+
+  pitch_start_step = {}
+  onset_velocities = np.zeros(constants.MAX_MIDI_PITCH+1, dtype=np.int32)
+
+  # Add silent frame at the end so we can do a final loop and terminate any
+  # notes that are still active.
+  frames = np.append(frames, [np.zeros(frames[0].shape)], 0)
+
+  if onset_predictions is not None:
+    onset_predictions = np.append(onset_predictions,
+                                  [np.zeros(onset_predictions[0].shape)], 0)
+    # Ensure that any frame with an onset prediction is considered active.
+    frames = np.logical_or(frames, onset_predictions)
+
+  if offset_predictions is not None:
+    offset_predictions = np.append(offset_predictions,
+                                   [np.zeros(offset_predictions[0].shape)], 0)
+    # If the frame and offset are both on, then turn it off
+    frames[np.where(np.logical_and(frames &gt; 0, offset_predictions &gt; 0))] = 0
+
+  def end_pitch(pitch, end_frame):
+    &#34;&#34;&#34;End an active pitch.&#34;&#34;&#34;
+    start_time = pitch_start_step[pitch] * frame_length_seconds
+    end_time = end_frame * frame_length_seconds
+
+    if (end_time - start_time) * 1000 &gt;= min_duration_ms:
+      note = sequence.notes.add()
+      note.start_time = start_time
+      note.end_time = end_time
+      note.pitch = pitch + min_midi_pitch
+      note.velocity = onset_velocities[pitch]
+      note.instrument = instrument
+      note.program = program
+
+    del pitch_start_step[pitch]
+
+  def process_active_pitch(pitch, i):
+    &#34;&#34;&#34;Process a pitch being active in a given frame.&#34;&#34;&#34;
+    if pitch not in pitch_start_step:
+      if onset_predictions is not None:
+        # If onset predictions were supplied, only allow a new note to start
+        # if we&#39;ve predicted an onset.
+        if onset_predictions[i, pitch]:
+          pitch_start_step[pitch] = i
+          if velocity_values is not None:
+            onset_velocities[pitch] = _unscale_velocity(
+                velocity_values[i, pitch],
+                scale=velocity_scale,
+                bias=velocity_bias)
+          else:
+            onset_velocities[pitch] = velocity
+        else:
+          # Even though the frame is active, the onset predictor doesn&#39;t
+          # say there should be an onset, so ignore it.
+          pass
+      else:
+        pitch_start_step[pitch] = i
+    else:
+      if onset_predictions is not None:
+        # pitch is already active, but if this is a new onset, we should end
+        # the note and start a new one.
+        if (onset_predictions[i, pitch] and
+            not onset_predictions[i - 1, pitch]):
+          end_pitch(pitch, i)
+          pitch_start_step[pitch] = i
+          if velocity_values is not None:
+            onset_velocities[pitch] = _unscale_velocity(
+                velocity_values[i, pitch],
+                scale=velocity_scale,
+                bias=velocity_bias)
+          else:
+            onset_velocities[pitch] = velocity
+
+  for i, frame in enumerate(frames):
+    for pitch, active in enumerate(frame):
+      if active:
+        process_active_pitch(pitch, i)
+      elif pitch in pitch_start_step:
+        end_pitch(pitch, i)
+
+  sequence.total_time = len(frames) * frame_length_seconds
+  if sequence.notes:
+    assert sequence.total_time &gt;= sequence.notes[-1].end_time
+
+  return sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.quantize_note_sequence"><code class="name flex">
+<span>def <span class="ident">quantize_note_sequence</span></span>(<span>note_sequence, steps_per_quarter)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Quantize a NoteSequence proto relative to tempo.</p>
+<p>The input NoteSequence is copied and quantization-related fields are
+populated. Sets the <code>steps_per_quarter</code> field in the <code>quantization_info</code>
+message in the NoteSequence.</p>
+<p>Note start and end times, and chord times are snapped to a nearby quantized
+step, and the resulting times are stored in a separate field (e.g.,
+quantized_start_step). See the comments above <code>QUANTIZE_CUTOFF</code> for details on
+how the quantizing algorithm works.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence protocol buffer.</dd>
+<dt><strong><code>steps_per_quarter</code></strong></dt>
+<dd>Each quarter note of music will be divided into this many
+quantized time steps.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A copy of the original NoteSequence, with quantized times added.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.MultipleTimeSignatureError" href="#note_seq.sequences_lib.MultipleTimeSignatureError">MultipleTimeSignatureError</a></code></dt>
+<dd>If there is a change in time signature
+in <code>note_sequence</code>.</dd>
+<dt><code><a title="note_seq.sequences_lib.MultipleTempoError" href="#note_seq.sequences_lib.MultipleTempoError">MultipleTempoError</a></code></dt>
+<dd>If there is a change in tempo in <code>note_sequence</code>.</dd>
+<dt><code><a title="note_seq.sequences_lib.BadTimeSignatureError" href="#note_seq.sequences_lib.BadTimeSignatureError">BadTimeSignatureError</a></code></dt>
+<dd>If the time signature found in <code>note_sequence</code>
+has a 0 numerator or a denominator which is not a power of 2.</dd>
+<dt><code><a title="note_seq.sequences_lib.NegativeTimeError" href="#note_seq.sequences_lib.NegativeTimeError">NegativeTimeError</a></code></dt>
+<dd>If a note or chord occurs at a negative time.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def quantize_note_sequence(note_sequence, steps_per_quarter):
+  &#34;&#34;&#34;Quantize a NoteSequence proto relative to tempo.
+
+  The input NoteSequence is copied and quantization-related fields are
+  populated. Sets the `steps_per_quarter` field in the `quantization_info`
+  message in the NoteSequence.
+
+  Note start and end times, and chord times are snapped to a nearby quantized
+  step, and the resulting times are stored in a separate field (e.g.,
+  quantized_start_step). See the comments above `QUANTIZE_CUTOFF` for details on
+  how the quantizing algorithm works.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence protocol buffer.
+    steps_per_quarter: Each quarter note of music will be divided into this many
+      quantized time steps.
+
+  Returns:
+    A copy of the original NoteSequence, with quantized times added.
+
+  Raises:
+    MultipleTimeSignatureError: If there is a change in time signature
+        in `note_sequence`.
+    MultipleTempoError: If there is a change in tempo in `note_sequence`.
+    BadTimeSignatureError: If the time signature found in `note_sequence`
+        has a 0 numerator or a denominator which is not a power of 2.
+    NegativeTimeError: If a note or chord occurs at a negative time.
+  &#34;&#34;&#34;
+  qns = copy.deepcopy(note_sequence)
+
+  qns.quantization_info.steps_per_quarter = steps_per_quarter
+
+  if qns.time_signatures:
+    time_signatures = sorted(qns.time_signatures, key=lambda ts: ts.time)
+    # There is an implicit 4/4 time signature at 0 time. So if the first time
+    # signature is something other than 4/4 and it&#39;s at a time other than 0,
+    # that&#39;s an implicit time signature change.
+    if time_signatures[0].time != 0 and not (
+        time_signatures[0].numerator == 4 and
+        time_signatures[0].denominator == 4):
+      raise MultipleTimeSignatureError(
+          &#39;NoteSequence has an implicit change from initial 4/4 time &#39;
+          &#39;signature to %d/%d at %.2f seconds.&#39; %
+          (time_signatures[0].numerator, time_signatures[0].denominator,
+           time_signatures[0].time))
+
+    for time_signature in time_signatures[1:]:
+      if (time_signature.numerator != qns.time_signatures[0].numerator or
+          time_signature.denominator != qns.time_signatures[0].denominator):
+        raise MultipleTimeSignatureError(
+            &#39;NoteSequence has at least one time signature change from %d/%d to &#39;
+            &#39;%d/%d at %.2f seconds.&#39; %
+            (time_signatures[0].numerator, time_signatures[0].denominator,
+             time_signature.numerator, time_signature.denominator,
+             time_signature.time))
+
+    # Make it clear that there is only 1 time signature and it starts at the
+    # beginning.
+    qns.time_signatures[0].time = 0
+    del qns.time_signatures[1:]
+  else:
+    time_signature = qns.time_signatures.add()
+    time_signature.numerator = 4
+    time_signature.denominator = 4
+    time_signature.time = 0
+
+  if not _is_power_of_2(qns.time_signatures[0].denominator):
+    raise BadTimeSignatureError(
+        &#39;Denominator is not a power of 2. Time signature: %d/%d&#39; %
+        (qns.time_signatures[0].numerator, qns.time_signatures[0].denominator))
+
+  if qns.time_signatures[0].numerator == 0:
+    raise BadTimeSignatureError(
+        &#39;Numerator is 0. Time signature: %d/%d&#39; %
+        (qns.time_signatures[0].numerator, qns.time_signatures[0].denominator))
+
+  if qns.tempos:
+    tempos = sorted(qns.tempos, key=lambda t: t.time)
+    # There is an implicit 120.0 qpm tempo at 0 time. So if the first tempo is
+    # something other that 120.0 and it&#39;s at a time other than 0, that&#39;s an
+    # implicit tempo change.
+    if tempos[0].time != 0 and (tempos[0].qpm !=
+                                constants.DEFAULT_QUARTERS_PER_MINUTE):
+      raise MultipleTempoError(
+          &#39;NoteSequence has an implicit tempo change from initial %.1f qpm to &#39;
+          &#39;%.1f qpm at %.2f seconds.&#39; % (constants.DEFAULT_QUARTERS_PER_MINUTE,
+                                         tempos[0].qpm, tempos[0].time))
+
+    for tempo in tempos[1:]:
+      if tempo.qpm != qns.tempos[0].qpm:
+        raise MultipleTempoError(
+            &#39;NoteSequence has at least one tempo change from %.1f qpm to %.1f &#39;
+            &#39;qpm at %.2f seconds.&#39; % (tempos[0].qpm, tempo.qpm, tempo.time))
+
+    # Make it clear that there is only 1 tempo and it starts at the beginning.
+    qns.tempos[0].time = 0
+    del qns.tempos[1:]
+  else:
+    tempo = qns.tempos.add()
+    tempo.qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+    tempo.time = 0
+
+  # Compute quantization steps per second.
+  steps_per_second = steps_per_quarter_to_steps_per_second(
+      steps_per_quarter, qns.tempos[0].qpm)
+
+  qns.total_quantized_steps = quantize_to_step(qns.total_time, steps_per_second)
+  _quantize_notes(qns, steps_per_second)
+
+  return qns</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.quantize_note_sequence_absolute"><code class="name flex">
+<span>def <span class="ident">quantize_note_sequence_absolute</span></span>(<span>note_sequence, steps_per_second)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Quantize a NoteSequence proto using absolute event times.</p>
+<p>The input NoteSequence is copied and quantization-related fields are
+populated. Sets the <code>steps_per_second</code> field in the <code>quantization_info</code>
+message in the NoteSequence.</p>
+<p>Note start and end times, and chord times are snapped to a nearby quantized
+step, and the resulting times are stored in a separate field (e.g.,
+quantized_start_step). See the comments above <code>QUANTIZE_CUTOFF</code> for details on
+how the quantizing algorithm works.</p>
+<p>Tempos and time signatures will be copied but ignored.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>A music_pb2.NoteSequence protocol buffer.</dd>
+<dt><strong><code>steps_per_second</code></strong></dt>
+<dd>Each second will be divided into this many quantized time
+steps.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A copy of the original NoteSequence, with quantized times added.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.NegativeTimeError" href="#note_seq.sequences_lib.NegativeTimeError">NegativeTimeError</a></code></dt>
+<dd>If a note or chord occurs at a negative time.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def quantize_note_sequence_absolute(note_sequence, steps_per_second):
+  &#34;&#34;&#34;Quantize a NoteSequence proto using absolute event times.
+
+  The input NoteSequence is copied and quantization-related fields are
+  populated. Sets the `steps_per_second` field in the `quantization_info`
+  message in the NoteSequence.
+
+  Note start and end times, and chord times are snapped to a nearby quantized
+  step, and the resulting times are stored in a separate field (e.g.,
+  quantized_start_step). See the comments above `QUANTIZE_CUTOFF` for details on
+  how the quantizing algorithm works.
+
+  Tempos and time signatures will be copied but ignored.
+
+  Args:
+    note_sequence: A music_pb2.NoteSequence protocol buffer.
+    steps_per_second: Each second will be divided into this many quantized time
+      steps.
+
+  Returns:
+    A copy of the original NoteSequence, with quantized times added.
+
+  Raises:
+    NegativeTimeError: If a note or chord occurs at a negative time.
+  &#34;&#34;&#34;
+  qns = copy.deepcopy(note_sequence)
+  qns.quantization_info.steps_per_second = steps_per_second
+
+  qns.total_quantized_steps = quantize_to_step(qns.total_time, steps_per_second)
+  _quantize_notes(qns, steps_per_second)
+
+  return qns</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.quantize_to_step"><code class="name flex">
+<span>def <span class="ident">quantize_to_step</span></span>(<span>unquantized_seconds, steps_per_second, quantize_cutoff=0.5)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Quantizes seconds to the nearest step, given steps_per_second.</p>
+<p>See the comments above <code>QUANTIZE_CUTOFF</code> for details on how the quantizing
+algorithm works.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>unquantized_seconds</code></strong></dt>
+<dd>Seconds to quantize.</dd>
+<dt><strong><code>steps_per_second</code></strong></dt>
+<dd>Quantizing resolution.</dd>
+<dt><strong><code>quantize_cutoff</code></strong></dt>
+<dd>Value to use for quantizing cutoff.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The input value quantized to the nearest step.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def quantize_to_step(unquantized_seconds,
+                     steps_per_second,
+                     quantize_cutoff=QUANTIZE_CUTOFF):
+  &#34;&#34;&#34;Quantizes seconds to the nearest step, given steps_per_second.
+
+  See the comments above `QUANTIZE_CUTOFF` for details on how the quantizing
+  algorithm works.
+
+  Args:
+    unquantized_seconds: Seconds to quantize.
+    steps_per_second: Quantizing resolution.
+    quantize_cutoff: Value to use for quantizing cutoff.
+
+  Returns:
+    The input value quantized to the nearest step.
+  &#34;&#34;&#34;
+  unquantized_steps = unquantized_seconds * steps_per_second
+  return int(unquantized_steps + (1 - quantize_cutoff))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.rectify_beats"><code class="name flex">
+<span>def <span class="ident">rectify_beats</span></span>(<span>sequence, beats_per_minute)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Warps a NoteSequence so that beats happen at regular intervals.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The source NoteSequence. Will not be modified.</dd>
+<dt><strong><code>beats_per_minute</code></strong></dt>
+<dd>Desired BPM of the rectified sequence.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>rectified_sequence</code></dt>
+<dd>A copy of <code>sequence</code> with times adjusted so that beats
+occur at regular intervals with BPM <code>beats_per_minute</code>.</dd>
+<dt><code>alignment</code></dt>
+<dd>An N-by-2 array where each row contains the original and
+rectified times for a beat.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If <code>sequence</code> is quantized.</dd>
+<dt><code><a title="note_seq.sequences_lib.RectifyBeatsError" href="#note_seq.sequences_lib.RectifyBeatsError">RectifyBeatsError</a></code></dt>
+<dd>If <code>sequence</code> has no beat annotations.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def rectify_beats(sequence, beats_per_minute):
+  &#34;&#34;&#34;Warps a NoteSequence so that beats happen at regular intervals.
+
+  Args:
+    sequence: The source NoteSequence. Will not be modified.
+    beats_per_minute: Desired BPM of the rectified sequence.
+
+  Returns:
+    rectified_sequence: A copy of `sequence` with times adjusted so that beats
+        occur at regular intervals with BPM `beats_per_minute`.
+    alignment: An N-by-2 array where each row contains the original and
+        rectified times for a beat.
+
+  Raises:
+    QuantizationStatusError: If `sequence` is quantized.
+    RectifyBeatsError: If `sequence` has no beat annotations.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Cannot rectify beat times for quantized NoteSequence.&#39;)
+
+  beat_times = [
+      ta.time for ta in sequence.text_annotations
+      if ta.annotation_type == music_pb2.NoteSequence.TextAnnotation.BEAT
+      and ta.time &lt;= sequence.total_time
+  ]
+
+  if not beat_times:
+    raise RectifyBeatsError(&#39;No beats in NoteSequence.&#39;)
+
+  # Add a beat at the very beginning and end of the sequence and dedupe.
+  sorted_beat_times = [0.0] + sorted(beat_times) + [sequence.total_time]
+  unique_beat_times = np.array([
+      sorted_beat_times[i] for i in range(len(sorted_beat_times))
+      if i == 0 or sorted_beat_times[i] &gt; sorted_beat_times[i - 1]
+  ])
+  num_beats = len(unique_beat_times)
+
+  # Use linear interpolation to map original times to rectified times.
+  seconds_per_beat = 60.0 / beats_per_minute
+  rectified_beat_times = seconds_per_beat * np.arange(num_beats)
+  def time_func(t):
+    return np.interp(t, unique_beat_times, rectified_beat_times,
+                     left=0.0, right=sequence.total_time)
+
+  rectified_sequence, _ = adjust_notesequence_times(sequence, time_func)
+
+  # Sequence probably shouldn&#39;t have time signatures but delete them just to be
+  # sure, and add a single tempo.
+  del rectified_sequence.time_signatures[:]
+  rectified_sequence.tempos.add(qpm=beats_per_minute)
+
+  return rectified_sequence, np.array([unique_beat_times,
+                                       rectified_beat_times]).T</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.remove_redundant_data"><code class="name flex">
+<span>def <span class="ident">remove_redundant_data</span></span>(<span>sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a copy of the sequence with redundant data removed.</p>
+<p>An event is considered redundant if it is a time signature, a key signature,
+or a tempo that differs from the previous event of the same type only by time.
+For example, a tempo mark of 120 qpm at 5 seconds would be considered
+redundant if it followed a tempo mark of 120 qpm and 4 seconds.</p>
+<p>Fields in sequence_metadata are considered redundant if the same string is
+repeated.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The sequence to process.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A new sequence with redundant events removed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def remove_redundant_data(sequence):
+  &#34;&#34;&#34;Returns a copy of the sequence with redundant data removed.
+
+  An event is considered redundant if it is a time signature, a key signature,
+  or a tempo that differs from the previous event of the same type only by time.
+  For example, a tempo mark of 120 qpm at 5 seconds would be considered
+  redundant if it followed a tempo mark of 120 qpm and 4 seconds.
+
+  Fields in sequence_metadata are considered redundant if the same string is
+  repeated.
+
+  Args:
+    sequence: The sequence to process.
+
+  Returns:
+    A new sequence with redundant events removed.
+  &#34;&#34;&#34;
+  fixed_sequence = copy.deepcopy(sequence)
+  for events in [
+      fixed_sequence.time_signatures, fixed_sequence.key_signatures,
+      fixed_sequence.tempos
+  ]:
+    events.sort(key=lambda e: e.time)
+    for i in range(len(events) - 1, 0, -1):
+      tmp_ts = copy.deepcopy(events[i])
+      tmp_ts.time = events[i - 1].time
+      # If the only difference between the two events is time, then delete the
+      # second one.
+      if tmp_ts == events[i - 1]:
+        del events[i]
+
+  if fixed_sequence.HasField(&#39;sequence_metadata&#39;):
+    # Add composers and genres, preserving order, but dropping duplicates.
+    del fixed_sequence.sequence_metadata.composers[:]
+    added_composer = set()
+    for composer in sequence.sequence_metadata.composers:
+      if composer not in added_composer:
+        fixed_sequence.sequence_metadata.composers.append(composer)
+        added_composer.add(composer)
+
+    del fixed_sequence.sequence_metadata.genre[:]
+    added_genre = set()
+    for genre in sequence.sequence_metadata.genre:
+      if genre not in added_genre:
+        fixed_sequence.sequence_metadata.genre.append(genre)
+        added_genre.add(genre)
+
+  return fixed_sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.repeat_sequence_to_duration"><code class="name flex">
+<span>def <span class="ident">repeat_sequence_to_duration</span></span>(<span>sequence, duration, sequence_duration=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Repeat a sequence until it is a given duration, trimming any extra.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>the sequence to repeat</dd>
+<dt><strong><code>duration</code></strong></dt>
+<dd>the desired duration</dd>
+<dt><strong><code>sequence_duration</code></strong></dt>
+<dd>If provided, will be used instead of sequence.total_time</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The repeated and possibly trimmed sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def repeat_sequence_to_duration(sequence, duration, sequence_duration=None):
+  &#34;&#34;&#34;Repeat a sequence until it is a given duration, trimming any extra.
+
+  Args:
+    sequence: the sequence to repeat
+    duration: the desired duration
+    sequence_duration: If provided, will be used instead of sequence.total_time
+
+  Returns:
+    The repeated and possibly trimmed sequence.
+  &#34;&#34;&#34;
+  if not sequence_duration:
+    sequence_duration = sequence.total_time
+  num_repeats = int(math.ceil(duration / sequence_duration))
+  repeated_ns = concatenate_sequences(
+      [sequence] * num_repeats,
+      sequence_durations=[sequence_duration] * num_repeats)
+
+  trimmed = extract_subsequence(repeated_ns, start_time=0, end_time=duration)
+  trimmed.ClearField(&#39;subsequence_info&#39;)  # Not relevant in this case.
+  return trimmed</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.sequence_to_pianoroll"><code class="name flex">
+<span>def <span class="ident">sequence_to_pianoroll</span></span>(<span>sequence, frames_per_second, min_pitch, max_pitch, min_velocity=1, max_velocity=127, add_blank_frame_before_onset=False, onset_upweight=5.0, onset_window=1, onset_length_ms=0, offset_length_ms=0, onset_mode='window', onset_delay_ms=0.0, min_frame_occupancy_for_label=0.0, onset_overlap=True)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transforms a NoteSequence to a pianoroll assuming a single instrument.</p>
+<p>This function uses floating point internally and may return different results
+on different platforms or with different compiler settings or with
+different compilers.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence to convert.</dd>
+<dt><strong><code>frames_per_second</code></strong></dt>
+<dd>How many frames per second.</dd>
+<dt><strong><code>min_pitch</code></strong></dt>
+<dd>pitches in the sequence below this will be ignored.</dd>
+<dt><strong><code>max_pitch</code></strong></dt>
+<dd>pitches in the sequence above this will be ignored.</dd>
+<dt><strong><code>min_velocity</code></strong></dt>
+<dd>minimum velocity for the track, currently unused.</dd>
+<dt><strong><code>max_velocity</code></strong></dt>
+<dd>maximum velocity for the track, not just the local sequence,
+used to globally normalize the velocities between [0, 1].</dd>
+<dt><strong><code>add_blank_frame_before_onset</code></strong></dt>
+<dd>Always have a blank frame before onsets.</dd>
+<dt><strong><code>onset_upweight</code></strong></dt>
+<dd>Factor by which to increase the weight assigned to onsets.</dd>
+<dt><strong><code>onset_window</code></strong></dt>
+<dd>Fixed window size to activate around onsets in <code>onsets</code> and
+<code>onset_velocities</code>. Used only if <code>onset_mode</code> is 'window'.</dd>
+<dt><strong><code>onset_length_ms</code></strong></dt>
+<dd>Length in milliseconds for the onset. Used only if
+onset_mode is 'length_ms'.</dd>
+<dt><strong><code>offset_length_ms</code></strong></dt>
+<dd>Length in milliseconds for the offset. Used only if
+offset_mode is 'length_ms'.</dd>
+<dt><strong><code>onset_mode</code></strong></dt>
+<dd>Either 'window', to use onset_window, or 'length_ms' to use
+onset_length_ms.</dd>
+<dt><strong><code>onset_delay_ms</code></strong></dt>
+<dd>Number of milliseconds to delay the onset. Can be negative.</dd>
+<dt><strong><code>min_frame_occupancy_for_label</code></strong></dt>
+<dd>floating point value in range [0, 1] a note
+must occupy at least this percentage of a frame, for the frame to be given
+a label with the note.</dd>
+<dt><strong><code>onset_overlap</code></strong></dt>
+<dd>Whether or not the onsets overlap with the frames.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>When an unknown onset_mode is supplied.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>active</code></dt>
+<dd>Active note pianoroll as a 2D array..</dd>
+<dt><code>weights</code></dt>
+<dd>Weights to be used when calculating loss against roll.</dd>
+<dt><code>onsets</code></dt>
+<dd>An onset-only pianoroll as a 2D array.</dd>
+<dt><code>onset_velocities</code></dt>
+<dd>Velocities of onsets scaled from [0, 1].</dd>
+<dt><code>active_velocities</code></dt>
+<dd>Velocities of active notes scaled from [0, 1].</dd>
+<dt><code>offsets</code></dt>
+<dd>An offset-only pianoroll as a 2D array.</dd>
+<dt><code>control_changes</code></dt>
+<dd>Control change onsets as a 2D array (time, control number)
+with 0 when there is no onset and (control_value + 1) when there is.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_to_pianoroll(
+    sequence,
+    frames_per_second,
+    min_pitch,
+    max_pitch,
+    # pylint: disable=unused-argument
+    min_velocity=constants.MIN_MIDI_VELOCITY,
+    # pylint: enable=unused-argument
+    max_velocity=constants.MAX_MIDI_VELOCITY,
+    add_blank_frame_before_onset=False,
+    onset_upweight=ONSET_UPWEIGHT,
+    onset_window=ONSET_WINDOW,
+    onset_length_ms=0,
+    offset_length_ms=0,
+    onset_mode=&#39;window&#39;,
+    onset_delay_ms=0.0,
+    min_frame_occupancy_for_label=0.0,
+    onset_overlap=True):
+  &#34;&#34;&#34;Transforms a NoteSequence to a pianoroll assuming a single instrument.
+
+  This function uses floating point internally and may return different results
+  on different platforms or with different compiler settings or with
+  different compilers.
+
+  Args:
+    sequence: The NoteSequence to convert.
+    frames_per_second: How many frames per second.
+    min_pitch: pitches in the sequence below this will be ignored.
+    max_pitch: pitches in the sequence above this will be ignored.
+    min_velocity: minimum velocity for the track, currently unused.
+    max_velocity: maximum velocity for the track, not just the local sequence,
+      used to globally normalize the velocities between [0, 1].
+    add_blank_frame_before_onset: Always have a blank frame before onsets.
+    onset_upweight: Factor by which to increase the weight assigned to onsets.
+    onset_window: Fixed window size to activate around onsets in `onsets` and
+      `onset_velocities`. Used only if `onset_mode` is &#39;window&#39;.
+    onset_length_ms: Length in milliseconds for the onset. Used only if
+      onset_mode is &#39;length_ms&#39;.
+    offset_length_ms: Length in milliseconds for the offset. Used only if
+      offset_mode is &#39;length_ms&#39;.
+    onset_mode: Either &#39;window&#39;, to use onset_window, or &#39;length_ms&#39; to use
+      onset_length_ms.
+    onset_delay_ms: Number of milliseconds to delay the onset. Can be negative.
+    min_frame_occupancy_for_label: floating point value in range [0, 1] a note
+      must occupy at least this percentage of a frame, for the frame to be given
+      a label with the note.
+    onset_overlap: Whether or not the onsets overlap with the frames.
+
+  Raises:
+    ValueError: When an unknown onset_mode is supplied.
+
+  Returns:
+    active: Active note pianoroll as a 2D array..
+    weights: Weights to be used when calculating loss against roll.
+    onsets: An onset-only pianoroll as a 2D array.
+    onset_velocities: Velocities of onsets scaled from [0, 1].
+    active_velocities: Velocities of active notes scaled from [0, 1].
+    offsets: An offset-only pianoroll as a 2D array.
+    control_changes: Control change onsets as a 2D array (time, control number)
+      with 0 when there is no onset and (control_value + 1) when there is.
+  &#34;&#34;&#34;
+  roll = np.zeros((int(sequence.total_time * frames_per_second + 1),
+                   max_pitch - min_pitch + 1),
+                  dtype=np.float32)
+
+  roll_weights = np.ones_like(roll)
+
+  onsets = np.zeros_like(roll)
+  offsets = np.zeros_like(roll)
+
+  control_changes = np.zeros(
+      (int(sequence.total_time * frames_per_second + 1), 128), dtype=np.int32)
+
+  def frames_from_times(start_time, end_time):
+    &#34;&#34;&#34;Converts start/end times to start/end frames.&#34;&#34;&#34;
+    # Will round down because note may start or end in the middle of the frame.
+    start_frame = int(start_time * frames_per_second)
+    start_frame_occupancy = (start_frame + 1 - start_time * frames_per_second)
+    # check for &gt; 0.0 to avoid possible numerical issues
+    if (min_frame_occupancy_for_label &gt; 0.0 and
+        start_frame_occupancy &lt; min_frame_occupancy_for_label):
+      start_frame += 1
+
+    end_frame = int(math.ceil(end_time * frames_per_second))
+    end_frame_occupancy = end_time * frames_per_second - start_frame - 1
+    if (min_frame_occupancy_for_label &gt; 0.0 and
+        end_frame_occupancy &lt; min_frame_occupancy_for_label):
+      end_frame -= 1
+
+    # Ensure that every note fills at least one frame.
+    end_frame = max(start_frame + 1, end_frame)
+
+    return start_frame, end_frame
+
+  velocities_roll = np.zeros_like(roll, dtype=np.float32)
+
+  for note in sorted(sequence.notes, key=lambda n: n.start_time):
+    if note.pitch &lt; min_pitch or note.pitch &gt; max_pitch:
+      logging.warn(&#39;Skipping out of range pitch: %d&#39;, note.pitch)
+      continue
+    start_frame, end_frame = frames_from_times(note.start_time, note.end_time)
+
+    # label onset events. Use a window size of onset_window to account of
+    # rounding issue in the start_frame computation.
+    onset_start_time = note.start_time + onset_delay_ms / 1000.
+    onset_end_time = note.end_time + onset_delay_ms / 1000.
+    if onset_mode == &#39;window&#39;:
+      onset_start_frame_without_window, _ = frames_from_times(
+          onset_start_time, onset_end_time)
+
+      onset_start_frame = max(0,
+                              onset_start_frame_without_window - onset_window)
+      onset_end_frame = min(onsets.shape[0],
+                            onset_start_frame_without_window + onset_window + 1)
+    elif onset_mode == &#39;length_ms&#39;:
+      onset_end_time = min(onset_end_time,
+                           onset_start_time + onset_length_ms / 1000.)
+      onset_start_frame, onset_end_frame = frames_from_times(
+          onset_start_time, onset_end_time)
+    else:
+      raise ValueError(&#39;Unknown onset mode: {}&#39;.format(onset_mode))
+
+    # label offset events.
+    offset_start_time = min(note.end_time,
+                            sequence.total_time - offset_length_ms / 1000.)
+    offset_end_time = offset_start_time + offset_length_ms / 1000.
+    offset_start_frame, offset_end_frame = frames_from_times(
+        offset_start_time, offset_end_time)
+    offset_end_frame = max(offset_end_frame, offset_start_frame + 1)
+
+    if not onset_overlap:
+      start_frame = onset_end_frame
+      end_frame = max(start_frame + 1, end_frame)
+
+    offsets[offset_start_frame:offset_end_frame, note.pitch - min_pitch] = 1.0
+    onsets[onset_start_frame:onset_end_frame, note.pitch - min_pitch] = 1.0
+    roll[start_frame:end_frame, note.pitch - min_pitch] = 1.0
+
+    if note.velocity &gt; max_velocity:
+      raise ValueError(&#39;Note velocity exceeds max velocity: %d &gt; %d&#39; %
+                       (note.velocity, max_velocity))
+
+    velocities_roll[start_frame:end_frame, note.pitch -
+                    min_pitch] = note.velocity / max_velocity
+    roll_weights[onset_start_frame:onset_end_frame, note.pitch - min_pitch] = (
+        onset_upweight)
+    roll_weights[onset_end_frame:end_frame, note.pitch - min_pitch] = [
+        onset_upweight / x for x in range(1, end_frame - onset_end_frame + 1)
+    ]
+
+    if add_blank_frame_before_onset:
+      if start_frame &gt; 0:
+        roll[start_frame - 1, note.pitch - min_pitch] = 0.0
+        roll_weights[start_frame - 1, note.pitch - min_pitch] = 1.0
+
+  for cc in sequence.control_changes:
+    frame, _ = frames_from_times(cc.time, 0)
+    if frame &lt; len(control_changes):
+      control_changes[frame, cc.control_number] = cc.control_value + 1
+
+  return Pianoroll(
+      active=roll,
+      weights=roll_weights,
+      onsets=onsets,
+      onset_velocities=velocities_roll * onsets,
+      active_velocities=velocities_roll,
+      offsets=offsets,
+      control_changes=control_changes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.sequence_to_valued_intervals"><code class="name flex">
+<span>def <span class="ident">sequence_to_valued_intervals</span></span>(<span>note_sequence, min_midi_pitch=0, max_midi_pitch=127, restrict_to_pitch=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Convert a NoteSequence to valued intervals.</p>
+<p>Value intervals are intended to be used with mir_eval metrics methods.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>sequence to convert.</dd>
+<dt><strong><code>min_midi_pitch</code></strong></dt>
+<dd>notes lower than this will be discarded.</dd>
+<dt><strong><code>max_midi_pitch</code></strong></dt>
+<dd>notes higher than this will be discarded.</dd>
+<dt><strong><code>restrict_to_pitch</code></strong></dt>
+<dd>notes that are not this pitch will be discarded.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>intervals</code></dt>
+<dd>start and end times</dd>
+<dt><code>pitches</code></dt>
+<dd>pitches in Hz.</dd>
+<dt><code>velocities</code></dt>
+<dd>MIDI velocities.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sequence_to_valued_intervals(note_sequence,
+                                 min_midi_pitch=constants.MIN_MIDI_PITCH,
+                                 max_midi_pitch=constants.MAX_MIDI_PITCH,
+                                 restrict_to_pitch=None):
+  &#34;&#34;&#34;Convert a NoteSequence to valued intervals.
+
+  Value intervals are intended to be used with mir_eval metrics methods.
+
+  Args:
+    note_sequence: sequence to convert.
+    min_midi_pitch: notes lower than this will be discarded.
+    max_midi_pitch: notes higher than this will be discarded.
+    restrict_to_pitch: notes that are not this pitch will be discarded.
+
+  Returns:
+    intervals: start and end times
+    pitches: pitches in Hz.
+    velocities: MIDI velocities.
+  &#34;&#34;&#34;
+  intervals = []
+  pitches = []
+  velocities = []
+
+  for note in note_sequence.notes:
+    if restrict_to_pitch and restrict_to_pitch != note.pitch:
+      continue
+    if note.pitch &lt; min_midi_pitch or note.pitch &gt; max_midi_pitch:
+      continue
+    # mir_eval does not allow notes that start and end at the same time.
+    if note.end_time == note.start_time:
+      continue
+    intervals.append((note.start_time, note.end_time))
+    pitches.append(note.pitch)
+    velocities.append(note.velocity)
+
+  # Reshape intervals to ensure that the second dim is 2, even if the list is
+  # of size 0. mir_eval functions will complain if intervals is not shaped
+  # appropriately.
+  intervals = np.array(intervals).reshape((-1, 2))
+  pitches = np.array(pitches)
+  pitches = pretty_midi.note_number_to_hz(pitches)
+  velocities = np.array(velocities)
+  return intervals, pitches, velocities</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.shift_sequence_times"><code class="name flex">
+<span>def <span class="ident">shift_sequence_times</span></span>(<span>sequence, shift_seconds)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Shifts times in a notesequence.</p>
+<p>Only forward shifts are supported.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence to shift.</dd>
+<dt><strong><code>shift_seconds</code></strong></dt>
+<dd>The amount to shift.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A new NoteSequence with shifted times.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If the shift amount is invalid.</dd>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence has already been quantized.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def shift_sequence_times(sequence, shift_seconds):
+  &#34;&#34;&#34;Shifts times in a notesequence.
+
+  Only forward shifts are supported.
+
+  Args:
+    sequence: The NoteSequence to shift.
+    shift_seconds: The amount to shift.
+
+  Returns:
+    A new NoteSequence with shifted times.
+
+  Raises:
+    ValueError: If the shift amount is invalid.
+    QuantizationStatusError: If the sequence has already been quantized.
+  &#34;&#34;&#34;
+  if shift_seconds &lt;= 0:
+    raise ValueError(&#39;Invalid shift amount: {}&#39;.format(shift_seconds))
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Can shift only unquantized NoteSequences.&#39;)
+
+  shifted = music_pb2.NoteSequence()
+  shifted.CopyFrom(sequence)
+
+  # Delete subsequence_info because our frame of reference has shifted.
+  shifted.ClearField(&#39;subsequence_info&#39;)
+
+  # Shift notes.
+  for note in shifted.notes:
+    note.start_time += shift_seconds
+    note.end_time += shift_seconds
+
+  events_to_shift = [
+      shifted.time_signatures, shifted.key_signatures, shifted.tempos,
+      shifted.pitch_bends, shifted.control_changes, shifted.text_annotations,
+      shifted.section_annotations
+  ]
+
+  for event in itertools.chain(*events_to_shift):
+    event.time += shift_seconds
+
+  shifted.total_time += shift_seconds
+
+  return shifted</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.split_note_sequence"><code class="name flex">
+<span>def <span class="ident">split_note_sequence</span></span>(<span>note_sequence, hop_size_seconds, skip_splits_inside_notes=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Split one NoteSequence into many at specified time intervals.</p>
+<p>If <code>hop_size_seconds</code> is a scalar, this function splits a NoteSequence into
+multiple NoteSequences, all of fixed size (unless <code>split_notes</code> is False, in
+which case splits that would have truncated notes will be skipped; i.e. each
+split will either happen at a multiple of <code>hop_size_seconds</code> or not at all).
+Each of the resulting NoteSequences is shifted to start at time zero.</p>
+<p>If <code>hop_size_seconds</code> is a list, the NoteSequence will be split at each time
+in the list (unless <code>split_notes</code> is False as above).</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence to split.</dd>
+<dt><strong><code>hop_size_seconds</code></strong></dt>
+<dd>The hop size, in seconds, at which the NoteSequence will
+be split. Alternatively, this can be a Python list of times in seconds at
+which to split the NoteSequence.</dd>
+<dt><strong><code>skip_splits_inside_notes</code></strong></dt>
+<dd>If False, the NoteSequence will be split at all
+hop positions, regardless of whether or not any notes are sustained across
+the potential split time, thus sustained notes will be truncated. If True,
+the NoteSequence will not be split at positions that occur within
+sustained notes.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list of NoteSequences.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def split_note_sequence(note_sequence,
+                        hop_size_seconds,
+                        skip_splits_inside_notes=False):
+  &#34;&#34;&#34;Split one NoteSequence into many at specified time intervals.
+
+  If `hop_size_seconds` is a scalar, this function splits a NoteSequence into
+  multiple NoteSequences, all of fixed size (unless `split_notes` is False, in
+  which case splits that would have truncated notes will be skipped; i.e. each
+  split will either happen at a multiple of `hop_size_seconds` or not at all).
+  Each of the resulting NoteSequences is shifted to start at time zero.
+
+  If `hop_size_seconds` is a list, the NoteSequence will be split at each time
+  in the list (unless `split_notes` is False as above).
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    hop_size_seconds: The hop size, in seconds, at which the NoteSequence will
+      be split. Alternatively, this can be a Python list of times in seconds at
+      which to split the NoteSequence.
+    skip_splits_inside_notes: If False, the NoteSequence will be split at all
+      hop positions, regardless of whether or not any notes are sustained across
+      the potential split time, thus sustained notes will be truncated. If True,
+      the NoteSequence will not be split at positions that occur within
+      sustained notes.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+  note_idx = 0
+  notes_crossing_split = []
+
+  if isinstance(hop_size_seconds, list):
+    split_times = sorted(hop_size_seconds)
+  else:
+    split_times = np.arange(hop_size_seconds, note_sequence.total_time,
+                            hop_size_seconds)
+
+  valid_split_times = [0.0]
+
+  for split_time in split_times:
+    # Update notes crossing potential split.
+    while (note_idx &lt; len(notes_by_start_time) and
+           notes_by_start_time[note_idx].start_time &lt; split_time):
+      notes_crossing_split.append(notes_by_start_time[note_idx])
+      note_idx += 1
+    notes_crossing_split = [
+        note for note in notes_crossing_split if note.end_time &gt; split_time
+    ]
+
+    if not (skip_splits_inside_notes and notes_crossing_split):
+      valid_split_times.append(split_time)
+
+  # Handle the final subsequence.
+  if note_sequence.total_time &gt; valid_split_times[-1]:
+    valid_split_times.append(note_sequence.total_time)
+
+  if len(valid_split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, valid_split_times)
+  else:
+    return []</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.split_note_sequence_on_silence"><code class="name flex">
+<span>def <span class="ident">split_note_sequence_on_silence</span></span>(<span>note_sequence, gap_seconds=3.0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Split one NoteSequence into many around gaps of silence.</p>
+<p>This function splits a NoteSequence into multiple NoteSequences, each of which
+contains no gaps of silence longer than <code>gap_seconds</code>. Each of the resulting
+NoteSequences is shifted such that the first note starts at time zero.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence to split.</dd>
+<dt><strong><code>gap_seconds</code></strong></dt>
+<dd>The maximum amount of contiguous silence to allow within a
+NoteSequence, in seconds.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list of NoteSequences.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def split_note_sequence_on_silence(note_sequence, gap_seconds=3.0):
+  &#34;&#34;&#34;Split one NoteSequence into many around gaps of silence.
+
+  This function splits a NoteSequence into multiple NoteSequences, each of which
+  contains no gaps of silence longer than `gap_seconds`. Each of the resulting
+  NoteSequences is shifted such that the first note starts at time zero.
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    gap_seconds: The maximum amount of contiguous silence to allow within a
+        NoteSequence, in seconds.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+
+  split_times = [0.0]
+  last_active_time = 0.0
+
+  for note in notes_by_start_time:
+    if note.start_time &gt; last_active_time + gap_seconds:
+      split_times.append(note.start_time)
+    last_active_time = max(last_active_time, note.end_time)
+
+  if note_sequence.total_time &gt; split_times[-1]:
+    split_times.append(note_sequence.total_time)
+
+  if len(split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, split_times)
+  else:
+    return []</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.split_note_sequence_on_time_changes"><code class="name flex">
+<span>def <span class="ident">split_note_sequence_on_time_changes</span></span>(<span>note_sequence, skip_splits_inside_notes=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Split one NoteSequence into many around time signature and tempo changes.</p>
+<p>This function splits a NoteSequence into multiple NoteSequences, each of which
+contains only a single time signature and tempo, unless <code>split_notes</code> is False
+in which case all time signature and tempo changes occur within sustained
+notes. Each of the resulting NoteSequences is shifted to start at time zero.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence to split.</dd>
+<dt><strong><code>skip_splits_inside_notes</code></strong></dt>
+<dd>If False, the NoteSequence will be split at all
+time changes, regardless of whether or not any notes are sustained across
+the time change. If True, the NoteSequence will not be split at time
+changes that occur within sustained notes.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A Python list of NoteSequences.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def split_note_sequence_on_time_changes(note_sequence,
+                                        skip_splits_inside_notes=False):
+  &#34;&#34;&#34;Split one NoteSequence into many around time signature and tempo changes.
+
+  This function splits a NoteSequence into multiple NoteSequences, each of which
+  contains only a single time signature and tempo, unless `split_notes` is False
+  in which case all time signature and tempo changes occur within sustained
+  notes. Each of the resulting NoteSequences is shifted to start at time zero.
+
+  Args:
+    note_sequence: The NoteSequence to split.
+    skip_splits_inside_notes: If False, the NoteSequence will be split at all
+      time changes, regardless of whether or not any notes are sustained across
+      the time change. If True, the NoteSequence will not be split at time
+      changes that occur within sustained notes.
+
+  Returns:
+    A Python list of NoteSequences.
+  &#34;&#34;&#34;
+  current_numerator = 4
+  current_denominator = 4
+  current_qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
+
+  time_signatures_and_tempos = sorted(
+      list(note_sequence.time_signatures) + list(note_sequence.tempos),
+      key=lambda t: t.time)
+  time_signatures_and_tempos = [
+      t for t in time_signatures_and_tempos if t.time &lt; note_sequence.total_time
+  ]
+
+  notes_by_start_time = sorted(
+      list(note_sequence.notes), key=lambda note: note.start_time)
+  note_idx = 0
+  notes_crossing_split = []
+
+  valid_split_times = [0.0]
+
+  for time_change in time_signatures_and_tempos:
+    if isinstance(time_change, music_pb2.NoteSequence.TimeSignature):
+      if (time_change.numerator == current_numerator and
+          time_change.denominator == current_denominator):
+        # Time signature didn&#39;t actually change.
+        continue
+    else:
+      if time_change.qpm == current_qpm:
+        # Tempo didn&#39;t actually change.
+        continue
+
+    # Update notes crossing potential split.
+    while (note_idx &lt; len(notes_by_start_time) and
+           notes_by_start_time[note_idx].start_time &lt; time_change.time):
+      notes_crossing_split.append(notes_by_start_time[note_idx])
+      note_idx += 1
+    notes_crossing_split = [
+        note for note in notes_crossing_split
+        if note.end_time &gt; time_change.time
+    ]
+
+    if time_change.time &gt; valid_split_times[-1]:
+      if not (skip_splits_inside_notes and notes_crossing_split):
+        valid_split_times.append(time_change.time)
+
+    # Even if we didn&#39;t split here, update the current time signature or tempo.
+    if isinstance(time_change, music_pb2.NoteSequence.TimeSignature):
+      current_numerator = time_change.numerator
+      current_denominator = time_change.denominator
+    else:
+      current_qpm = time_change.qpm
+
+  # Handle the final subsequence.
+  if note_sequence.total_time &gt; valid_split_times[-1]:
+    valid_split_times.append(note_sequence.total_time)
+
+  if len(valid_split_times) &gt; 1:
+    return _extract_subsequences(note_sequence, valid_split_times)
+  else:
+    return []</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.steps_per_bar_in_quantized_sequence"><code class="name flex">
+<span>def <span class="ident">steps_per_bar_in_quantized_sequence</span></span>(<span>note_sequence)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Calculates steps per bar in a NoteSequence that has been quantized.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence to examine.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Steps per bar as a floating point number.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def steps_per_bar_in_quantized_sequence(note_sequence):
+  &#34;&#34;&#34;Calculates steps per bar in a NoteSequence that has been quantized.
+
+  Args:
+    note_sequence: The NoteSequence to examine.
+
+  Returns:
+    Steps per bar as a floating point number.
+  &#34;&#34;&#34;
+  assert_is_relative_quantized_sequence(note_sequence)
+
+  quarters_per_beat = 4.0 / note_sequence.time_signatures[0].denominator
+  quarters_per_bar = (
+      quarters_per_beat * note_sequence.time_signatures[0].numerator)
+  steps_per_bar_float = (
+      note_sequence.quantization_info.steps_per_quarter * quarters_per_bar)
+  return steps_per_bar_float</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.steps_per_quarter_to_steps_per_second"><code class="name flex">
+<span>def <span class="ident">steps_per_quarter_to_steps_per_second</span></span>(<span>steps_per_quarter, qpm)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Calculates steps per second given steps_per_quarter and a qpm.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def steps_per_quarter_to_steps_per_second(steps_per_quarter, qpm):
+  &#34;&#34;&#34;Calculates steps per second given steps_per_quarter and a qpm.&#34;&#34;&#34;
+  return steps_per_quarter * qpm / 60.0</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.stretch_note_sequence"><code class="name flex">
+<span>def <span class="ident">stretch_note_sequence</span></span>(<span>note_sequence, stretch_factor, in_place=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Apply a constant temporal stretch to a NoteSequence proto.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>note_sequence</code></strong></dt>
+<dd>The NoteSequence to stretch.</dd>
+<dt><strong><code>stretch_factor</code></strong></dt>
+<dd>How much to stretch the NoteSequence. Values greater than
+one increase the length of the NoteSequence (making it "slower"). Values
+less than one decrease the length of the NoteSequence (making it
+"faster").</dd>
+<dt><strong><code>in_place</code></strong></dt>
+<dd>If True, the input note_sequence is edited directly.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A stretched copy of the original NoteSequence.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the <code>note_sequence</code> is quantized. Only
+unquantized NoteSequences can be stretched.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def stretch_note_sequence(note_sequence, stretch_factor, in_place=False):
+  &#34;&#34;&#34;Apply a constant temporal stretch to a NoteSequence proto.
+
+  Args:
+    note_sequence: The NoteSequence to stretch.
+    stretch_factor: How much to stretch the NoteSequence. Values greater than
+      one increase the length of the NoteSequence (making it &#34;slower&#34;). Values
+      less than one decrease the length of the NoteSequence (making it
+      &#34;faster&#34;).
+    in_place: If True, the input note_sequence is edited directly.
+
+  Returns:
+    A stretched copy of the original NoteSequence.
+
+  Raises:
+    QuantizationStatusError: If the `note_sequence` is quantized. Only
+        unquantized NoteSequences can be stretched.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(note_sequence):
+    raise QuantizationStatusError(
+        &#39;Can only stretch unquantized NoteSequence.&#39;)
+
+  if in_place:
+    stretched_sequence = note_sequence
+  else:
+    stretched_sequence = music_pb2.NoteSequence()
+    stretched_sequence.CopyFrom(note_sequence)
+
+  if stretch_factor == 1.0:
+    return stretched_sequence
+
+  # Stretch all notes.
+  for note in stretched_sequence.notes:
+    note.start_time *= stretch_factor
+    note.end_time *= stretch_factor
+  stretched_sequence.total_time *= stretch_factor
+
+  # Stretch all other event times.
+  events = itertools.chain(
+      stretched_sequence.time_signatures, stretched_sequence.key_signatures,
+      stretched_sequence.tempos, stretched_sequence.pitch_bends,
+      stretched_sequence.control_changes, stretched_sequence.text_annotations)
+  for event in events:
+    event.time *= stretch_factor
+
+  # Stretch tempos.
+  for tempo in stretched_sequence.tempos:
+    tempo.qpm /= stretch_factor
+
+  return stretched_sequence</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.transpose_note_sequence"><code class="name flex">
+<span>def <span class="ident">transpose_note_sequence</span></span>(<span>ns, amount, min_allowed_pitch=0, max_allowed_pitch=127, transpose_chords=True, in_place=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Transposes note sequence specified amount, deleting out-of-bound notes.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>ns</code></strong></dt>
+<dd>The NoteSequence proto to be transposed.</dd>
+<dt><strong><code>amount</code></strong></dt>
+<dd>Number of half-steps to transpose up or down.</dd>
+<dt><strong><code>min_allowed_pitch</code></strong></dt>
+<dd>Minimum pitch allowed in transposed NoteSequence. Notes
+assigned lower pitches will be deleted.</dd>
+<dt><strong><code>max_allowed_pitch</code></strong></dt>
+<dd>Maximum pitch allowed in transposed NoteSequence. Notes
+assigned higher pitches will be deleted.</dd>
+<dt><strong><code>transpose_chords</code></strong></dt>
+<dd>If True, also transpose chord symbol text annotations. If
+False, chord symbols will be removed.</dd>
+<dt><strong><code>in_place</code></strong></dt>
+<dd>If True, the input note_sequence is edited directly.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>The transposed NoteSequence and a count of how many notes were deleted.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ChordSymbolError</code></dt>
+<dd>If a chord symbol is unable to be transposed.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def transpose_note_sequence(ns,
+                            amount,
+                            min_allowed_pitch=constants.MIN_MIDI_PITCH,
+                            max_allowed_pitch=constants.MAX_MIDI_PITCH,
+                            transpose_chords=True,
+                            in_place=False):
+  &#34;&#34;&#34;Transposes note sequence specified amount, deleting out-of-bound notes.
+
+  Args:
+    ns: The NoteSequence proto to be transposed.
+    amount: Number of half-steps to transpose up or down.
+    min_allowed_pitch: Minimum pitch allowed in transposed NoteSequence. Notes
+      assigned lower pitches will be deleted.
+    max_allowed_pitch: Maximum pitch allowed in transposed NoteSequence. Notes
+      assigned higher pitches will be deleted.
+    transpose_chords: If True, also transpose chord symbol text annotations. If
+      False, chord symbols will be removed.
+    in_place: If True, the input note_sequence is edited directly.
+
+  Returns:
+    The transposed NoteSequence and a count of how many notes were deleted.
+
+  Raises:
+    ChordSymbolError: If a chord symbol is unable to be transposed.
+  &#34;&#34;&#34;
+  if not in_place:
+    new_ns = music_pb2.NoteSequence()
+    new_ns.CopyFrom(ns)
+    ns = new_ns
+
+  new_note_list = []
+  deleted_note_count = 0
+  end_time = 0
+
+  for note in ns.notes:
+    new_pitch = note.pitch + amount
+    if (min_allowed_pitch &lt;= new_pitch &lt;= max_allowed_pitch) or note.is_drum:
+      end_time = max(end_time, note.end_time)
+
+      if not note.is_drum:
+        note.pitch += amount
+
+        # The pitch name, if present, will no longer be valid.
+        note.pitch_name = UNKNOWN_PITCH_NAME
+
+      new_note_list.append(note)
+    else:
+      deleted_note_count += 1
+
+  if deleted_note_count &gt; 0:
+    del ns.notes[:]
+    ns.notes.extend(new_note_list)
+
+  # Since notes were deleted, we may need to update the total time.
+  ns.total_time = end_time
+
+  if transpose_chords:
+    # Also update the chord symbol text annotations. This can raise a
+    # ChordSymbolError if a chord symbol cannot be interpreted.
+    for ta in ns.text_annotations:
+      if ta.annotation_type == CHORD_SYMBOL and ta.text != constants.NO_CHORD:
+        ta.text = chord_symbols_lib.transpose_chord_symbol(ta.text, amount)
+  else:
+    # Remove chord symbol text annotations.
+    text_annotations_to_keep = []
+    for ta in ns.text_annotations:
+      if ta.annotation_type != CHORD_SYMBOL:
+        text_annotations_to_keep.append(ta)
+    if len(text_annotations_to_keep) &lt; len(ns.text_annotations):
+      del ns.text_annotations[:]
+      ns.text_annotations.extend(text_annotations_to_keep)
+
+  # Also transpose key signatures.
+  for ks in ns.key_signatures:
+    ks.key = (ks.key + amount) % 12
+
+  return ns, deleted_note_count</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib.trim_note_sequence"><code class="name flex">
+<span>def <span class="ident">trim_note_sequence</span></span>(<span>sequence, start_time, end_time)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Trim notes from a NoteSequence to lie within a specified time range.</p>
+<p>Notes starting before <code>start_time</code> are not included. Notes ending after
+<code>end_time</code> are truncated.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>sequence</code></strong></dt>
+<dd>The NoteSequence for which to trim notes.</dd>
+<dt><strong><code>start_time</code></strong></dt>
+<dd>The float time in seconds after which all notes should begin.</dd>
+<dt><strong><code>end_time</code></strong></dt>
+<dd>The float time in seconds before which all notes should end.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A copy of <code>sequence</code> with all notes trimmed to lie between <code>start_time</code> and
+<code>end_time</code>.</p>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></dt>
+<dd>If the sequence has already been quantized.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def trim_note_sequence(sequence, start_time, end_time):
+  &#34;&#34;&#34;Trim notes from a NoteSequence to lie within a specified time range.
+
+  Notes starting before `start_time` are not included. Notes ending after
+  `end_time` are truncated.
+
+  Args:
+    sequence: The NoteSequence for which to trim notes.
+    start_time: The float time in seconds after which all notes should begin.
+    end_time: The float time in seconds before which all notes should end.
+
+  Returns:
+    A copy of `sequence` with all notes trimmed to lie between `start_time` and
+    `end_time`.
+
+  Raises:
+    QuantizationStatusError: If the sequence has already been quantized.
+  &#34;&#34;&#34;
+  if is_quantized_sequence(sequence):
+    raise QuantizationStatusError(
+        &#39;Can only trim notes and chords for unquantized NoteSequence.&#39;)
+
+  subsequence = music_pb2.NoteSequence()
+  subsequence.CopyFrom(sequence)
+
+  del subsequence.notes[:]
+  for note in sequence.notes:
+    if note.start_time &lt; start_time or note.start_time &gt;= end_time:
+      continue
+    new_note = subsequence.notes.add()
+    new_note.CopyFrom(note)
+    new_note.end_time = min(note.end_time, end_time)
+
+  subsequence.total_time = min(sequence.total_time, end_time)
+
+  return subsequence</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.sequences_lib.BadTimeSignatureError"><code class="flex name class">
+<span>class <span class="ident">BadTimeSignatureError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BadTimeSignatureError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.InvalidTimeAdjustmentError"><code class="flex name class">
+<span>class <span class="ident">InvalidTimeAdjustmentError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InvalidTimeAdjustmentError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.MultipleTempoError"><code class="flex name class">
+<span>class <span class="ident">MultipleTempoError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultipleTempoError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.MultipleTimeSignatureError"><code class="flex name class">
+<span>class <span class="ident">MultipleTimeSignatureError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MultipleTimeSignatureError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.NegativeTimeError"><code class="flex name class">
+<span>class <span class="ident">NegativeTimeError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NegativeTimeError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll"><code class="flex name class">
+<span>class <span class="ident">Pianoroll</span></span>
+<span>(</span><span>active, weights, onsets, onset_velocities, active_velocities, offsets, control_changes)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Pianoroll(active, weights, onsets, onset_velocities, active_velocities, offsets, control_changes)</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.tuple</li>
+</ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="note_seq.sequences_lib.Pianoroll.active"><code class="name">var <span class="ident">active</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 0</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.active_velocities"><code class="name">var <span class="ident">active_velocities</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 4</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.control_changes"><code class="name">var <span class="ident">control_changes</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 6</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.offsets"><code class="name">var <span class="ident">offsets</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 5</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.onset_velocities"><code class="name">var <span class="ident">onset_velocities</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 3</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.onsets"><code class="name">var <span class="ident">onsets</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 2</p></div>
+</dd>
+<dt id="note_seq.sequences_lib.Pianoroll.weights"><code class="name">var <span class="ident">weights</span></code></dt>
+<dd>
+<div class="desc"><p>Alias for field number 1</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.sequences_lib.QuantizationStatusError"><code class="flex name class">
+<span>class <span class="ident">QuantizationStatusError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exception for when a sequence was unexpectedly quantized or unquantized.</p>
+<p>Should not happen during normal operation and likely indicates a programming
+error.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class QuantizationStatusError(Exception):
+  &#34;&#34;&#34;Exception for when a sequence was unexpectedly quantized or unquantized.
+
+  Should not happen during normal operation and likely indicates a programming
+  error.
+  &#34;&#34;&#34;
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="note_seq.sequences_lib.RectifyBeatsError"><code class="flex name class">
+<span>class <span class="ident">RectifyBeatsError</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class RectifyBeatsError(Exception):
+  pass</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.sequences_lib.adjust_notesequence_times" href="#note_seq.sequences_lib.adjust_notesequence_times">adjust_notesequence_times</a></code></li>
+<li><code><a title="note_seq.sequences_lib.apply_sustain_control_changes" href="#note_seq.sequences_lib.apply_sustain_control_changes">apply_sustain_control_changes</a></code></li>
+<li><code><a title="note_seq.sequences_lib.assert_is_absolute_quantized_sequence" href="#note_seq.sequences_lib.assert_is_absolute_quantized_sequence">assert_is_absolute_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.assert_is_quantized_sequence" href="#note_seq.sequences_lib.assert_is_quantized_sequence">assert_is_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.assert_is_relative_quantized_sequence" href="#note_seq.sequences_lib.assert_is_relative_quantized_sequence">assert_is_relative_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.augment_note_sequence" href="#note_seq.sequences_lib.augment_note_sequence">augment_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.concatenate_sequences" href="#note_seq.sequences_lib.concatenate_sequences">concatenate_sequences</a></code></li>
+<li><code><a title="note_seq.sequences_lib.expand_section_groups" href="#note_seq.sequences_lib.expand_section_groups">expand_section_groups</a></code></li>
+<li><code><a title="note_seq.sequences_lib.extract_subsequence" href="#note_seq.sequences_lib.extract_subsequence">extract_subsequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.infer_dense_chords_for_sequence" href="#note_seq.sequences_lib.infer_dense_chords_for_sequence">infer_dense_chords_for_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.is_absolute_quantized_sequence" href="#note_seq.sequences_lib.is_absolute_quantized_sequence">is_absolute_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.is_quantized_sequence" href="#note_seq.sequences_lib.is_quantized_sequence">is_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.is_relative_quantized_sequence" href="#note_seq.sequences_lib.is_relative_quantized_sequence">is_relative_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.pianoroll_onsets_to_note_sequence" href="#note_seq.sequences_lib.pianoroll_onsets_to_note_sequence">pianoroll_onsets_to_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.pianoroll_to_note_sequence" href="#note_seq.sequences_lib.pianoroll_to_note_sequence">pianoroll_to_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.quantize_note_sequence" href="#note_seq.sequences_lib.quantize_note_sequence">quantize_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.quantize_note_sequence_absolute" href="#note_seq.sequences_lib.quantize_note_sequence_absolute">quantize_note_sequence_absolute</a></code></li>
+<li><code><a title="note_seq.sequences_lib.quantize_to_step" href="#note_seq.sequences_lib.quantize_to_step">quantize_to_step</a></code></li>
+<li><code><a title="note_seq.sequences_lib.rectify_beats" href="#note_seq.sequences_lib.rectify_beats">rectify_beats</a></code></li>
+<li><code><a title="note_seq.sequences_lib.remove_redundant_data" href="#note_seq.sequences_lib.remove_redundant_data">remove_redundant_data</a></code></li>
+<li><code><a title="note_seq.sequences_lib.repeat_sequence_to_duration" href="#note_seq.sequences_lib.repeat_sequence_to_duration">repeat_sequence_to_duration</a></code></li>
+<li><code><a title="note_seq.sequences_lib.sequence_to_pianoroll" href="#note_seq.sequences_lib.sequence_to_pianoroll">sequence_to_pianoroll</a></code></li>
+<li><code><a title="note_seq.sequences_lib.sequence_to_valued_intervals" href="#note_seq.sequences_lib.sequence_to_valued_intervals">sequence_to_valued_intervals</a></code></li>
+<li><code><a title="note_seq.sequences_lib.shift_sequence_times" href="#note_seq.sequences_lib.shift_sequence_times">shift_sequence_times</a></code></li>
+<li><code><a title="note_seq.sequences_lib.split_note_sequence" href="#note_seq.sequences_lib.split_note_sequence">split_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.split_note_sequence_on_silence" href="#note_seq.sequences_lib.split_note_sequence_on_silence">split_note_sequence_on_silence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.split_note_sequence_on_time_changes" href="#note_seq.sequences_lib.split_note_sequence_on_time_changes">split_note_sequence_on_time_changes</a></code></li>
+<li><code><a title="note_seq.sequences_lib.steps_per_bar_in_quantized_sequence" href="#note_seq.sequences_lib.steps_per_bar_in_quantized_sequence">steps_per_bar_in_quantized_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.steps_per_quarter_to_steps_per_second" href="#note_seq.sequences_lib.steps_per_quarter_to_steps_per_second">steps_per_quarter_to_steps_per_second</a></code></li>
+<li><code><a title="note_seq.sequences_lib.stretch_note_sequence" href="#note_seq.sequences_lib.stretch_note_sequence">stretch_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.transpose_note_sequence" href="#note_seq.sequences_lib.transpose_note_sequence">transpose_note_sequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib.trim_note_sequence" href="#note_seq.sequences_lib.trim_note_sequence">trim_note_sequence</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.sequences_lib.BadTimeSignatureError" href="#note_seq.sequences_lib.BadTimeSignatureError">BadTimeSignatureError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.InvalidTimeAdjustmentError" href="#note_seq.sequences_lib.InvalidTimeAdjustmentError">InvalidTimeAdjustmentError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.MultipleTempoError" href="#note_seq.sequences_lib.MultipleTempoError">MultipleTempoError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.MultipleTimeSignatureError" href="#note_seq.sequences_lib.MultipleTimeSignatureError">MultipleTimeSignatureError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.NegativeTimeError" href="#note_seq.sequences_lib.NegativeTimeError">NegativeTimeError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.Pianoroll" href="#note_seq.sequences_lib.Pianoroll">Pianoroll</a></code></h4>
+<ul class="two-column">
+<li><code><a title="note_seq.sequences_lib.Pianoroll.active" href="#note_seq.sequences_lib.Pianoroll.active">active</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.active_velocities" href="#note_seq.sequences_lib.Pianoroll.active_velocities">active_velocities</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.control_changes" href="#note_seq.sequences_lib.Pianoroll.control_changes">control_changes</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.offsets" href="#note_seq.sequences_lib.Pianoroll.offsets">offsets</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.onset_velocities" href="#note_seq.sequences_lib.Pianoroll.onset_velocities">onset_velocities</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.onsets" href="#note_seq.sequences_lib.Pianoroll.onsets">onsets</a></code></li>
+<li><code><a title="note_seq.sequences_lib.Pianoroll.weights" href="#note_seq.sequences_lib.Pianoroll.weights">weights</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.QuantizationStatusError" href="#note_seq.sequences_lib.QuantizationStatusError">QuantizationStatusError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="note_seq.sequences_lib.RectifyBeatsError" href="#note_seq.sequences_lib.RectifyBeatsError">RectifyBeatsError</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/sequences_lib_test.html
+++ b/docs/sequences_lib_test.html
@@ -1,0 +1,7874 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.sequences_lib_test API documentation</title>
+<meta name="description" content="Tests for sequences_lib." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.sequences_lib_test</code></h1>
+</header>
+<section id="section-intro">
+<p>Tests for sequences_lib.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Tests for sequences_lib.&#34;&#34;&#34;
+
+import copy
+
+from absl.testing import absltest
+from note_seq import constants
+from note_seq import sequences_lib
+from note_seq import testing_lib
+from note_seq.protobuf import music_pb2
+import numpy as np
+
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+DEFAULT_FRAMES_PER_SECOND = 16000.0 / 512
+MIDI_PITCHES = constants.MAX_MIDI_PITCH - constants.MIN_MIDI_PITCH + 1
+
+
+class SequencesLibTest(testing_lib.ProtoTestCase):
+
+  def testTransposeNoteSequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    sequence.text_annotations.add(
+        time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+    sequence.text_annotations.add(
+        time=2, annotation_type=CHORD_SYMBOL, text=&#39;E7&#39;)
+    sequence.key_signatures.add(
+        time=0, key=music_pb2.NoteSequence.KeySignature.E,
+        mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(13, 100, 0.01, 10.0), (12, 55, 0.22, 0.50), (41, 45, 2.50, 3.50),
+         (56, 120, 4.0, 4.01), (53, 99, 4.75, 5.0)])
+    expected_sequence.text_annotations.add(
+        time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+    expected_sequence.text_annotations.add(
+        time=2, annotation_type=CHORD_SYMBOL, text=&#39;F7&#39;)
+    expected_sequence.key_signatures.add(
+        time=0, key=music_pb2.NoteSequence.KeySignature.F,
+        mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence, 1)
+    self.assertProtoEquals(expected_sequence, transposed_sequence)
+    self.assertEqual(delete_count, 0)
+
+  def testTransposeNoteSequenceOutOfRange(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(35, 100, 0.01, 10.0), (36, 55, 0.22, 0.50), (37, 45, 2.50, 3.50),
+         (38, 120, 4.0, 4.01), (39, 99, 4.75, 5.0)])
+
+    expected_sequence_1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence_1, 0,
+        [(39, 100, 0.01, 10.0), (40, 55, 0.22, 0.50)])
+
+    expected_sequence_2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence_2, 0,
+        [(30, 120, 4.0, 4.01), (31, 99, 4.75, 5.0)])
+
+    sequence_copy = copy.copy(sequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence_copy, 4, 30, 40)
+    self.assertProtoEquals(expected_sequence_1, transposed_sequence)
+    self.assertEqual(delete_count, 3)
+
+    sequence_copy = copy.copy(sequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence_copy, -8, 30, 40)
+    self.assertProtoEquals(expected_sequence_2, transposed_sequence)
+    self.assertEqual(delete_count, 3)
+
+  def testClampTranspose(self):
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        5, 20, 60, 10, 70)
+    self.assertEqual(clamped, 5)
+
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        15, 20, 60, 10, 65)
+    self.assertEqual(clamped, 5)
+
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        -16, 20, 60, 10, 70)
+    self.assertEqual(clamped, -10)
+
+  def testAugmentNoteSequenceDeleteFalse(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2,
+        min_transpose=-15,
+        max_transpose=-10,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=False)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(10, 100, 0.02, 20.0), (11, 55, 0.44, 1.0),
+                               (38, 45, 5., 7.), (53, 120, 8.0, 8.02),
+                               (50, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceDeleteTrue(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2,
+        min_transpose=-15,
+        max_transpose=-15,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(25, 45, 5., 7.), (40, 120, 8.0, 8.02),
+                               (37, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceNoStretch(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=1,
+        max_stretch_factor=1.,
+        min_transpose=-15,
+        max_transpose=-15,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(25, 45, 2.5, 3.50), (40, 120, 4.0, 4.01),
+                               (37, 99, 4.75, 5.0)])
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceNoTranspose(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2.,
+        min_transpose=0,
+        max_transpose=0,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(12, 100, 0.02, 20.0), (13, 55, 0.44, 1.0),
+                               (40, 45, 5., 7.), (55, 120, 8.0, 8.02),
+                               (52, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testTrimNoteSequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0,
+        [(40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+    expected_subsequence.total_time = 4.75
+
+    subsequence = sequences_lib.trim_note_sequence(sequence, 2.5, 4.75)
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testExtractSubsequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0,
+        [(40, 45, 0.0, 1.0), (55, 120, 1.5, 1.51)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 0.5)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 1, [(0.0, 64, 127)])
+    expected_subsequence.total_time = 1.51
+    expected_subsequence.subsequence_info.start_time_offset = 2.5
+    expected_subsequence.subsequence_info.end_time_offset = 5.99
+
+    subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+    subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.time))
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testExtractSubsequencePastEnd(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 18.0)])
+
+    with self.assertRaises(ValueError):
+      sequences_lib.extract_subsequence(sequence, 15.0, 16.0)
+
+  def testExtractSubsequencePedalEvents(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(60, 80, 2.5, 5.0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 66, 0), (2.0, 66, 127), (4.0, 66, 0), (5.0, 66, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 67, 10), (2.0, 67, 20), (4.0, 67, 30), (5.0, 67, 40)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0, [(60, 80, 0, 2.25)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 1, [(0.0, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 66, 127), (1.5, 66, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 67, 20), (1.5, 67, 30)])
+    expected_subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+    expected_subsequence.total_time = 2.25
+    expected_subsequence.subsequence_info.start_time_offset = 2.5
+    expected_subsequence.subsequence_info.end_time_offset = .25
+
+    subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+    subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testSplitNoteSequenceWithHopSize(self):
+    # Tests splitting a NoteSequence at regular hop size, truncating notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(55, 120, 1.0, 1.01), (52, 99, 1.75, 2.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 1.0)])
+    expected_subsequence_2.total_time = 2.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 3.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+    expected_subsequence_3.total_time = 0.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 6.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 2.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=3.0)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceAtTimes(self):
+    # Tests splitting a NoteSequence at specified times, truncating notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0)])
+    expected_subsequence_2.total_time = 0.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+    expected_subsequence_3.total_time = 1.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=[3.0, 4.0])
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceSkipSplitsInsideNotes(self):
+    # Tests splitting a NoteSequence at regular hop size, skipping splits that
+    # would have occurred inside a note.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.5)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0)])
+    expected_subsequence_1.total_time = 3.50
+    expected_subsequence_1.subsequence_info.end_time_offset = 1.5
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.5)])
+    expected_subsequence_2.total_time = 1.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 4.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=2.0, skip_splits_inside_notes=True)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceNoTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # no time changes (time signature and tempo changes).
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence = music_pb2.NoteSequence()
+    expected_subsequence.CopyFrom(sequence)
+    expected_subsequence.subsequence_info.start_time_offset = 0.0
+    expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 1)
+    self.assertProtoEquals(expected_subsequence, subsequences[0])
+
+  def testSplitNoteSequenceDuplicateTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # duplicate time changes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence = music_pb2.NoteSequence()
+    expected_subsequence.CopyFrom(sequence)
+    expected_subsequence.subsequence_info.start_time_offset = 0.0
+    expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 1)
+    self.assertProtoEquals(expected_subsequence, subsequences[0])
+
+  def testSplitNoteSequenceCoincidentTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # two time changes occurring simultaneously.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 2.0
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+    expected_subsequence_1.total_time = 2.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01), (52, 99, 2.75, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0), (&#39;F&#39;, 2.8)])
+    expected_subsequence_2.total_time = 3.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes(self):
+    # Tests splitting a NoteSequence on time changes skipping splits that occur
+    # inside notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 4.25
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0)])
+    expected_subsequence_1.total_time = 4.01
+    expected_subsequence_1.subsequence_info.end_time_offset = 0.99
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0, [(52, 99, 0.5, 0.75)])
+    testing_lib.add_chords_to_sequence(expected_subsequence_2, [
+        (&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+    expected_subsequence_2.total_time = 0.75
+    expected_subsequence_2.subsequence_info.start_time_offset = 4.25
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(
+        sequence, skip_splits_inside_notes=True)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceMultipleTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes, truncating notes on splits
+    # that occur inside notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 4.25
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+    expected_subsequence_1.total_time = 2.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0)])
+    expected_subsequence_2.total_time = 2.01
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.99
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(52, 99, 0.5, 0.75)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+    expected_subsequence_3.total_time = 0.75
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.25
+    expected_subsequence_3.subsequence_info.end_time_offset = 5.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceWithStatelessEvents(self):
+    # Tests splitting a NoteSequence at specified times with stateless events.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_beats_to_sequence(sequence, [1.0, 2.0, 4.0])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_beats_to_sequence(expected_subsequence_1, [1.0, 2.0])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    expected_subsequence_2.total_time = 0.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_beats_to_sequence(expected_subsequence_3, [0.0])
+    expected_subsequence_3.total_time = 1.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=[3.0, 4.0])
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceOnSilence(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    expected_subsequence_1 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50)])
+    expected_subsequence_1.total_time = 1.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 4.0
+
+    expected_subsequence_2 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.0, 1.0), (55, 120, 1.50, 1.51)])
+    expected_subsequence_2.total_time = 1.51
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.50
+    expected_subsequence_2.subsequence_info.end_time_offset = 0.99
+
+    expected_subsequence_3 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(52, 99, 0.0, 0.25)])
+    expected_subsequence_3.total_time = 0.25
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.75
+
+    subsequences = sequences_lib.split_note_sequence_on_silence(
+        sequence, gap_seconds=0.5)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceOnSilenceInitialGap(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 1.5, 2.0), (11, 55, 1.5, 3.0), (40, 45, 2.5, 3.5)])
+
+    expected_subsequence_1 = music_pb2.NoteSequence()
+    expected_subsequence_1.total_time = 0.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 3.5
+
+    expected_subsequence_2 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(12, 100, 0.0, 0.5), (11, 55, 0.0, 1.5), (40, 45, 1.0, 2.0)])
+    expected_subsequence_2.total_time = 2.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 1.5
+
+    subsequences = sequences_lib.split_note_sequence_on_silence(
+        sequence, gap_seconds=1.0)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testQuantizeNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+    testing_lib.add_control_changes_to_sequence(
+        self.note_sequence, 0,
+        [(2.0, 64, 127), (4.0, 64, 0)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_quantized_sequence, [1, 16])
+    testing_lib.add_quantized_control_steps_to_sequence(
+        expected_quantized_sequence, [8, 16])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testQuantizeNoteSequenceAbsolute(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+    testing_lib.add_control_changes_to_sequence(
+        self.note_sequence, 0,
+        [(2.0, 64, 127), (4.0, 64, 0)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_second = 4
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_quantized_sequence, [1, 16])
+    testing_lib.add_quantized_control_steps_to_sequence(
+        expected_quantized_sequence, [8, 16])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testAssertIsQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+    absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    sequences_lib.assert_is_quantized_sequence(relative_quantized_sequence)
+    sequences_lib.assert_is_quantized_sequence(absolute_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_quantized_sequence(self.note_sequence)
+
+  def testAssertIsRelativeQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+    absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    sequences_lib.assert_is_relative_quantized_sequence(
+        relative_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_relative_quantized_sequence(
+          absolute_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_relative_quantized_sequence(self.note_sequence)
+
+  def testQuantizeNoteSequence_TimeSignatureChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Single time signature.
+    self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Multiple time signatures with no change.
+    self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=1)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Time signature change.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testQuantizeNoteSequence_ImplicitTimeSignatureChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+
+    # No time signature.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Implicit time signature change.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+
+    # No time signature.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # No implicit time signature change, but time signatures are added out of
+    # order.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+  def testStepsPerQuarterToStepsPerSecond(self):
+    self.assertEqual(
+        4.0, sequences_lib.steps_per_quarter_to_steps_per_second(4, 60.0))
+
+  def testQuantizeToStep(self):
+    self.assertEqual(
+        32, sequences_lib.quantize_to_step(8.0001, 4))
+    self.assertEqual(
+        34, sequences_lib.quantize_to_step(8.4999, 4))
+    self.assertEqual(
+        33, sequences_lib.quantize_to_step(8.4999, 4, quantize_cutoff=1.0))
+
+  def testFromNoteSequence_TempoChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempos.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Single tempo.
+    self.note_sequence.tempos.add(qpm=60, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Multiple tempos with no change.
+    self.note_sequence.tempos.add(qpm=60, time=1)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Tempo change.
+    self.note_sequence.tempos.add(qpm=120, time=2)
+    with self.assertRaises(sequences_lib.MultipleTempoError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testFromNoteSequence_ImplicitTempoChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempo.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Implicit tempo change.
+    self.note_sequence.tempos.add(qpm=60, time=2)
+    with self.assertRaises(sequences_lib.MultipleTempoError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testFromNoteSequence_NoImplicitTempoChangeOutOfOrder(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempo.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # No implicit tempo change, but tempos are added out of order.
+    self.note_sequence.tempos.add(qpm=60, time=2)
+    self.note_sequence.tempos.add(qpm=60, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+  def testRounding(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1,
+        [(12, 100, 0.01, 0.24), (11, 100, 0.22, 0.55), (40, 100, 0.50, 0.75),
+         (41, 100, 0.689, 1.18), (44, 100, 1.19, 1.69), (55, 100, 4.0, 4.01)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 1), (1, 2), (2, 3), (3, 5), (5, 7), (16, 17)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testMultiTrack(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.0, 4.0), (19, 100, 0.95, 3.0)])
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 3,
+        [(12, 100, 1.0, 4.0), (19, 100, 2.0, 5.0)])
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 7,
+        [(12, 100, 1.0, 5.0), (19, 100, 2.0, 4.0), (24, 100, 3.0, 3.5)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(4, 16), (4, 12), (4, 16), (8, 20), (4, 20), (8, 16), (12, 14)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testStepsPerBar(self):
+    qns = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertEqual(16, sequences_lib.steps_per_bar_in_quantized_sequence(qns))
+
+    self.note_sequence.time_signatures[0].numerator = 6
+    self.note_sequence.time_signatures[0].denominator = 8
+    qns = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertEqual(12.0,
+                     sequences_lib.steps_per_bar_in_quantized_sequence(qns))
+
+  def testStretchNoteSequence(self):
+    expected_stretched_sequence = copy.deepcopy(self.note_sequence)
+    expected_stretched_sequence.tempos[0].qpm = 40
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.2, 0.5), (40, 45, 2.5, 3.5)])
+    testing_lib.add_track_to_sequence(
+        expected_stretched_sequence, 0,
+        [(12, 100, 0.0, 15.0), (11, 55, 0.3, 0.75), (40, 45, 3.75, 5.25)])
+
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence, [(&#39;B7&#39;, 0.5), (&#39;Em9&#39;, 2.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_stretched_sequence, [(&#39;B7&#39;, 0.75), (&#39;Em9&#39;, 3.0)])
+
+    prestretched_sequence = copy.deepcopy(self.note_sequence)
+
+    stretched_sequence = sequences_lib.stretch_note_sequence(
+        self.note_sequence, stretch_factor=1.5, in_place=False)
+    self.assertProtoEquals(expected_stretched_sequence, stretched_sequence)
+
+    # Make sure the proto was not modified
+    self.assertProtoEquals(prestretched_sequence, self.note_sequence)
+
+    sequences_lib.stretch_note_sequence(
+        self.note_sequence, stretch_factor=1.5, in_place=True)
+    self.assertProtoEquals(stretched_sequence, self.note_sequence)
+
+  def testAdjustNoteSequenceTimes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.control_changes.add(control_number=1, time=2.0)
+    sequence.pitch_bends.add(bend=5, time=2.0)
+    sequence.total_time = 7.0
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, lambda t: t - 1)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=0.0, end_time=4.0)
+    expected_sequence.notes.add(pitch=61, start_time=5.0, end_time=6.0)
+    expected_sequence.control_changes.add(control_number=1, time=1.0)
+    expected_sequence.pitch_bends.add(bend=5, time=1.0)
+    expected_sequence.total_time = 6.0
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(0, skipped_notes)
+
+  def testAdjustNoteSequenceTimesWithSkippedNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time &gt; 5:
+        return 5
+      else:
+        return time
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    expected_sequence.total_time = 5.0
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(2, skipped_notes)
+
+  def testAdjustNoteSequenceTimesWithNotesBeforeTimeZero(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      return time - 5
+
+    with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+      sequences_lib.adjust_notesequence_times(sequence, time_func)
+
+  def testAdjustNoteSequenceTimesWithZeroDurations(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+    sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time % 2 == 0:
+        return time - 1
+      else:
+        return time
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func)
+
+    expected_sequence = music_pb2.NoteSequence()
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(3, skipped_notes)
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func, minimum_duration=.1)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=1.1)
+    expected_sequence.notes.add(pitch=61, start_time=3.0, end_time=3.1)
+    expected_sequence.notes.add(pitch=62, start_time=5.0, end_time=5.1)
+    expected_sequence.total_time = 5.1
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(0, skipped_notes)
+
+  def testAdjustNoteSequenceTimesEndBeforeStart(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+    sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time % 2 == 0:
+        return time - 2
+      else:
+        return time
+
+    with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+      sequences_lib.adjust_notesequence_times(sequence, time_func)
+
+  def testRectifyBeats(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.5),
+         (65, 100, 1.0, 1.5), (67, 100, 1.5, 2.0)])
+    testing_lib.add_beats_to_sequence(sequence, [0.5, 1.0, 2.0])
+
+    rectified_sequence, alignment = sequences_lib.rectify_beats(
+        sequence, 120)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.tempos.add(qpm=120)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.0),
+         (65, 100, 1.0, 1.25), (67, 100, 1.25, 1.5)])
+    testing_lib.add_beats_to_sequence(expected_sequence, [0.5, 1.0, 1.5])
+
+    self.assertEqual(expected_sequence, rectified_sequence)
+
+    expected_alignment = [
+        [0.0, 0.5, 1.0, 2.0, 2.5],
+        [0.0, 0.5, 1.0, 1.5, 2.0]
+    ]
+    self.assertEqual(expected_alignment, alignment.T.tolist())
+
+  def testApplySustainControlChanges(self):
+    &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0),
+         (3.75, 64, 127), (4.5, 64, 127), (4.8, 64, 0), (4.9, 64, 127),
+         (6.0, 64, 0)])
+    testing_lib.add_track_to_sequence(
+        sequence, 1,
+        [(12, 100, 0.01, 10.0), (52, 99, 4.75, 5.0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.8)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithRepeatedNotes(self):
+    &#34;&#34;&#34;Verify that sustain control handles repeated notes correctly.
+
+    For example, a single pitch played before sustain:
+    x-- x-- x--
+    After sustain:
+    x---x---x--
+
+    Notes should be extended until either the end of the sustain control or the
+    beginning of another note of the same pitch.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 1.50), (60, 100, 1.25, 1.50), (72, 100, 2.00, 3.50),
+         (60, 100, 2.0, 3.00), (60, 100, 3.50, 4.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 1.25), (60, 100, 1.25, 2.00), (72, 100, 2.00, 4.00),
+         (60, 100, 2.0, 3.50), (60, 100, 3.50, 4.50)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithRepeatedNotesBeforeSustain(self):
+    &#34;&#34;&#34;Repeated notes before sustain can overlap and should not be modified.
+
+    Once a repeat happens within the sustain, any active notes should end
+    before the next one starts.
+
+    This is kind of an edge case because a note overlapping a note of the same
+    pitch may not make sense, but apply_sustain_control_changes tries not to
+    modify events that happen outside of a sustain.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 1.50), (60, 100, .50, 1.50), (60, 100, 1.25, 2.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 1.25), (60, 100, 0.50, 1.25), (60, 100, 1.25, 4.00)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesSimultaneousOnOff(self):
+    &#34;&#34;&#34;Test sustain on and off events happening at the same time.
+
+    The off event should be processed last, so this should be a no-op.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(1.0, 64, 127), (1.0, 64, 0)])
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (60, 100, 2.0, 3.0)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(sequence, sus_sequence)
+
+  def testApplySustainControlChangesExtendNotesToEnd(self):
+    &#34;&#34;&#34;Test sustain control extending the duration of the final note.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.50, 4.00), (72, 100, 2.0, 4.0)])
+    expected_sequence.total_time = 4.0
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesExtraneousSustain(self):
+    &#34;&#34;&#34;Test applying extraneous sustain control at the end of the sequence.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(4.0, 64, 127), (5.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    # The total_time field only takes *notes* into account, and should not be
+    # affected by a sustain-on event beyond the last note.
+    expected_sequence.total_time = 3.0
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithIdenticalNotes(self):
+    &#34;&#34;&#34;In the case of identical notes, one should be dropped.
+
+    This is an edge case because in most cases, the same pitch should not sound
+    twice at the same time on one instrument.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 2.00, 2.50), (60, 100, 2.00, 2.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 2.00, 4.00)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithDrumNotes(self):
+    &#34;&#34;&#34;Drum notes should not be modified when applying sustain changes.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 2.00, 2.50)])
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(38, 100, 2.00, 2.50)], is_drum=True)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 2.00, 4.00)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(38, 100, 2.0, 2.5)], is_drum=True)
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesProcessSustainBeforeNotes(self):
+    &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testInferDenseChordsForSequence(self):
+    # Test non-quantized sequence.
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 1.0, 3.0), (64, 100, 1.0, 2.0), (67, 100, 1.0, 2.0),
+         (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),
+         (62, 100, 3.0, 5.0), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+    sequences_lib.infer_dense_chords_for_sequence(sequence)
+    self.assertProtoEquals(expected_sequence, sequence)
+
+    # Test quantized sequence.
+    sequence = copy.copy(self.note_sequence)
+    sequence.quantization_info.steps_per_quarter = 1
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 1.1, 3.0), (64, 100, 1.0, 1.9), (67, 100, 1.0, 2.0),
+         (65, 100, 2.0, 3.2), (69, 100, 2.1, 3.1),
+         (62, 100, 2.9, 4.8), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.1)])
+    testing_lib.add_quantized_steps_to_sequence(
+        sequence,
+        [(1, 3), (1, 2), (1, 2), (2, 3), (2, 3), (3, 5), (3, 4), (3, 4)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_sequence, [1, 2, 3])
+    sequences_lib.infer_dense_chords_for_sequence(sequence)
+    self.assertProtoEquals(expected_sequence, sequence)
+
+  def testShiftSequenceTimes(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    testing_lib.add_pitch_bends_to_sequence(
+        sequence, 1, 1, [(2.0, 100), (3.0, 0)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(12, 100, 1.01, 11.0), (11, 55, 1.22, 1.50), (40, 45, 3.50, 4.50),
+         (55, 120, 5.0, 5.01), (52, 99, 5.75, 6.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 2.5), (&#39;G7&#39;, 4.0), (&#39;F&#39;, 5.8)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_sequence, 0,
+        [(1.0, 64, 127), (3.0, 64, 0), (5.0, 64, 127), (6.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_sequence, 1, [(3.0, 64, 127)])
+    testing_lib.add_pitch_bends_to_sequence(
+        expected_sequence, 1, 1, [(3.0, 100), (4.0, 0)])
+
+    expected_sequence.time_signatures[0].time = 1
+    expected_sequence.tempos[0].time = 1
+
+    shifted_sequence = sequences_lib.shift_sequence_times(sequence, 1.0)
+    self.assertProtoEquals(expected_sequence, shifted_sequence)
+
+  def testConcatenateSequences(self):
+    sequence1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence1, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+    sequence2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence2, 0,
+        [(59, 100, 0.0, 1.0), (71, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (59, 100, 1.5, 2.5), (71, 100, 2.0, 3.0)])
+
+    cat_seq = sequences_lib.concatenate_sequences([sequence1, sequence2])
+    self.assertProtoEquals(expected_sequence, cat_seq)
+
+  def testConcatenateSequencesWithSpecifiedDurations(self):
+    sequence1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence1, 0, [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+    sequence2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence2, 0,
+        [(59, 100, 0.0, 1.0)])
+    sequence3 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence3, 0,
+        [(72, 100, 0.0, 1.0), (73, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (59, 100, 2.0, 3.0),
+         (72, 100, 3.5, 4.5), (73, 100, 4.0, 5.0)])
+
+    cat_seq = sequences_lib.concatenate_sequences(
+        [sequence1, sequence2, sequence3],
+        sequence_durations=[2, 1.5, 2])
+    self.assertProtoEquals(expected_sequence, cat_seq)
+
+  def testRepeatSequenceToDuration(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (60, 100, 1.5, 2.5), (72, 100, 2.0, 3.0)])
+
+    repeated_seq = sequences_lib.repeat_sequence_to_duration(
+        sequence, duration=3)
+    self.assertProtoEquals(expected_sequence, repeated_seq)
+
+  def testRepeatSequenceToDurationProvidedDuration(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (60, 100, 2.0, 3.0), (72, 100, 2.5, 3.0)])
+
+    repeated_seq = sequences_lib.repeat_sequence_to_duration(
+        sequence, duration=3, sequence_duration=2)
+    self.assertProtoEquals(expected_sequence, repeated_seq)
+
+  def testRemoveRedundantData(self):
+    sequence = copy.copy(self.note_sequence)
+    redundant_tempo = sequence.tempos.add()
+    redundant_tempo.CopyFrom(sequence.tempos[0])
+    redundant_tempo.time = 5.0
+    sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+    sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    expected_sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    expected_sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
+
+  def testRemoveRedundantDataOutOfOrder(self):
+    sequence = copy.copy(self.note_sequence)
+    meaningful_tempo = sequence.tempos.add()
+    meaningful_tempo.time = 5.0
+    meaningful_tempo.qpm = 50
+    redundant_tempo = sequence.tempos.add()
+    redundant_tempo.CopyFrom(sequence.tempos[0])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_meaningful_tempo = expected_sequence.tempos.add()
+    expected_meaningful_tempo.time = 5.0
+    expected_meaningful_tempo.qpm = 50
+
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
+
+  def testExpandSectionGroups(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+    sequence.section_annotations.add(time=0, section_id=0)
+    sequence.section_annotations.add(time=1, section_id=1)
+    sequence.section_annotations.add(time=2, section_id=2)
+    sequence.section_annotations.add(time=3, section_id=3)
+
+    # A((BC)2D)2
+    sg = sequence.section_groups.add()
+    sg.sections.add(section_id=0)
+    sg.num_times = 1
+    sg = sequence.section_groups.add()
+    sg.sections.add(section_group=music_pb2.NoteSequence.SectionGroup(
+        sections=[music_pb2.NoteSequence.Section(section_id=1),
+                  music_pb2.NoteSequence.Section(section_id=2)],
+        num_times=2))
+    sg.sections.add(section_id=3)
+    sg.num_times = 2
+
+    expanded = sequences_lib.expand_section_groups(sequence)
+
+    expected = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected, 0,
+        [(60, 100, 0.0, 1.0),
+         (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0),
+         (72, 100, 3.0, 4.0),
+         (59, 100, 4.0, 5.0),
+         (71, 100, 5.0, 6.0),
+         (72, 100, 6.0, 7.0),
+         (59, 100, 7.0, 8.0),
+         (72, 100, 8.0, 9.0),
+         (59, 100, 9.0, 10.0),
+         (71, 100, 10.0, 11.0)])
+    expected.section_annotations.add(time=0, section_id=0)
+    expected.section_annotations.add(time=1, section_id=1)
+    expected.section_annotations.add(time=2, section_id=2)
+    expected.section_annotations.add(time=3, section_id=1)
+    expected.section_annotations.add(time=4, section_id=2)
+    expected.section_annotations.add(time=5, section_id=3)
+    expected.section_annotations.add(time=6, section_id=1)
+    expected.section_annotations.add(time=7, section_id=2)
+    expected.section_annotations.add(time=8, section_id=1)
+    expected.section_annotations.add(time=9, section_id=2)
+    expected.section_annotations.add(time=10, section_id=3)
+    self.assertProtoEquals(expected, expanded)
+
+  def testExpandWithoutSectionGroups(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+    sequence.section_annotations.add(time=0, section_id=0)
+    sequence.section_annotations.add(time=1, section_id=1)
+    sequence.section_annotations.add(time=2, section_id=2)
+    sequence.section_annotations.add(time=3, section_id=3)
+
+    expanded = sequences_lib.expand_section_groups(sequence)
+
+    self.assertEqual(sequence, expanded)
+
+  def testSequenceToPianoroll(self):
+    sequence = music_pb2.NoteSequence(total_time=1.21)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.11, 1.01),
+                                                    (2, 55, 0.22, 0.50),
+                                                    (3, 100, 0.3, 0.8),
+                                                    (2, 45, 1.0, 1.21)])
+
+    pianoroll_tuple = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=1, max_pitch=2)
+    output = pianoroll_tuple.active
+    offset = pianoroll_tuple.offsets
+
+    expected_pianoroll = [[0, 0],
+                          [1, 0],
+                          [1, 1],
+                          [1, 1],
+                          [1, 1],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 1],
+                          [0, 1],
+                          [0, 1]]
+
+    expected_offsets = [[0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 1],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [1, 0],
+                        [0, 0],
+                        [0, 1]]
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+    np.testing.assert_allclose(expected_offsets, offset)
+
+  def testSequenceToPianorollWithBlankFrameBeforeOffset(self):
+    sequence = music_pb2.NoteSequence(total_time=1.5)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                    (2, 100, 0.20, 0.50),
+                                                    (1, 100, 1.20, 1.50),
+                                                    (2, 100, 0.50, 1.50)])
+
+    expected_pianoroll = [
+        [1, 0],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 1],
+        [0, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 0],
+    ]
+
+    output = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=1, max_pitch=2).active
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+
+    expected_pianoroll_with_blank_frame = [
+        [1, 0],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 1],
+        [0, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 0],
+    ]
+
+    output_with_blank_frame = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=10,
+        min_pitch=1,
+        max_pitch=2,
+        add_blank_frame_before_onset=True).active
+
+    np.testing.assert_allclose(expected_pianoroll_with_blank_frame,
+                               output_with_blank_frame)
+
+  def testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder(self):
+    sequence = music_pb2.NoteSequence(total_time=.5)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.20, 0.50),
+                                                    (1, 100, 0.00, 0.20)])
+
+    expected_pianoroll = [
+        [1],
+        [0],
+        [1],
+        [1],
+        [1],
+        [0],
+    ]
+
+    output = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=10,
+        min_pitch=1,
+        max_pitch=1,
+        add_blank_frame_before_onset=True).active
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+
+  def testSequenceToPianorollWeightedRoll(self):
+    sequence = music_pb2.NoteSequence(total_time=2.0)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                    (2, 100, 0.20, 0.50),
+                                                    (3, 100, 1.20, 1.50),
+                                                    (4, 100, 0.40, 2.00),
+                                                    (6, 100, 0.10, 0.60)])
+
+    onset_upweight = 5.0
+    expected_roll_weights = [
+        [onset_upweight, onset_upweight, 1, onset_upweight],
+        [onset_upweight, onset_upweight, onset_upweight, onset_upweight],
+        [1, 1, onset_upweight, onset_upweight / 1],
+        [1, 1, onset_upweight, onset_upweight / 2],
+        [1, 1, 1, 1],
+    ]
+
+    expected_onsets = [
+        [1, 1, 0, 1],
+        [1, 1, 1, 1],
+        [0, 0, 1, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 0],
+    ]
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=2,
+        min_pitch=1,
+        max_pitch=4,
+        onset_upweight=onset_upweight)
+
+    np.testing.assert_allclose(expected_roll_weights, roll.weights)
+    np.testing.assert_allclose(expected_onsets, roll.onsets)
+
+  def testSequenceToPianorollOnsets(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=2.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    onsets = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        100,
+        60,
+        62,
+        onset_mode=&#39;length_ms&#39;,
+        onset_length_ms=100.0,
+        onset_delay_ms=10.0,
+        min_frame_occupancy_for_label=.999).onsets
+
+    expected_roll = np.zeros([801, 3])
+    expected_roll[201:211, 0] = 1.
+    expected_roll[601:611, 1] = 1.
+    expected_roll[701:711, 2] = 1.
+
+    np.testing.assert_equal(expected_roll, onsets)
+
+  def testSequenceToPianorollFrameOccupancy(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=1.7)
+    sequence.notes.add(pitch=61, start_time=6.2, end_time=6.55)
+    sequence.notes.add(pitch=62, start_time=3.4, end_time=4.3)
+    sequence.total_time = 6.55
+
+    active = sequences_lib.sequence_to_pianoroll(
+        sequence, 2, 60, 62, min_frame_occupancy_for_label=0.5).active
+
+    expected_roll = np.zeros([14, 3])
+    expected_roll[2:3, 0] = 1.
+    expected_roll[12:13, 1] = 1.
+    expected_roll[7:9, 2] = 1.
+
+    np.testing.assert_equal(expected_roll, active)
+
+  def testSequenceToPianorollOnsetVelocities(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+    sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+    sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+    sequence.total_time = 2.0
+
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence, 1, 60, 62, max_velocity=64, onset_window=0)
+    onset_velocities = roll.onset_velocities
+
+    self.assertEqual(onset_velocities[0, 0], 0.25)
+    self.assertEqual(onset_velocities[0, 1], 0.5)
+    self.assertEqual(onset_velocities[0, 2], 1.)
+    self.assertEqual(np.all(onset_velocities[1:] == 0), True)
+
+  def testSequenceToPianorollActiveVelocities(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+    sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+    sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+    sequence.total_time = 2.0
+
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence, 1, 60, 62, max_velocity=64)
+    active_velocities = roll.active_velocities
+
+    self.assertEqual(np.all(active_velocities[0:2, 0] == 0.25), True)
+    self.assertEqual(np.all(active_velocities[0:2, 1] == 0.5), True)
+    self.assertEqual(np.all(active_velocities[0:2, 2] == 1.), True)
+    self.assertEqual(np.all(active_velocities[2:] == 0), True)
+
+  def testPianorollToNoteSequence(self):
+    # 100 frames of notes.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames.
+    frames[25:75, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+    self.assertLen(sequence.notes, 1)
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+  def testPianorollToNoteSequenceAllNotes(self):
+    # Test all 128 notes
+    frames = np.eye(MIDI_PITCHES, dtype=np.bool)  # diagonal identity matrix
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+    self.assertLen(sequence.notes, MIDI_PITCHES)
+    for i in range(MIDI_PITCHES):
+      self.assertEqual(i, sequence.notes[i].pitch)
+      self.assertAlmostEqual(i / DEFAULT_FRAMES_PER_SECOND,
+                             sequence.notes[i].start_time)
+      self.assertAlmostEqual((i+1) / DEFAULT_FRAMES_PER_SECOND,
+                             sequence.notes[i].end_time)
+
+  def testPianorollToNoteSequenceWithOnsets(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    # Add an onset for the first occurrence.
+    onsets[25, 39] = True
+    # Add an onset for a note that doesn&#39;t have an active frame.
+    onsets[80, 49] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+    self.assertEqual(49, sequence.notes[1].pitch)
+    self.assertEqual(80 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[1].start_time)
+    self.assertEqual(81 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)
+
+  def testPianorollToNoteSequenceWithOnsetsAndVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    # Add an onset for the first occurrence with a valid velocity.
+    onsets[25, 39] = True
+    velocity_values[25, 39] = 0.5
+    # Add an onset for the second occurrence with a NaN velocity.
+    onsets[90, 39] = True
+    velocity_values[90, 39] = float(&#39;nan&#39;)
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity_values=velocity_values)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(50, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(0, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    onsets[25, 39] = True
+    velocity_values[25, 39] = 0.5
+    onsets[90, 39] = True
+    velocity_values[90, 39] = 1.0
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity_values=velocity_values,
+        velocity_scale=127,
+        velocity_bias=0)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(63, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(127, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsDefaultVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    onsets[25, 39] = True
+    onsets[90, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity=100)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(100, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(100, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsOverlappingFrames(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames.
+    frames[25:75, 39] = True
+    # Add multiple onsets within those frames.
+    onsets[25, 39] = True
+    onsets[30, 39] = True
+    # If an onset lasts for multiple frames, it should create only 1 note.
+    onsets[35, 39] = True
+    onsets[36, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets)
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[1].start_time)
+    self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)
+
+    self.assertEqual(39, sequence.notes[2].pitch)
+    self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[2].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[2].end_time)
+
+  def testPianorollOnsetsToNoteSequence(self):
+    onsets = np.zeros((10, 2), np.bool)
+    velocity_values = np.zeros_like(onsets, np.float32)
+    onsets[0:2, 0] = True
+    velocity_values[0:2, 0] = .5
+    onsets[1:2, 1] = True
+    velocity_values[1:2, 1] = 1
+    sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+        onsets, frames_per_second=10, note_duration_seconds=0.05,
+        min_midi_pitch=60, velocity_values=velocity_values)
+
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(60, sequence.notes[0].pitch)
+    self.assertEqual(0, sequence.notes[0].start_time)
+    self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+    self.assertEqual(50, sequence.notes[0].velocity)
+
+    self.assertEqual(60, sequence.notes[1].pitch)
+    self.assertEqual(0.1, sequence.notes[1].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+    self.assertEqual(50, sequence.notes[1].velocity)
+
+    self.assertEqual(61, sequence.notes[2].pitch)
+    self.assertEqual(0.1, sequence.notes[2].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+    self.assertEqual(90, sequence.notes[2].velocity)
+
+  def testPianorollOnsetsToNoteSequenceFullVelocityScale(self):
+    onsets = np.zeros((10, 2), np.bool)
+    velocity_values = np.zeros_like(onsets, np.float32)
+    onsets[0:2, 0] = True
+    velocity_values[0:2, 0] = .5
+    onsets[1:2, 1] = True
+    velocity_values[1:2, 1] = 1
+    sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+        onsets, frames_per_second=10, note_duration_seconds=0.05,
+        min_midi_pitch=60, velocity_values=velocity_values,
+        velocity_scale=127, velocity_bias=0)
+
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(60, sequence.notes[0].pitch)
+    self.assertEqual(0, sequence.notes[0].start_time)
+    self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+    self.assertEqual(63, sequence.notes[0].velocity)
+
+    self.assertEqual(60, sequence.notes[1].pitch)
+    self.assertEqual(0.1, sequence.notes[1].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+    self.assertEqual(63, sequence.notes[1].velocity)
+
+    self.assertEqual(61, sequence.notes[2].pitch)
+    self.assertEqual(0.1, sequence.notes[2].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+    self.assertEqual(127, sequence.notes[2].velocity)
+
+  def testSequenceToPianorollControlChanges(self):
+    sequence = music_pb2.NoteSequence(total_time=2.0)
+    cc = music_pb2.NoteSequence.ControlChange
+    sequence.control_changes.extend([
+        cc(time=0.7, control_number=3, control_value=16),
+        cc(time=0.0, control_number=4, control_value=32),
+        cc(time=0.5, control_number=4, control_value=32),
+        cc(time=1.6, control_number=3, control_value=64),
+    ])
+
+    expected_cc_roll = np.zeros((5, 128), dtype=np.int32)
+    expected_cc_roll[0:2, 4] = 33
+    expected_cc_roll[1, 3] = 17
+    expected_cc_roll[3, 3] = 65
+
+    cc_roll = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=2, min_pitch=1, max_pitch=4).control_changes
+
+    np.testing.assert_allclose(expected_cc_roll, cc_roll)
+
+  def testSequenceToPianorollOverlappingNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=60, start_time=1.2, end_time=2.0)
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.5)
+    sequence.total_time = 2.5
+
+    rolls = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+        onset_mode=&#39;length_ms&#39;, onset_length_ms=10)
+
+    expected_onsets = np.zeros([26, 1])
+    expected_onsets[10, 0] = 1
+    expected_onsets[12, 0] = 1
+    np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+    expected_offsets = np.zeros([26, 1])
+    expected_offsets[20, 0] = 1
+    expected_offsets[25, 0] = 1
+    np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+    expected_active = np.zeros([26, 1])
+    expected_active[10:25, 0] = 1
+    np.testing.assert_equal(expected_active, rolls.active)
+
+  def testSequenceToPianorollShortNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=1.0001)
+    sequence.notes.add(pitch=60, start_time=1.2, end_time=1.2001)
+    sequence.total_time = 2.5
+
+    rolls = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+        onset_mode=&#39;length_ms&#39;, onset_length_ms=0)
+
+    expected_onsets = np.zeros([26, 1])
+    expected_onsets[10, 0] = 1
+    expected_onsets[12, 0] = 1
+    np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+    expected_offsets = np.zeros([26, 1])
+    expected_offsets[10, 0] = 1
+    expected_offsets[12, 0] = 1
+    np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+    expected_active = np.zeros([26, 1])
+    expected_active[10:11, 0] = 1
+    expected_active[12:13, 0] = 1
+    np.testing.assert_equal(expected_active, rolls.active)
+
+  def testSequenceToValuedIntervals(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=69, start_time=1.0, end_time=2.0, velocity=80)
+    # Should be dropped because it is 0 duration.
+    sequence.notes.add(pitch=60, start_time=3.0, end_time=3.0, velocity=90)
+
+    intervals, pitches, velocities = sequences_lib.sequence_to_valued_intervals(
+        sequence)
+    np.testing.assert_array_equal([[1., 2.]], intervals)
+    np.testing.assert_array_equal([440.0], pitches)
+    np.testing.assert_array_equal([80], velocities)
+
+
+if __name__ == &#39;__main__&#39;:
+  absltest.main()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest"><code class="flex name class">
+<span>class <span class="ident">SequencesLibTest</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SequencesLibTest(testing_lib.ProtoTestCase):
+
+  def testTransposeNoteSequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    sequence.text_annotations.add(
+        time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+    sequence.text_annotations.add(
+        time=2, annotation_type=CHORD_SYMBOL, text=&#39;E7&#39;)
+    sequence.key_signatures.add(
+        time=0, key=music_pb2.NoteSequence.KeySignature.E,
+        mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(13, 100, 0.01, 10.0), (12, 55, 0.22, 0.50), (41, 45, 2.50, 3.50),
+         (56, 120, 4.0, 4.01), (53, 99, 4.75, 5.0)])
+    expected_sequence.text_annotations.add(
+        time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+    expected_sequence.text_annotations.add(
+        time=2, annotation_type=CHORD_SYMBOL, text=&#39;F7&#39;)
+    expected_sequence.key_signatures.add(
+        time=0, key=music_pb2.NoteSequence.KeySignature.F,
+        mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence, 1)
+    self.assertProtoEquals(expected_sequence, transposed_sequence)
+    self.assertEqual(delete_count, 0)
+
+  def testTransposeNoteSequenceOutOfRange(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(35, 100, 0.01, 10.0), (36, 55, 0.22, 0.50), (37, 45, 2.50, 3.50),
+         (38, 120, 4.0, 4.01), (39, 99, 4.75, 5.0)])
+
+    expected_sequence_1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence_1, 0,
+        [(39, 100, 0.01, 10.0), (40, 55, 0.22, 0.50)])
+
+    expected_sequence_2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence_2, 0,
+        [(30, 120, 4.0, 4.01), (31, 99, 4.75, 5.0)])
+
+    sequence_copy = copy.copy(sequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence_copy, 4, 30, 40)
+    self.assertProtoEquals(expected_sequence_1, transposed_sequence)
+    self.assertEqual(delete_count, 3)
+
+    sequence_copy = copy.copy(sequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence_copy, -8, 30, 40)
+    self.assertProtoEquals(expected_sequence_2, transposed_sequence)
+    self.assertEqual(delete_count, 3)
+
+  def testClampTranspose(self):
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        5, 20, 60, 10, 70)
+    self.assertEqual(clamped, 5)
+
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        15, 20, 60, 10, 65)
+    self.assertEqual(clamped, 5)
+
+    clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+        -16, 20, 60, 10, 70)
+    self.assertEqual(clamped, -10)
+
+  def testAugmentNoteSequenceDeleteFalse(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2,
+        min_transpose=-15,
+        max_transpose=-10,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=False)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(10, 100, 0.02, 20.0), (11, 55, 0.44, 1.0),
+                               (38, 45, 5., 7.), (53, 120, 8.0, 8.02),
+                               (50, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceDeleteTrue(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2,
+        min_transpose=-15,
+        max_transpose=-15,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(25, 45, 5., 7.), (40, 120, 8.0, 8.02),
+                               (37, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceNoStretch(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=1,
+        max_stretch_factor=1.,
+        min_transpose=-15,
+        max_transpose=-15,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(25, 45, 2.5, 3.50), (40, 120, 4.0, 4.01),
+                               (37, 99, 4.75, 5.0)])
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testAugmentNoteSequenceNoTranspose(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                      (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                      (52, 99, 4.75, 5.0)])
+
+    augmented_sequence = sequences_lib.augment_note_sequence(
+        sequence,
+        min_stretch_factor=2,
+        max_stretch_factor=2.,
+        min_transpose=0,
+        max_transpose=0,
+        min_allowed_pitch=10,
+        max_allowed_pitch=127,
+        delete_out_of_range_notes=True)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0, [(12, 100, 0.02, 20.0), (13, 55, 0.44, 1.0),
+                               (40, 45, 5., 7.), (55, 120, 8.0, 8.02),
+                               (52, 99, 9.5, 10.0)])
+    expected_sequence.tempos[0].qpm = 30.
+
+    self.assertProtoEquals(augmented_sequence, expected_sequence)
+
+  def testTrimNoteSequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0,
+        [(40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+    expected_subsequence.total_time = 4.75
+
+    subsequence = sequences_lib.trim_note_sequence(sequence, 2.5, 4.75)
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testExtractSubsequence(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0,
+        [(40, 45, 0.0, 1.0), (55, 120, 1.5, 1.51)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 0.5)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 1, [(0.0, 64, 127)])
+    expected_subsequence.total_time = 1.51
+    expected_subsequence.subsequence_info.start_time_offset = 2.5
+    expected_subsequence.subsequence_info.end_time_offset = 5.99
+
+    subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+    subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.time))
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testExtractSubsequencePastEnd(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 18.0)])
+
+    with self.assertRaises(ValueError):
+      sequences_lib.extract_subsequence(sequence, 15.0, 16.0)
+
+  def testExtractSubsequencePedalEvents(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0, [(60, 80, 2.5, 5.0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 66, 0), (2.0, 66, 127), (4.0, 66, 0), (5.0, 66, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 67, 10), (2.0, 67, 20), (4.0, 67, 30), (5.0, 67, 40)])
+    expected_subsequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence, 0, [(60, 80, 0, 2.25)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 1, [(0.0, 64, 127)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 66, 127), (1.5, 66, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_subsequence, 0, [(0.0, 67, 20), (1.5, 67, 30)])
+    expected_subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+    expected_subsequence.total_time = 2.25
+    expected_subsequence.subsequence_info.start_time_offset = 2.5
+    expected_subsequence.subsequence_info.end_time_offset = .25
+
+    subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+    subsequence.control_changes.sort(
+        key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+    self.assertProtoEquals(expected_subsequence, subsequence)
+
+  def testSplitNoteSequenceWithHopSize(self):
+    # Tests splitting a NoteSequence at regular hop size, truncating notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(55, 120, 1.0, 1.01), (52, 99, 1.75, 2.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 1.0)])
+    expected_subsequence_2.total_time = 2.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 3.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+    expected_subsequence_3.total_time = 0.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 6.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 2.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=3.0)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceAtTimes(self):
+    # Tests splitting a NoteSequence at specified times, truncating notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0)])
+    expected_subsequence_2.total_time = 0.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+    expected_subsequence_3.total_time = 1.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=[3.0, 4.0])
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceSkipSplitsInsideNotes(self):
+    # Tests splitting a NoteSequence at regular hop size, skipping splits that
+    # would have occurred inside a note.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.5)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0)])
+    expected_subsequence_1.total_time = 3.50
+    expected_subsequence_1.subsequence_info.end_time_offset = 1.5
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.5)])
+    expected_subsequence_2.total_time = 1.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 4.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=2.0, skip_splits_inside_notes=True)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceNoTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # no time changes (time signature and tempo changes).
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence = music_pb2.NoteSequence()
+    expected_subsequence.CopyFrom(sequence)
+    expected_subsequence.subsequence_info.start_time_offset = 0.0
+    expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 1)
+    self.assertProtoEquals(expected_subsequence, subsequences[0])
+
+  def testSplitNoteSequenceDuplicateTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # duplicate time changes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence = music_pb2.NoteSequence()
+    expected_subsequence.CopyFrom(sequence)
+    expected_subsequence.subsequence_info.start_time_offset = 0.0
+    expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 1)
+    self.assertProtoEquals(expected_subsequence, subsequences[0])
+
+  def testSplitNoteSequenceCoincidentTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+    # two time changes occurring simultaneously.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 2.0
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+    expected_subsequence_1.total_time = 2.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01), (52, 99, 2.75, 3.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0), (&#39;F&#39;, 2.8)])
+    expected_subsequence_2.total_time = 3.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes(self):
+    # Tests splitting a NoteSequence on time changes skipping splits that occur
+    # inside notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 4.25
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0)])
+    expected_subsequence_1.total_time = 4.01
+    expected_subsequence_1.subsequence_info.end_time_offset = 0.99
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0, [(52, 99, 0.5, 0.75)])
+    testing_lib.add_chords_to_sequence(expected_subsequence_2, [
+        (&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+    expected_subsequence_2.total_time = 0.75
+    expected_subsequence_2.subsequence_info.start_time_offset = 4.25
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(
+        sequence, skip_splits_inside_notes=True)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testSplitNoteSequenceMultipleTimeChanges(self):
+    # Tests splitting a NoteSequence on time changes, truncating notes on splits
+    # that occur inside notes.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        time_signatures: {
+          time: 2.0
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}
+        tempos: {
+          time: 4.25
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+    expected_subsequence_1.total_time = 2.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0)])
+    expected_subsequence_2.total_time = 2.01
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.99
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 3
+          denominator: 4}
+        tempos: {
+          qpm: 80}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(52, 99, 0.5, 0.75)])
+    testing_lib.add_chords_to_sequence(
+        expected_subsequence_3, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+    expected_subsequence_3.total_time = 0.75
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.25
+    expected_subsequence_3.subsequence_info.end_time_offset = 5.0
+
+    subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceWithStatelessEvents(self):
+    # Tests splitting a NoteSequence at specified times with stateless events.
+    sequence = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_beats_to_sequence(sequence, [1.0, 2.0, 4.0])
+
+    expected_subsequence_1 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+    testing_lib.add_beats_to_sequence(expected_subsequence_1, [1.0, 2.0])
+    expected_subsequence_1.total_time = 3.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_2 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    expected_subsequence_2.total_time = 0.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+    expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+    expected_subsequence_3 = testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4}
+        tempos: {
+          qpm: 60}&#34;&#34;&#34;)
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+    testing_lib.add_beats_to_sequence(expected_subsequence_3, [0.0])
+    expected_subsequence_3.total_time = 1.0
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+    expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+    subsequences = sequences_lib.split_note_sequence(
+        sequence, hop_size_seconds=[3.0, 4.0])
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceOnSilence(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    expected_subsequence_1 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_1, 0,
+        [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50)])
+    expected_subsequence_1.total_time = 1.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 4.0
+
+    expected_subsequence_2 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(40, 45, 0.0, 1.0), (55, 120, 1.50, 1.51)])
+    expected_subsequence_2.total_time = 1.51
+    expected_subsequence_2.subsequence_info.start_time_offset = 2.50
+    expected_subsequence_2.subsequence_info.end_time_offset = 0.99
+
+    expected_subsequence_3 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_3, 0,
+        [(52, 99, 0.0, 0.25)])
+    expected_subsequence_3.total_time = 0.25
+    expected_subsequence_3.subsequence_info.start_time_offset = 4.75
+
+    subsequences = sequences_lib.split_note_sequence_on_silence(
+        sequence, gap_seconds=0.5)
+    self.assertLen(subsequences, 3)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+    self.assertProtoEquals(expected_subsequence_3, subsequences[2])
+
+  def testSplitNoteSequenceOnSilenceInitialGap(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 1.5, 2.0), (11, 55, 1.5, 3.0), (40, 45, 2.5, 3.5)])
+
+    expected_subsequence_1 = music_pb2.NoteSequence()
+    expected_subsequence_1.total_time = 0.0
+    expected_subsequence_1.subsequence_info.end_time_offset = 3.5
+
+    expected_subsequence_2 = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        expected_subsequence_2, 0,
+        [(12, 100, 0.0, 0.5), (11, 55, 0.0, 1.5), (40, 45, 1.0, 2.0)])
+    expected_subsequence_2.total_time = 2.0
+    expected_subsequence_2.subsequence_info.start_time_offset = 1.5
+
+    subsequences = sequences_lib.split_note_sequence_on_silence(
+        sequence, gap_seconds=1.0)
+    self.assertLen(subsequences, 2)
+    self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+    self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+
+  def testQuantizeNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+    testing_lib.add_control_changes_to_sequence(
+        self.note_sequence, 0,
+        [(2.0, 64, 127), (4.0, 64, 0)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_quantized_sequence, [1, 16])
+    testing_lib.add_quantized_control_steps_to_sequence(
+        expected_quantized_sequence, [8, 16])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testQuantizeNoteSequenceAbsolute(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence,
+        [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+    testing_lib.add_control_changes_to_sequence(
+        self.note_sequence, 0,
+        [(2.0, 64, 127), (4.0, 64, 0)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_second = 4
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_quantized_sequence, [1, 16])
+    testing_lib.add_quantized_control_steps_to_sequence(
+        expected_quantized_sequence, [8, 16])
+
+    quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testAssertIsQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+    absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    sequences_lib.assert_is_quantized_sequence(relative_quantized_sequence)
+    sequences_lib.assert_is_quantized_sequence(absolute_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_quantized_sequence(self.note_sequence)
+
+  def testAssertIsRelativeQuantizedNoteSequence(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+    relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+    absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+        self.note_sequence, steps_per_second=4)
+
+    sequences_lib.assert_is_relative_quantized_sequence(
+        relative_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_relative_quantized_sequence(
+          absolute_quantized_sequence)
+    with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+      sequences_lib.assert_is_relative_quantized_sequence(self.note_sequence)
+
+  def testQuantizeNoteSequence_TimeSignatureChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Single time signature.
+    self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Multiple time signatures with no change.
+    self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=1)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Time signature change.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testQuantizeNoteSequence_ImplicitTimeSignatureChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+
+    # No time signature.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Implicit time signature change.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.time_signatures[:]
+
+    # No time signature.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # No implicit time signature change, but time signatures are added out of
+    # order.
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+    self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+  def testStepsPerQuarterToStepsPerSecond(self):
+    self.assertEqual(
+        4.0, sequences_lib.steps_per_quarter_to_steps_per_second(4, 60.0))
+
+  def testQuantizeToStep(self):
+    self.assertEqual(
+        32, sequences_lib.quantize_to_step(8.0001, 4))
+    self.assertEqual(
+        34, sequences_lib.quantize_to_step(8.4999, 4))
+    self.assertEqual(
+        33, sequences_lib.quantize_to_step(8.4999, 4, quantize_cutoff=1.0))
+
+  def testFromNoteSequence_TempoChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempos.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Single tempo.
+    self.note_sequence.tempos.add(qpm=60, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Multiple tempos with no change.
+    self.note_sequence.tempos.add(qpm=60, time=1)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Tempo change.
+    self.note_sequence.tempos.add(qpm=120, time=2)
+    with self.assertRaises(sequences_lib.MultipleTempoError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testFromNoteSequence_ImplicitTempoChange(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempo.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # Implicit tempo change.
+    self.note_sequence.tempos.add(qpm=60, time=2)
+    with self.assertRaises(sequences_lib.MultipleTempoError):
+      sequences_lib.quantize_note_sequence(
+          self.note_sequence, self.steps_per_quarter)
+
+  def testFromNoteSequence_NoImplicitTempoChangeOutOfOrder(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    del self.note_sequence.tempos[:]
+
+    # No tempo.
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+    # No implicit tempo change, but tempos are added out of order.
+    self.note_sequence.tempos.add(qpm=60, time=2)
+    self.note_sequence.tempos.add(qpm=60, time=0)
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+
+  def testRounding(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 1,
+        [(12, 100, 0.01, 0.24), (11, 100, 0.22, 0.55), (40, 100, 0.50, 0.75),
+         (41, 100, 0.689, 1.18), (44, 100, 1.19, 1.69), (55, 100, 4.0, 4.01)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(0, 1), (1, 2), (2, 3), (3, 5), (5, 7), (16, 17)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testMultiTrack(self):
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 1.0, 4.0), (19, 100, 0.95, 3.0)])
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 3,
+        [(12, 100, 1.0, 4.0), (19, 100, 2.0, 5.0)])
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 7,
+        [(12, 100, 1.0, 5.0), (19, 100, 2.0, 4.0), (24, 100, 3.0, 3.5)])
+
+    expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+    expected_quantized_sequence.quantization_info.steps_per_quarter = (
+        self.steps_per_quarter)
+    testing_lib.add_quantized_steps_to_sequence(
+        expected_quantized_sequence,
+        [(4, 16), (4, 12), (4, 16), (8, 20), (4, 20), (8, 16), (12, 14)])
+    quantized_sequence = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)
+
+  def testStepsPerBar(self):
+    qns = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertEqual(16, sequences_lib.steps_per_bar_in_quantized_sequence(qns))
+
+    self.note_sequence.time_signatures[0].numerator = 6
+    self.note_sequence.time_signatures[0].denominator = 8
+    qns = sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)
+    self.assertEqual(12.0,
+                     sequences_lib.steps_per_bar_in_quantized_sequence(qns))
+
+  def testStretchNoteSequence(self):
+    expected_stretched_sequence = copy.deepcopy(self.note_sequence)
+    expected_stretched_sequence.tempos[0].qpm = 40
+
+    testing_lib.add_track_to_sequence(
+        self.note_sequence, 0,
+        [(12, 100, 0.0, 10.0), (11, 55, 0.2, 0.5), (40, 45, 2.5, 3.5)])
+    testing_lib.add_track_to_sequence(
+        expected_stretched_sequence, 0,
+        [(12, 100, 0.0, 15.0), (11, 55, 0.3, 0.75), (40, 45, 3.75, 5.25)])
+
+    testing_lib.add_chords_to_sequence(
+        self.note_sequence, [(&#39;B7&#39;, 0.5), (&#39;Em9&#39;, 2.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_stretched_sequence, [(&#39;B7&#39;, 0.75), (&#39;Em9&#39;, 3.0)])
+
+    prestretched_sequence = copy.deepcopy(self.note_sequence)
+
+    stretched_sequence = sequences_lib.stretch_note_sequence(
+        self.note_sequence, stretch_factor=1.5, in_place=False)
+    self.assertProtoEquals(expected_stretched_sequence, stretched_sequence)
+
+    # Make sure the proto was not modified
+    self.assertProtoEquals(prestretched_sequence, self.note_sequence)
+
+    sequences_lib.stretch_note_sequence(
+        self.note_sequence, stretch_factor=1.5, in_place=True)
+    self.assertProtoEquals(stretched_sequence, self.note_sequence)
+
+  def testAdjustNoteSequenceTimes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.control_changes.add(control_number=1, time=2.0)
+    sequence.pitch_bends.add(bend=5, time=2.0)
+    sequence.total_time = 7.0
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, lambda t: t - 1)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=0.0, end_time=4.0)
+    expected_sequence.notes.add(pitch=61, start_time=5.0, end_time=6.0)
+    expected_sequence.control_changes.add(control_number=1, time=1.0)
+    expected_sequence.pitch_bends.add(bend=5, time=1.0)
+    expected_sequence.total_time = 6.0
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(0, skipped_notes)
+
+  def testAdjustNoteSequenceTimesWithSkippedNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time &gt; 5:
+        return 5
+      else:
+        return time
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    expected_sequence.total_time = 5.0
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(2, skipped_notes)
+
+  def testAdjustNoteSequenceTimesWithNotesBeforeTimeZero(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      return time - 5
+
+    with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+      sequences_lib.adjust_notesequence_times(sequence, time_func)
+
+  def testAdjustNoteSequenceTimesWithZeroDurations(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+    sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time % 2 == 0:
+        return time - 1
+      else:
+        return time
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func)
+
+    expected_sequence = music_pb2.NoteSequence()
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(3, skipped_notes)
+
+    adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+        sequence, time_func, minimum_duration=.1)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=1.1)
+    expected_sequence.notes.add(pitch=61, start_time=3.0, end_time=3.1)
+    expected_sequence.notes.add(pitch=62, start_time=5.0, end_time=5.1)
+    expected_sequence.total_time = 5.1
+
+    self.assertEqual(expected_sequence, adjusted_ns)
+    self.assertEqual(0, skipped_notes)
+
+  def testAdjustNoteSequenceTimesEndBeforeStart(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+    sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+    sequence.total_time = 8.0
+
+    def time_func(time):
+      if time % 2 == 0:
+        return time - 2
+      else:
+        return time
+
+    with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+      sequences_lib.adjust_notesequence_times(sequence, time_func)
+
+  def testRectifyBeats(self):
+    sequence = music_pb2.NoteSequence()
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.5),
+         (65, 100, 1.0, 1.5), (67, 100, 1.5, 2.0)])
+    testing_lib.add_beats_to_sequence(sequence, [0.5, 1.0, 2.0])
+
+    rectified_sequence, alignment = sequences_lib.rectify_beats(
+        sequence, 120)
+
+    expected_sequence = music_pb2.NoteSequence()
+    expected_sequence.tempos.add(qpm=120)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.0),
+         (65, 100, 1.0, 1.25), (67, 100, 1.25, 1.5)])
+    testing_lib.add_beats_to_sequence(expected_sequence, [0.5, 1.0, 1.5])
+
+    self.assertEqual(expected_sequence, rectified_sequence)
+
+    expected_alignment = [
+        [0.0, 0.5, 1.0, 2.0, 2.5],
+        [0.0, 0.5, 1.0, 1.5, 2.0]
+    ]
+    self.assertEqual(expected_alignment, alignment.T.tolist())
+
+  def testApplySustainControlChanges(self):
+    &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0),
+         (3.75, 64, 127), (4.5, 64, 127), (4.8, 64, 0), (4.9, 64, 127),
+         (6.0, 64, 0)])
+    testing_lib.add_track_to_sequence(
+        sequence, 1,
+        [(12, 100, 0.01, 10.0), (52, 99, 4.75, 5.0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.8)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithRepeatedNotes(self):
+    &#34;&#34;&#34;Verify that sustain control handles repeated notes correctly.
+
+    For example, a single pitch played before sustain:
+    x-- x-- x--
+    After sustain:
+    x---x---x--
+
+    Notes should be extended until either the end of the sustain control or the
+    beginning of another note of the same pitch.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 1.50), (60, 100, 1.25, 1.50), (72, 100, 2.00, 3.50),
+         (60, 100, 2.0, 3.00), (60, 100, 3.50, 4.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 1.25), (60, 100, 1.25, 2.00), (72, 100, 2.00, 4.00),
+         (60, 100, 2.0, 3.50), (60, 100, 3.50, 4.50)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithRepeatedNotesBeforeSustain(self):
+    &#34;&#34;&#34;Repeated notes before sustain can overlap and should not be modified.
+
+    Once a repeat happens within the sustain, any active notes should end
+    before the next one starts.
+
+    This is kind of an edge case because a note overlapping a note of the same
+    pitch may not make sense, but apply_sustain_control_changes tries not to
+    modify events that happen outside of a sustain.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.25, 1.50), (60, 100, .50, 1.50), (60, 100, 1.25, 2.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.25, 1.25), (60, 100, 0.50, 1.25), (60, 100, 1.25, 4.00)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesSimultaneousOnOff(self):
+    &#34;&#34;&#34;Test sustain on and off events happening at the same time.
+
+    The off event should be processed last, so this should be a no-op.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(1.0, 64, 127), (1.0, 64, 0)])
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (60, 100, 2.0, 3.0)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(sequence, sus_sequence)
+
+  def testApplySustainControlChangesExtendNotesToEnd(self):
+    &#34;&#34;&#34;Test sustain control extending the duration of the final note.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.50, 4.00), (72, 100, 2.0, 4.0)])
+    expected_sequence.total_time = 4.0
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesExtraneousSustain(self):
+    &#34;&#34;&#34;Test applying extraneous sustain control at the end of the sequence.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0, [(4.0, 64, 127), (5.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+    # The total_time field only takes *notes* into account, and should not be
+    # affected by a sustain-on event beyond the last note.
+    expected_sequence.total_time = 3.0
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithIdenticalNotes(self):
+    &#34;&#34;&#34;In the case of identical notes, one should be dropped.
+
+    This is an edge case because in most cases, the same pitch should not sound
+    twice at the same time on one instrument.
+    &#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 2.00, 2.50), (60, 100, 2.00, 2.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 2.00, 4.00)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesWithDrumNotes(self):
+    &#34;&#34;&#34;Drum notes should not be modified when applying sustain changes.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(1.0, 64, 127), (4.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 2.00, 2.50)])
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(38, 100, 2.00, 2.50)], is_drum=True)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 2.00, 4.00)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(38, 100, 2.0, 2.5)], is_drum=True)
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testApplySustainControlChangesProcessSustainBeforeNotes(self):
+    &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+
+    sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+    self.assertProtoEquals(expected_sequence, sus_sequence)
+
+  def testInferDenseChordsForSequence(self):
+    # Test non-quantized sequence.
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 1.0, 3.0), (64, 100, 1.0, 2.0), (67, 100, 1.0, 2.0),
+         (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),
+         (62, 100, 3.0, 5.0), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.0)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+    sequences_lib.infer_dense_chords_for_sequence(sequence)
+    self.assertProtoEquals(expected_sequence, sequence)
+
+    # Test quantized sequence.
+    sequence = copy.copy(self.note_sequence)
+    sequence.quantization_info.steps_per_quarter = 1
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 1.1, 3.0), (64, 100, 1.0, 1.9), (67, 100, 1.0, 2.0),
+         (65, 100, 2.0, 3.2), (69, 100, 2.1, 3.1),
+         (62, 100, 2.9, 4.8), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.1)])
+    testing_lib.add_quantized_steps_to_sequence(
+        sequence,
+        [(1, 3), (1, 2), (1, 2), (2, 3), (2, 3), (3, 5), (3, 4), (3, 4)])
+    expected_sequence = copy.copy(sequence)
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+    testing_lib.add_quantized_chord_steps_to_sequence(
+        expected_sequence, [1, 2, 3])
+    sequences_lib.infer_dense_chords_for_sequence(sequence)
+    self.assertProtoEquals(expected_sequence, sequence)
+
+  def testShiftSequenceTimes(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+         (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+    testing_lib.add_chords_to_sequence(
+        sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 0,
+        [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        sequence, 1, [(2.0, 64, 127)])
+    testing_lib.add_pitch_bends_to_sequence(
+        sequence, 1, 1, [(2.0, 100), (3.0, 0)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(12, 100, 1.01, 11.0), (11, 55, 1.22, 1.50), (40, 45, 3.50, 4.50),
+         (55, 120, 5.0, 5.01), (52, 99, 5.75, 6.0)])
+    testing_lib.add_chords_to_sequence(
+        expected_sequence, [(&#39;C&#39;, 2.5), (&#39;G7&#39;, 4.0), (&#39;F&#39;, 5.8)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_sequence, 0,
+        [(1.0, 64, 127), (3.0, 64, 0), (5.0, 64, 127), (6.0, 64, 0)])
+    testing_lib.add_control_changes_to_sequence(
+        expected_sequence, 1, [(3.0, 64, 127)])
+    testing_lib.add_pitch_bends_to_sequence(
+        expected_sequence, 1, 1, [(3.0, 100), (4.0, 0)])
+
+    expected_sequence.time_signatures[0].time = 1
+    expected_sequence.tempos[0].time = 1
+
+    shifted_sequence = sequences_lib.shift_sequence_times(sequence, 1.0)
+    self.assertProtoEquals(expected_sequence, shifted_sequence)
+
+  def testConcatenateSequences(self):
+    sequence1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence1, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+    sequence2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence2, 0,
+        [(59, 100, 0.0, 1.0), (71, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (59, 100, 1.5, 2.5), (71, 100, 2.0, 3.0)])
+
+    cat_seq = sequences_lib.concatenate_sequences([sequence1, sequence2])
+    self.assertProtoEquals(expected_sequence, cat_seq)
+
+  def testConcatenateSequencesWithSpecifiedDurations(self):
+    sequence1 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence1, 0, [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+    sequence2 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence2, 0,
+        [(59, 100, 0.0, 1.0)])
+    sequence3 = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence3, 0,
+        [(72, 100, 0.0, 1.0), (73, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (59, 100, 2.0, 3.0),
+         (72, 100, 3.5, 4.5), (73, 100, 4.0, 5.0)])
+
+    cat_seq = sequences_lib.concatenate_sequences(
+        [sequence1, sequence2, sequence3],
+        sequence_durations=[2, 1.5, 2])
+    self.assertProtoEquals(expected_sequence, cat_seq)
+
+  def testRepeatSequenceToDuration(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (60, 100, 1.5, 2.5), (72, 100, 2.0, 3.0)])
+
+    repeated_seq = sequences_lib.repeat_sequence_to_duration(
+        sequence, duration=3)
+    self.assertProtoEquals(expected_sequence, repeated_seq)
+
+  def testRepeatSequenceToDurationProvidedDuration(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected_sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+         (60, 100, 2.0, 3.0), (72, 100, 2.5, 3.0)])
+
+    repeated_seq = sequences_lib.repeat_sequence_to_duration(
+        sequence, duration=3, sequence_duration=2)
+    self.assertProtoEquals(expected_sequence, repeated_seq)
+
+  def testRemoveRedundantData(self):
+    sequence = copy.copy(self.note_sequence)
+    redundant_tempo = sequence.tempos.add()
+    redundant_tempo.CopyFrom(sequence.tempos[0])
+    redundant_tempo.time = 5.0
+    sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+    sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+    expected_sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+    expected_sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
+
+  def testRemoveRedundantDataOutOfOrder(self):
+    sequence = copy.copy(self.note_sequence)
+    meaningful_tempo = sequence.tempos.add()
+    meaningful_tempo.time = 5.0
+    meaningful_tempo.qpm = 50
+    redundant_tempo = sequence.tempos.add()
+    redundant_tempo.CopyFrom(sequence.tempos[0])
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_meaningful_tempo = expected_sequence.tempos.add()
+    expected_meaningful_tempo.time = 5.0
+    expected_meaningful_tempo.qpm = 50
+
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
+
+  def testExpandSectionGroups(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+    sequence.section_annotations.add(time=0, section_id=0)
+    sequence.section_annotations.add(time=1, section_id=1)
+    sequence.section_annotations.add(time=2, section_id=2)
+    sequence.section_annotations.add(time=3, section_id=3)
+
+    # A((BC)2D)2
+    sg = sequence.section_groups.add()
+    sg.sections.add(section_id=0)
+    sg.num_times = 1
+    sg = sequence.section_groups.add()
+    sg.sections.add(section_group=music_pb2.NoteSequence.SectionGroup(
+        sections=[music_pb2.NoteSequence.Section(section_id=1),
+                  music_pb2.NoteSequence.Section(section_id=2)],
+        num_times=2))
+    sg.sections.add(section_id=3)
+    sg.num_times = 2
+
+    expanded = sequences_lib.expand_section_groups(sequence)
+
+    expected = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        expected, 0,
+        [(60, 100, 0.0, 1.0),
+         (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0),
+         (72, 100, 3.0, 4.0),
+         (59, 100, 4.0, 5.0),
+         (71, 100, 5.0, 6.0),
+         (72, 100, 6.0, 7.0),
+         (59, 100, 7.0, 8.0),
+         (72, 100, 8.0, 9.0),
+         (59, 100, 9.0, 10.0),
+         (71, 100, 10.0, 11.0)])
+    expected.section_annotations.add(time=0, section_id=0)
+    expected.section_annotations.add(time=1, section_id=1)
+    expected.section_annotations.add(time=2, section_id=2)
+    expected.section_annotations.add(time=3, section_id=1)
+    expected.section_annotations.add(time=4, section_id=2)
+    expected.section_annotations.add(time=5, section_id=3)
+    expected.section_annotations.add(time=6, section_id=1)
+    expected.section_annotations.add(time=7, section_id=2)
+    expected.section_annotations.add(time=8, section_id=1)
+    expected.section_annotations.add(time=9, section_id=2)
+    expected.section_annotations.add(time=10, section_id=3)
+    self.assertProtoEquals(expected, expanded)
+
+  def testExpandWithoutSectionGroups(self):
+    sequence = copy.copy(self.note_sequence)
+    testing_lib.add_track_to_sequence(
+        sequence, 0,
+        [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+         (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+    sequence.section_annotations.add(time=0, section_id=0)
+    sequence.section_annotations.add(time=1, section_id=1)
+    sequence.section_annotations.add(time=2, section_id=2)
+    sequence.section_annotations.add(time=3, section_id=3)
+
+    expanded = sequences_lib.expand_section_groups(sequence)
+
+    self.assertEqual(sequence, expanded)
+
+  def testSequenceToPianoroll(self):
+    sequence = music_pb2.NoteSequence(total_time=1.21)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.11, 1.01),
+                                                    (2, 55, 0.22, 0.50),
+                                                    (3, 100, 0.3, 0.8),
+                                                    (2, 45, 1.0, 1.21)])
+
+    pianoroll_tuple = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=1, max_pitch=2)
+    output = pianoroll_tuple.active
+    offset = pianoroll_tuple.offsets
+
+    expected_pianoroll = [[0, 0],
+                          [1, 0],
+                          [1, 1],
+                          [1, 1],
+                          [1, 1],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 0],
+                          [1, 1],
+                          [0, 1],
+                          [0, 1]]
+
+    expected_offsets = [[0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 1],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [0, 0],
+                        [1, 0],
+                        [0, 0],
+                        [0, 1]]
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+    np.testing.assert_allclose(expected_offsets, offset)
+
+  def testSequenceToPianorollWithBlankFrameBeforeOffset(self):
+    sequence = music_pb2.NoteSequence(total_time=1.5)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                    (2, 100, 0.20, 0.50),
+                                                    (1, 100, 1.20, 1.50),
+                                                    (2, 100, 0.50, 1.50)])
+
+    expected_pianoroll = [
+        [1, 0],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 1],
+        [0, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 0],
+    ]
+
+    output = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=1, max_pitch=2).active
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+
+    expected_pianoroll_with_blank_frame = [
+        [1, 0],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 1],
+        [0, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        [0, 0],
+    ]
+
+    output_with_blank_frame = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=10,
+        min_pitch=1,
+        max_pitch=2,
+        add_blank_frame_before_onset=True).active
+
+    np.testing.assert_allclose(expected_pianoroll_with_blank_frame,
+                               output_with_blank_frame)
+
+  def testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder(self):
+    sequence = music_pb2.NoteSequence(total_time=.5)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.20, 0.50),
+                                                    (1, 100, 0.00, 0.20)])
+
+    expected_pianoroll = [
+        [1],
+        [0],
+        [1],
+        [1],
+        [1],
+        [0],
+    ]
+
+    output = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=10,
+        min_pitch=1,
+        max_pitch=1,
+        add_blank_frame_before_onset=True).active
+
+    np.testing.assert_allclose(expected_pianoroll, output)
+
+  def testSequenceToPianorollWeightedRoll(self):
+    sequence = music_pb2.NoteSequence(total_time=2.0)
+    testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                    (2, 100, 0.20, 0.50),
+                                                    (3, 100, 1.20, 1.50),
+                                                    (4, 100, 0.40, 2.00),
+                                                    (6, 100, 0.10, 0.60)])
+
+    onset_upweight = 5.0
+    expected_roll_weights = [
+        [onset_upweight, onset_upweight, 1, onset_upweight],
+        [onset_upweight, onset_upweight, onset_upweight, onset_upweight],
+        [1, 1, onset_upweight, onset_upweight / 1],
+        [1, 1, onset_upweight, onset_upweight / 2],
+        [1, 1, 1, 1],
+    ]
+
+    expected_onsets = [
+        [1, 1, 0, 1],
+        [1, 1, 1, 1],
+        [0, 0, 1, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 0],
+    ]
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        frames_per_second=2,
+        min_pitch=1,
+        max_pitch=4,
+        onset_upweight=onset_upweight)
+
+    np.testing.assert_allclose(expected_roll_weights, roll.weights)
+    np.testing.assert_allclose(expected_onsets, roll.onsets)
+
+  def testSequenceToPianorollOnsets(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=2.0, end_time=5.0)
+    sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+    sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+    sequence.total_time = 8.0
+
+    onsets = sequences_lib.sequence_to_pianoroll(
+        sequence,
+        100,
+        60,
+        62,
+        onset_mode=&#39;length_ms&#39;,
+        onset_length_ms=100.0,
+        onset_delay_ms=10.0,
+        min_frame_occupancy_for_label=.999).onsets
+
+    expected_roll = np.zeros([801, 3])
+    expected_roll[201:211, 0] = 1.
+    expected_roll[601:611, 1] = 1.
+    expected_roll[701:711, 2] = 1.
+
+    np.testing.assert_equal(expected_roll, onsets)
+
+  def testSequenceToPianorollFrameOccupancy(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=1.7)
+    sequence.notes.add(pitch=61, start_time=6.2, end_time=6.55)
+    sequence.notes.add(pitch=62, start_time=3.4, end_time=4.3)
+    sequence.total_time = 6.55
+
+    active = sequences_lib.sequence_to_pianoroll(
+        sequence, 2, 60, 62, min_frame_occupancy_for_label=0.5).active
+
+    expected_roll = np.zeros([14, 3])
+    expected_roll[2:3, 0] = 1.
+    expected_roll[12:13, 1] = 1.
+    expected_roll[7:9, 2] = 1.
+
+    np.testing.assert_equal(expected_roll, active)
+
+  def testSequenceToPianorollOnsetVelocities(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+    sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+    sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+    sequence.total_time = 2.0
+
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence, 1, 60, 62, max_velocity=64, onset_window=0)
+    onset_velocities = roll.onset_velocities
+
+    self.assertEqual(onset_velocities[0, 0], 0.25)
+    self.assertEqual(onset_velocities[0, 1], 0.5)
+    self.assertEqual(onset_velocities[0, 2], 1.)
+    self.assertEqual(np.all(onset_velocities[1:] == 0), True)
+
+  def testSequenceToPianorollActiveVelocities(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+    sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+    sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+    sequence.total_time = 2.0
+
+    roll = sequences_lib.sequence_to_pianoroll(
+        sequence, 1, 60, 62, max_velocity=64)
+    active_velocities = roll.active_velocities
+
+    self.assertEqual(np.all(active_velocities[0:2, 0] == 0.25), True)
+    self.assertEqual(np.all(active_velocities[0:2, 1] == 0.5), True)
+    self.assertEqual(np.all(active_velocities[0:2, 2] == 1.), True)
+    self.assertEqual(np.all(active_velocities[2:] == 0), True)
+
+  def testPianorollToNoteSequence(self):
+    # 100 frames of notes.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames.
+    frames[25:75, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+    self.assertLen(sequence.notes, 1)
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+  def testPianorollToNoteSequenceAllNotes(self):
+    # Test all 128 notes
+    frames = np.eye(MIDI_PITCHES, dtype=np.bool)  # diagonal identity matrix
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+    self.assertLen(sequence.notes, MIDI_PITCHES)
+    for i in range(MIDI_PITCHES):
+      self.assertEqual(i, sequence.notes[i].pitch)
+      self.assertAlmostEqual(i / DEFAULT_FRAMES_PER_SECOND,
+                             sequence.notes[i].start_time)
+      self.assertAlmostEqual((i+1) / DEFAULT_FRAMES_PER_SECOND,
+                             sequence.notes[i].end_time)
+
+  def testPianorollToNoteSequenceWithOnsets(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    # Add an onset for the first occurrence.
+    onsets[25, 39] = True
+    # Add an onset for a note that doesn&#39;t have an active frame.
+    onsets[80, 49] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+    self.assertEqual(49, sequence.notes[1].pitch)
+    self.assertEqual(80 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[1].start_time)
+    self.assertEqual(81 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)
+
+  def testPianorollToNoteSequenceWithOnsetsAndVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    # Add an onset for the first occurrence with a valid velocity.
+    onsets[25, 39] = True
+    velocity_values[25, 39] = 0.5
+    # Add an onset for the second occurrence with a NaN velocity.
+    onsets[90, 39] = True
+    velocity_values[90, 39] = float(&#39;nan&#39;)
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity_values=velocity_values)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(50, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(0, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    onsets[25, 39] = True
+    velocity_values[25, 39] = 0.5
+    onsets[90, 39] = True
+    velocity_values[90, 39] = 1.0
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity_values=velocity_values,
+        velocity_scale=127,
+        velocity_bias=0)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(63, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(127, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsDefaultVelocity(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames and last 10 frames.
+    frames[25:75, 39] = True
+    frames[90:100, 39] = True
+    onsets[25, 39] = True
+    onsets[90, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets,
+        velocity=100)
+    self.assertLen(sequence.notes, 2)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(100, sequence.notes[0].velocity)
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(100, sequence.notes[1].velocity)
+
+  def testPianorollToNoteSequenceWithOnsetsOverlappingFrames(self):
+    # 100 frames of notes and onsets.
+    frames = np.zeros((100, MIDI_PITCHES), np.bool)
+    onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+    # Activate key 39 for the middle 50 frames.
+    frames[25:75, 39] = True
+    # Add multiple onsets within those frames.
+    onsets[25, 39] = True
+    onsets[30, 39] = True
+    # If an onset lasts for multiple frames, it should create only 1 note.
+    onsets[35, 39] = True
+    onsets[36, 39] = True
+    sequence = sequences_lib.pianoroll_to_note_sequence(
+        frames,
+        frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+        min_duration_ms=0,
+        onset_predictions=onsets)
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(39, sequence.notes[0].pitch)
+    self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[0].start_time)
+    self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+    self.assertEqual(39, sequence.notes[1].pitch)
+    self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[1].start_time)
+    self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)
+
+    self.assertEqual(39, sequence.notes[2].pitch)
+    self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND,
+                     sequence.notes[2].start_time)
+    self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[2].end_time)
+
+  def testPianorollOnsetsToNoteSequence(self):
+    onsets = np.zeros((10, 2), np.bool)
+    velocity_values = np.zeros_like(onsets, np.float32)
+    onsets[0:2, 0] = True
+    velocity_values[0:2, 0] = .5
+    onsets[1:2, 1] = True
+    velocity_values[1:2, 1] = 1
+    sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+        onsets, frames_per_second=10, note_duration_seconds=0.05,
+        min_midi_pitch=60, velocity_values=velocity_values)
+
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(60, sequence.notes[0].pitch)
+    self.assertEqual(0, sequence.notes[0].start_time)
+    self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+    self.assertEqual(50, sequence.notes[0].velocity)
+
+    self.assertEqual(60, sequence.notes[1].pitch)
+    self.assertEqual(0.1, sequence.notes[1].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+    self.assertEqual(50, sequence.notes[1].velocity)
+
+    self.assertEqual(61, sequence.notes[2].pitch)
+    self.assertEqual(0.1, sequence.notes[2].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+    self.assertEqual(90, sequence.notes[2].velocity)
+
+  def testPianorollOnsetsToNoteSequenceFullVelocityScale(self):
+    onsets = np.zeros((10, 2), np.bool)
+    velocity_values = np.zeros_like(onsets, np.float32)
+    onsets[0:2, 0] = True
+    velocity_values[0:2, 0] = .5
+    onsets[1:2, 1] = True
+    velocity_values[1:2, 1] = 1
+    sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+        onsets, frames_per_second=10, note_duration_seconds=0.05,
+        min_midi_pitch=60, velocity_values=velocity_values,
+        velocity_scale=127, velocity_bias=0)
+
+    self.assertLen(sequence.notes, 3)
+
+    self.assertEqual(60, sequence.notes[0].pitch)
+    self.assertEqual(0, sequence.notes[0].start_time)
+    self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+    self.assertEqual(63, sequence.notes[0].velocity)
+
+    self.assertEqual(60, sequence.notes[1].pitch)
+    self.assertEqual(0.1, sequence.notes[1].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+    self.assertEqual(63, sequence.notes[1].velocity)
+
+    self.assertEqual(61, sequence.notes[2].pitch)
+    self.assertEqual(0.1, sequence.notes[2].start_time)
+    self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+    self.assertEqual(127, sequence.notes[2].velocity)
+
+  def testSequenceToPianorollControlChanges(self):
+    sequence = music_pb2.NoteSequence(total_time=2.0)
+    cc = music_pb2.NoteSequence.ControlChange
+    sequence.control_changes.extend([
+        cc(time=0.7, control_number=3, control_value=16),
+        cc(time=0.0, control_number=4, control_value=32),
+        cc(time=0.5, control_number=4, control_value=32),
+        cc(time=1.6, control_number=3, control_value=64),
+    ])
+
+    expected_cc_roll = np.zeros((5, 128), dtype=np.int32)
+    expected_cc_roll[0:2, 4] = 33
+    expected_cc_roll[1, 3] = 17
+    expected_cc_roll[3, 3] = 65
+
+    cc_roll = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=2, min_pitch=1, max_pitch=4).control_changes
+
+    np.testing.assert_allclose(expected_cc_roll, cc_roll)
+
+  def testSequenceToPianorollOverlappingNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+    sequence.notes.add(pitch=60, start_time=1.2, end_time=2.0)
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=2.5)
+    sequence.total_time = 2.5
+
+    rolls = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+        onset_mode=&#39;length_ms&#39;, onset_length_ms=10)
+
+    expected_onsets = np.zeros([26, 1])
+    expected_onsets[10, 0] = 1
+    expected_onsets[12, 0] = 1
+    np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+    expected_offsets = np.zeros([26, 1])
+    expected_offsets[20, 0] = 1
+    expected_offsets[25, 0] = 1
+    np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+    expected_active = np.zeros([26, 1])
+    expected_active[10:25, 0] = 1
+    np.testing.assert_equal(expected_active, rolls.active)
+
+  def testSequenceToPianorollShortNotes(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=60, start_time=1.0, end_time=1.0001)
+    sequence.notes.add(pitch=60, start_time=1.2, end_time=1.2001)
+    sequence.total_time = 2.5
+
+    rolls = sequences_lib.sequence_to_pianoroll(
+        sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+        onset_mode=&#39;length_ms&#39;, onset_length_ms=0)
+
+    expected_onsets = np.zeros([26, 1])
+    expected_onsets[10, 0] = 1
+    expected_onsets[12, 0] = 1
+    np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+    expected_offsets = np.zeros([26, 1])
+    expected_offsets[10, 0] = 1
+    expected_offsets[12, 0] = 1
+    np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+    expected_active = np.zeros([26, 1])
+    expected_active[10:11, 0] = 1
+    expected_active[12:13, 0] = 1
+    np.testing.assert_equal(expected_active, rolls.active)
+
+  def testSequenceToValuedIntervals(self):
+    sequence = music_pb2.NoteSequence()
+    sequence.notes.add(pitch=69, start_time=1.0, end_time=2.0, velocity=80)
+    # Should be dropped because it is 0 duration.
+    sequence.notes.add(pitch=60, start_time=3.0, end_time=3.0, velocity=90)
+
+    intervals, pitches, velocities = sequences_lib.sequence_to_valued_intervals(
+        sequence)
+    np.testing.assert_array_equal([[1., 2.]], intervals)
+    np.testing.assert_array_equal([440.0], pitches)
+    np.testing.assert_array_equal([80], velocities)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></li>
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimes"><code class="name flex">
+<span>def <span class="ident">testAdjustNoteSequenceTimes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAdjustNoteSequenceTimes(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+  sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+  sequence.control_changes.add(control_number=1, time=2.0)
+  sequence.pitch_bends.add(bend=5, time=2.0)
+  sequence.total_time = 7.0
+
+  adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+      sequence, lambda t: t - 1)
+
+  expected_sequence = music_pb2.NoteSequence()
+  expected_sequence.notes.add(pitch=60, start_time=0.0, end_time=4.0)
+  expected_sequence.notes.add(pitch=61, start_time=5.0, end_time=6.0)
+  expected_sequence.control_changes.add(control_number=1, time=1.0)
+  expected_sequence.pitch_bends.add(bend=5, time=1.0)
+  expected_sequence.total_time = 6.0
+
+  self.assertEqual(expected_sequence, adjusted_ns)
+  self.assertEqual(0, skipped_notes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesEndBeforeStart"><code class="name flex">
+<span>def <span class="ident">testAdjustNoteSequenceTimesEndBeforeStart</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAdjustNoteSequenceTimesEndBeforeStart(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+  sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+  sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+  sequence.total_time = 8.0
+
+  def time_func(time):
+    if time % 2 == 0:
+      return time - 2
+    else:
+      return time
+
+  with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+    sequences_lib.adjust_notesequence_times(sequence, time_func)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithNotesBeforeTimeZero"><code class="name flex">
+<span>def <span class="ident">testAdjustNoteSequenceTimesWithNotesBeforeTimeZero</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAdjustNoteSequenceTimesWithNotesBeforeTimeZero(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+  sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+  sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+  sequence.total_time = 8.0
+
+  def time_func(time):
+    return time - 5
+
+  with self.assertRaises(sequences_lib.InvalidTimeAdjustmentError):
+    sequences_lib.adjust_notesequence_times(sequence, time_func)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithSkippedNotes"><code class="name flex">
+<span>def <span class="ident">testAdjustNoteSequenceTimesWithSkippedNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAdjustNoteSequenceTimesWithSkippedNotes(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+  sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+  sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+  sequence.total_time = 8.0
+
+  def time_func(time):
+    if time &gt; 5:
+      return 5
+    else:
+      return time
+
+  adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+      sequence, time_func)
+
+  expected_sequence = music_pb2.NoteSequence()
+  expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=5.0)
+  expected_sequence.total_time = 5.0
+
+  self.assertEqual(expected_sequence, adjusted_ns)
+  self.assertEqual(2, skipped_notes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithZeroDurations"><code class="name flex">
+<span>def <span class="ident">testAdjustNoteSequenceTimesWithZeroDurations</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAdjustNoteSequenceTimesWithZeroDurations(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+  sequence.notes.add(pitch=61, start_time=3.0, end_time=4.0)
+  sequence.notes.add(pitch=62, start_time=5.0, end_time=6.0)
+  sequence.total_time = 8.0
+
+  def time_func(time):
+    if time % 2 == 0:
+      return time - 1
+    else:
+      return time
+
+  adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+      sequence, time_func)
+
+  expected_sequence = music_pb2.NoteSequence()
+
+  self.assertEqual(expected_sequence, adjusted_ns)
+  self.assertEqual(3, skipped_notes)
+
+  adjusted_ns, skipped_notes = sequences_lib.adjust_notesequence_times(
+      sequence, time_func, minimum_duration=.1)
+
+  expected_sequence = music_pb2.NoteSequence()
+  expected_sequence.notes.add(pitch=60, start_time=1.0, end_time=1.1)
+  expected_sequence.notes.add(pitch=61, start_time=3.0, end_time=3.1)
+  expected_sequence.notes.add(pitch=62, start_time=5.0, end_time=5.1)
+  expected_sequence.total_time = 5.1
+
+  self.assertEqual(expected_sequence, adjusted_ns)
+  self.assertEqual(0, skipped_notes)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChanges"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify sustain controls extend notes until the end of the control.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChanges(self):
+  &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0),
+       (3.75, 64, 127), (4.5, 64, 127), (4.8, 64, 0), (4.9, 64, 127),
+       (6.0, 64, 0)])
+  testing_lib.add_track_to_sequence(
+      sequence, 1,
+      [(12, 100, 0.01, 10.0), (52, 99, 4.75, 5.0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.8)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtendNotesToEnd"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesExtendNotesToEnd</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test sustain control extending the duration of the final note.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesExtendNotesToEnd(self):
+  &#34;&#34;&#34;Test sustain control extending the duration of the final note.&#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0, [(1.0, 64, 127), (4.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.50, 4.00), (72, 100, 2.0, 4.0)])
+  expected_sequence.total_time = 4.0
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtraneousSustain"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesExtraneousSustain</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test applying extraneous sustain control at the end of the sequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesExtraneousSustain(self):
+  &#34;&#34;&#34;Test applying extraneous sustain control at the end of the sequence.&#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0, [(4.0, 64, 127), (5.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.50, 1.50), (72, 100, 2.0, 3.0)])
+  # The total_time field only takes *notes* into account, and should not be
+  # affected by a sustain-on event beyond the last note.
+  expected_sequence.total_time = 3.0
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesProcessSustainBeforeNotes"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesProcessSustainBeforeNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify sustain controls extend notes until the end of the control.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesProcessSustainBeforeNotes(self):
+  &#34;&#34;&#34;Verify sustain controls extend notes until the end of the control.&#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 64, 127), (0.75, 64, 0), (2.0, 64, 127), (3.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(11, 55, 0.22, 0.75), (40, 45, 2.50, 3.50)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesSimultaneousOnOff"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesSimultaneousOnOff</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Test sustain on and off events happening at the same time.</p>
+<p>The off event should be processed last, so this should be a no-op.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesSimultaneousOnOff(self):
+  &#34;&#34;&#34;Test sustain on and off events happening at the same time.
+
+  The off event should be processed last, so this should be a no-op.
+  &#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0, [(1.0, 64, 127), (1.0, 64, 0)])
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.50, 1.50), (60, 100, 2.0, 3.0)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithDrumNotes"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesWithDrumNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Drum notes should not be modified when applying sustain changes.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesWithDrumNotes(self):
+  &#34;&#34;&#34;Drum notes should not be modified when applying sustain changes.&#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(1.0, 64, 127), (4.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 2.00, 2.50)])
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(38, 100, 2.00, 2.50)], is_drum=True)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 2.00, 4.00)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(38, 100, 2.0, 2.5)], is_drum=True)
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithIdenticalNotes"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesWithIdenticalNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>In the case of identical notes, one should be dropped.</p>
+<p>This is an edge case because in most cases, the same pitch should not sound
+twice at the same time on one instrument.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesWithIdenticalNotes(self):
+  &#34;&#34;&#34;In the case of identical notes, one should be dropped.
+
+  This is an edge case because in most cases, the same pitch should not sound
+  twice at the same time on one instrument.
+  &#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(1.0, 64, 127), (4.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 2.00, 2.50), (60, 100, 2.00, 2.50)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 2.00, 4.00)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotes"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesWithRepeatedNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Verify that sustain control handles repeated notes correctly.</p>
+<p>For example, a single pitch played before sustain:
+x&ndash; x&ndash; x&ndash;
+After sustain:
+x&mdash;x&mdash;x&ndash;</p>
+<p>Notes should be extended until either the end of the sustain control or the
+beginning of another note of the same pitch.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesWithRepeatedNotes(self):
+  &#34;&#34;&#34;Verify that sustain control handles repeated notes correctly.
+
+  For example, a single pitch played before sustain:
+  x-- x-- x--
+  After sustain:
+  x---x---x--
+
+  Notes should be extended until either the end of the sustain control or the
+  beginning of another note of the same pitch.
+  &#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(1.0, 64, 127), (4.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.25, 1.50), (60, 100, 1.25, 1.50), (72, 100, 2.00, 3.50),
+       (60, 100, 2.0, 3.00), (60, 100, 3.50, 4.50)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.25, 1.25), (60, 100, 1.25, 2.00), (72, 100, 2.00, 4.00),
+       (60, 100, 2.0, 3.50), (60, 100, 3.50, 4.50)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotesBeforeSustain"><code class="name flex">
+<span>def <span class="ident">testApplySustainControlChangesWithRepeatedNotesBeforeSustain</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Repeated notes before sustain can overlap and should not be modified.</p>
+<p>Once a repeat happens within the sustain, any active notes should end
+before the next one starts.</p>
+<p>This is kind of an edge case because a note overlapping a note of the same
+pitch may not make sense, but apply_sustain_control_changes tries not to
+modify events that happen outside of a sustain.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testApplySustainControlChangesWithRepeatedNotesBeforeSustain(self):
+  &#34;&#34;&#34;Repeated notes before sustain can overlap and should not be modified.
+
+  Once a repeat happens within the sustain, any active notes should end
+  before the next one starts.
+
+  This is kind of an edge case because a note overlapping a note of the same
+  pitch may not make sense, but apply_sustain_control_changes tries not to
+  modify events that happen outside of a sustain.
+  &#34;&#34;&#34;
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(1.0, 64, 127), (4.0, 64, 0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.25, 1.50), (60, 100, .50, 1.50), (60, 100, 1.25, 2.0)])
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.25, 1.25), (60, 100, 0.50, 1.25), (60, 100, 1.25, 4.00)])
+
+  sus_sequence = sequences_lib.apply_sustain_control_changes(sequence)
+  self.assertProtoEquals(expected_sequence, sus_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAssertIsQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testAssertIsQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAssertIsQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+  relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+  absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=4)
+
+  sequences_lib.assert_is_quantized_sequence(relative_quantized_sequence)
+  sequences_lib.assert_is_quantized_sequence(absolute_quantized_sequence)
+  with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+    sequences_lib.assert_is_quantized_sequence(self.note_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAssertIsRelativeQuantizedNoteSequence"><code class="name flex">
+<span>def <span class="ident">testAssertIsRelativeQuantizedNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAssertIsRelativeQuantizedNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+  relative_quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+  absolute_quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=4)
+
+  sequences_lib.assert_is_relative_quantized_sequence(
+      relative_quantized_sequence)
+  with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+    sequences_lib.assert_is_relative_quantized_sequence(
+        absolute_quantized_sequence)
+  with self.assertRaises(sequences_lib.QuantizationStatusError):  # pylint:disable=g-error-prone-assert-raises
+    sequences_lib.assert_is_relative_quantized_sequence(self.note_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteFalse"><code class="name flex">
+<span>def <span class="ident">testAugmentNoteSequenceDeleteFalse</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAugmentNoteSequenceDeleteFalse(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                    (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                    (52, 99, 4.75, 5.0)])
+
+  augmented_sequence = sequences_lib.augment_note_sequence(
+      sequence,
+      min_stretch_factor=2,
+      max_stretch_factor=2,
+      min_transpose=-15,
+      max_transpose=-10,
+      min_allowed_pitch=10,
+      max_allowed_pitch=127,
+      delete_out_of_range_notes=False)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [(10, 100, 0.02, 20.0), (11, 55, 0.44, 1.0),
+                             (38, 45, 5., 7.), (53, 120, 8.0, 8.02),
+                             (50, 99, 9.5, 10.0)])
+  expected_sequence.tempos[0].qpm = 30.
+
+  self.assertProtoEquals(augmented_sequence, expected_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteTrue"><code class="name flex">
+<span>def <span class="ident">testAugmentNoteSequenceDeleteTrue</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAugmentNoteSequenceDeleteTrue(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                    (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                    (52, 99, 4.75, 5.0)])
+
+  augmented_sequence = sequences_lib.augment_note_sequence(
+      sequence,
+      min_stretch_factor=2,
+      max_stretch_factor=2,
+      min_transpose=-15,
+      max_transpose=-15,
+      min_allowed_pitch=10,
+      max_allowed_pitch=127,
+      delete_out_of_range_notes=True)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [(25, 45, 5., 7.), (40, 120, 8.0, 8.02),
+                             (37, 99, 9.5, 10.0)])
+  expected_sequence.tempos[0].qpm = 30.
+
+  self.assertProtoEquals(augmented_sequence, expected_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoStretch"><code class="name flex">
+<span>def <span class="ident">testAugmentNoteSequenceNoStretch</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAugmentNoteSequenceNoStretch(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                    (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                    (52, 99, 4.75, 5.0)])
+
+  augmented_sequence = sequences_lib.augment_note_sequence(
+      sequence,
+      min_stretch_factor=1,
+      max_stretch_factor=1.,
+      min_transpose=-15,
+      max_transpose=-15,
+      min_allowed_pitch=10,
+      max_allowed_pitch=127,
+      delete_out_of_range_notes=True)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [(25, 45, 2.5, 3.50), (40, 120, 4.0, 4.01),
+                             (37, 99, 4.75, 5.0)])
+
+  self.assertProtoEquals(augmented_sequence, expected_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoTranspose"><code class="name flex">
+<span>def <span class="ident">testAugmentNoteSequenceNoTranspose</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testAugmentNoteSequenceNoTranspose(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(12, 100, 0.01, 10.0), (13, 55, 0.22, 0.50),
+                    (40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01),
+                    (52, 99, 4.75, 5.0)])
+
+  augmented_sequence = sequences_lib.augment_note_sequence(
+      sequence,
+      min_stretch_factor=2,
+      max_stretch_factor=2.,
+      min_transpose=0,
+      max_transpose=0,
+      min_allowed_pitch=10,
+      max_allowed_pitch=127,
+      delete_out_of_range_notes=True)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0, [(12, 100, 0.02, 20.0), (13, 55, 0.44, 1.0),
+                             (40, 45, 5., 7.), (55, 120, 8.0, 8.02),
+                             (52, 99, 9.5, 10.0)])
+  expected_sequence.tempos[0].qpm = 30.
+
+  self.assertProtoEquals(augmented_sequence, expected_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testClampTranspose"><code class="name flex">
+<span>def <span class="ident">testClampTranspose</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testClampTranspose(self):
+  clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+      5, 20, 60, 10, 70)
+  self.assertEqual(clamped, 5)
+
+  clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+      15, 20, 60, 10, 65)
+  self.assertEqual(clamped, 5)
+
+  clamped = sequences_lib._clamp_transpose(  # pylint:disable=protected-access
+      -16, 20, 60, 10, 70)
+  self.assertEqual(clamped, -10)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequences"><code class="name flex">
+<span>def <span class="ident">testConcatenateSequences</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testConcatenateSequences(self):
+  sequence1 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence1, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+  sequence2 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence2, 0,
+      [(59, 100, 0.0, 1.0), (71, 100, 0.5, 1.5)])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+       (59, 100, 1.5, 2.5), (71, 100, 2.0, 3.0)])
+
+  cat_seq = sequences_lib.concatenate_sequences([sequence1, sequence2])
+  self.assertProtoEquals(expected_sequence, cat_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequencesWithSpecifiedDurations"><code class="name flex">
+<span>def <span class="ident">testConcatenateSequencesWithSpecifiedDurations</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testConcatenateSequencesWithSpecifiedDurations(self):
+  sequence1 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence1, 0, [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+  sequence2 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence2, 0,
+      [(59, 100, 0.0, 1.0)])
+  sequence3 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence3, 0,
+      [(72, 100, 0.0, 1.0), (73, 100, 0.5, 1.5)])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+       (59, 100, 2.0, 3.0),
+       (72, 100, 3.5, 4.5), (73, 100, 4.0, 5.0)])
+
+  cat_seq = sequences_lib.concatenate_sequences(
+      [sequence1, sequence2, sequence3],
+      sequence_durations=[2, 1.5, 2])
+  self.assertProtoEquals(expected_sequence, cat_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testExpandSectionGroups"><code class="name flex">
+<span>def <span class="ident">testExpandSectionGroups</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExpandSectionGroups(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+       (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+  sequence.section_annotations.add(time=0, section_id=0)
+  sequence.section_annotations.add(time=1, section_id=1)
+  sequence.section_annotations.add(time=2, section_id=2)
+  sequence.section_annotations.add(time=3, section_id=3)
+
+  # A((BC)2D)2
+  sg = sequence.section_groups.add()
+  sg.sections.add(section_id=0)
+  sg.num_times = 1
+  sg = sequence.section_groups.add()
+  sg.sections.add(section_group=music_pb2.NoteSequence.SectionGroup(
+      sections=[music_pb2.NoteSequence.Section(section_id=1),
+                music_pb2.NoteSequence.Section(section_id=2)],
+      num_times=2))
+  sg.sections.add(section_id=3)
+  sg.num_times = 2
+
+  expanded = sequences_lib.expand_section_groups(sequence)
+
+  expected = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected, 0,
+      [(60, 100, 0.0, 1.0),
+       (72, 100, 1.0, 2.0),
+       (59, 100, 2.0, 3.0),
+       (72, 100, 3.0, 4.0),
+       (59, 100, 4.0, 5.0),
+       (71, 100, 5.0, 6.0),
+       (72, 100, 6.0, 7.0),
+       (59, 100, 7.0, 8.0),
+       (72, 100, 8.0, 9.0),
+       (59, 100, 9.0, 10.0),
+       (71, 100, 10.0, 11.0)])
+  expected.section_annotations.add(time=0, section_id=0)
+  expected.section_annotations.add(time=1, section_id=1)
+  expected.section_annotations.add(time=2, section_id=2)
+  expected.section_annotations.add(time=3, section_id=1)
+  expected.section_annotations.add(time=4, section_id=2)
+  expected.section_annotations.add(time=5, section_id=3)
+  expected.section_annotations.add(time=6, section_id=1)
+  expected.section_annotations.add(time=7, section_id=2)
+  expected.section_annotations.add(time=8, section_id=1)
+  expected.section_annotations.add(time=9, section_id=2)
+  expected.section_annotations.add(time=10, section_id=3)
+  self.assertProtoEquals(expected, expanded)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testExpandWithoutSectionGroups"><code class="name flex">
+<span>def <span class="ident">testExpandWithoutSectionGroups</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExpandWithoutSectionGroups(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 1.0, 2.0),
+       (59, 100, 2.0, 3.0), (71, 100, 3.0, 4.0)])
+  sequence.section_annotations.add(time=0, section_id=0)
+  sequence.section_annotations.add(time=1, section_id=1)
+  sequence.section_annotations.add(time=2, section_id=2)
+  sequence.section_annotations.add(time=3, section_id=3)
+
+  expanded = sequences_lib.expand_section_groups(sequence)
+
+  self.assertEqual(sequence, expanded)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequence"><code class="name flex">
+<span>def <span class="ident">testExtractSubsequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtractSubsequence(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 1, [(2.0, 64, 127)])
+  expected_subsequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence, 0,
+      [(40, 45, 0.0, 1.0), (55, 120, 1.5, 1.51)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 0.5)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 1, [(0.0, 64, 127)])
+  expected_subsequence.total_time = 1.51
+  expected_subsequence.subsequence_info.start_time_offset = 2.5
+  expected_subsequence.subsequence_info.end_time_offset = 5.99
+
+  subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+  subsequence.control_changes.sort(
+      key=lambda cc: (cc.instrument, cc.time))
+  self.assertProtoEquals(expected_subsequence, subsequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePastEnd"><code class="name flex">
+<span>def <span class="ident">testExtractSubsequencePastEnd</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtractSubsequencePastEnd(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 18.0)])
+
+  with self.assertRaises(ValueError):
+    sequences_lib.extract_subsequence(sequence, 15.0, 16.0)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePedalEvents"><code class="name flex">
+<span>def <span class="ident">testExtractSubsequencePedalEvents</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testExtractSubsequencePedalEvents(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0, [(60, 80, 2.5, 5.0)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 1, [(2.0, 64, 127)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 66, 0), (2.0, 66, 127), (4.0, 66, 0), (5.0, 66, 127)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 67, 10), (2.0, 67, 20), (4.0, 67, 30), (5.0, 67, 40)])
+  expected_subsequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence, 0, [(60, 80, 0, 2.25)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 0, [(0.0, 64, 0), (1.5, 64, 127)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 1, [(0.0, 64, 127)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 0, [(0.0, 66, 127), (1.5, 66, 0)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_subsequence, 0, [(0.0, 67, 20), (1.5, 67, 30)])
+  expected_subsequence.control_changes.sort(
+      key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+  expected_subsequence.total_time = 2.25
+  expected_subsequence.subsequence_info.start_time_offset = 2.5
+  expected_subsequence.subsequence_info.end_time_offset = .25
+
+  subsequence = sequences_lib.extract_subsequence(sequence, 2.5, 4.75)
+  subsequence.control_changes.sort(
+      key=lambda cc: (cc.instrument, cc.control_number, cc.time))
+  self.assertProtoEquals(expected_subsequence, subsequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_ImplicitTempoChange"><code class="name flex">
+<span>def <span class="ident">testFromNoteSequence_ImplicitTempoChange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNoteSequence_ImplicitTempoChange(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.tempos[:]
+
+  # No tempo.
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Implicit tempo change.
+  self.note_sequence.tempos.add(qpm=60, time=2)
+  with self.assertRaises(sequences_lib.MultipleTempoError):
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_NoImplicitTempoChangeOutOfOrder"><code class="name flex">
+<span>def <span class="ident">testFromNoteSequence_NoImplicitTempoChangeOutOfOrder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNoteSequence_NoImplicitTempoChangeOutOfOrder(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.tempos[:]
+
+  # No tempo.
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # No implicit tempo change, but tempos are added out of order.
+  self.note_sequence.tempos.add(qpm=60, time=2)
+  self.note_sequence.tempos.add(qpm=60, time=0)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_TempoChange"><code class="name flex">
+<span>def <span class="ident">testFromNoteSequence_TempoChange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testFromNoteSequence_TempoChange(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.tempos[:]
+
+  # No tempos.
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Single tempo.
+  self.note_sequence.tempos.add(qpm=60, time=0)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Multiple tempos with no change.
+  self.note_sequence.tempos.add(qpm=60, time=1)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Tempo change.
+  self.note_sequence.tempos.add(qpm=120, time=2)
+  with self.assertRaises(sequences_lib.MultipleTempoError):
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testInferDenseChordsForSequence"><code class="name flex">
+<span>def <span class="ident">testInferDenseChordsForSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testInferDenseChordsForSequence(self):
+  # Test non-quantized sequence.
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 1.0, 3.0), (64, 100, 1.0, 2.0), (67, 100, 1.0, 2.0),
+       (65, 100, 2.0, 3.0), (69, 100, 2.0, 3.0),
+       (62, 100, 3.0, 5.0), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.0)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_chords_to_sequence(
+      expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+  sequences_lib.infer_dense_chords_for_sequence(sequence)
+  self.assertProtoEquals(expected_sequence, sequence)
+
+  # Test quantized sequence.
+  sequence = copy.copy(self.note_sequence)
+  sequence.quantization_info.steps_per_quarter = 1
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 1.1, 3.0), (64, 100, 1.0, 1.9), (67, 100, 1.0, 2.0),
+       (65, 100, 2.0, 3.2), (69, 100, 2.1, 3.1),
+       (62, 100, 2.9, 4.8), (65, 100, 3.0, 4.0), (69, 100, 3.0, 4.1)])
+  testing_lib.add_quantized_steps_to_sequence(
+      sequence,
+      [(1, 3), (1, 2), (1, 2), (2, 3), (2, 3), (3, 5), (3, 4), (3, 4)])
+  expected_sequence = copy.copy(sequence)
+  testing_lib.add_chords_to_sequence(
+      expected_sequence, [(&#39;C&#39;, 1.0), (&#39;F/C&#39;, 2.0), (&#39;Dm&#39;, 3.0)])
+  testing_lib.add_quantized_chord_steps_to_sequence(
+      expected_sequence, [1, 2, 3])
+  sequences_lib.infer_dense_chords_for_sequence(sequence)
+  self.assertProtoEquals(expected_sequence, sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testMultiTrack"><code class="name flex">
+<span>def <span class="ident">testMultiTrack</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testMultiTrack(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 1.0, 4.0), (19, 100, 0.95, 3.0)])
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 3,
+      [(12, 100, 1.0, 4.0), (19, 100, 2.0, 5.0)])
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 7,
+      [(12, 100, 1.0, 5.0), (19, 100, 2.0, 4.0), (24, 100, 3.0, 3.5)])
+
+  expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+  expected_quantized_sequence.quantization_info.steps_per_quarter = (
+      self.steps_per_quarter)
+  testing_lib.add_quantized_steps_to_sequence(
+      expected_quantized_sequence,
+      [(4, 16), (4, 12), (4, 16), (8, 20), (4, 20), (8, 16), (12, 14)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequence"><code class="name flex">
+<span>def <span class="ident">testPianorollOnsetsToNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollOnsetsToNoteSequence(self):
+  onsets = np.zeros((10, 2), np.bool)
+  velocity_values = np.zeros_like(onsets, np.float32)
+  onsets[0:2, 0] = True
+  velocity_values[0:2, 0] = .5
+  onsets[1:2, 1] = True
+  velocity_values[1:2, 1] = 1
+  sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+      onsets, frames_per_second=10, note_duration_seconds=0.05,
+      min_midi_pitch=60, velocity_values=velocity_values)
+
+  self.assertLen(sequence.notes, 3)
+
+  self.assertEqual(60, sequence.notes[0].pitch)
+  self.assertEqual(0, sequence.notes[0].start_time)
+  self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+  self.assertEqual(50, sequence.notes[0].velocity)
+
+  self.assertEqual(60, sequence.notes[1].pitch)
+  self.assertEqual(0.1, sequence.notes[1].start_time)
+  self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+  self.assertEqual(50, sequence.notes[1].velocity)
+
+  self.assertEqual(61, sequence.notes[2].pitch)
+  self.assertEqual(0.1, sequence.notes[2].start_time)
+  self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+  self.assertEqual(90, sequence.notes[2].velocity)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequenceFullVelocityScale"><code class="name flex">
+<span>def <span class="ident">testPianorollOnsetsToNoteSequenceFullVelocityScale</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollOnsetsToNoteSequenceFullVelocityScale(self):
+  onsets = np.zeros((10, 2), np.bool)
+  velocity_values = np.zeros_like(onsets, np.float32)
+  onsets[0:2, 0] = True
+  velocity_values[0:2, 0] = .5
+  onsets[1:2, 1] = True
+  velocity_values[1:2, 1] = 1
+  sequence = sequences_lib.pianoroll_onsets_to_note_sequence(
+      onsets, frames_per_second=10, note_duration_seconds=0.05,
+      min_midi_pitch=60, velocity_values=velocity_values,
+      velocity_scale=127, velocity_bias=0)
+
+  self.assertLen(sequence.notes, 3)
+
+  self.assertEqual(60, sequence.notes[0].pitch)
+  self.assertEqual(0, sequence.notes[0].start_time)
+  self.assertAlmostEqual(0.05, sequence.notes[0].end_time)
+  self.assertEqual(63, sequence.notes[0].velocity)
+
+  self.assertEqual(60, sequence.notes[1].pitch)
+  self.assertEqual(0.1, sequence.notes[1].start_time)
+  self.assertAlmostEqual(0.15, sequence.notes[1].end_time)
+  self.assertEqual(63, sequence.notes[1].velocity)
+
+  self.assertEqual(61, sequence.notes[2].pitch)
+  self.assertEqual(0.1, sequence.notes[2].start_time)
+  self.assertAlmostEqual(0.15, sequence.notes[2].end_time)
+  self.assertEqual(127, sequence.notes[2].velocity)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequence"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequence(self):
+  # 100 frames of notes.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  # Activate key 39 for the middle 50 frames.
+  frames[25:75, 39] = True
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+  self.assertLen(sequence.notes, 1)
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[0].start_time)
+  self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceAllNotes"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceAllNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceAllNotes(self):
+  # Test all 128 notes
+  frames = np.eye(MIDI_PITCHES, dtype=np.bool)  # diagonal identity matrix
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames, frames_per_second=DEFAULT_FRAMES_PER_SECOND, min_duration_ms=0)
+
+  self.assertLen(sequence.notes, MIDI_PITCHES)
+  for i in range(MIDI_PITCHES):
+    self.assertEqual(i, sequence.notes[i].pitch)
+    self.assertAlmostEqual(i / DEFAULT_FRAMES_PER_SECOND,
+                           sequence.notes[i].start_time)
+    self.assertAlmostEqual((i+1) / DEFAULT_FRAMES_PER_SECOND,
+                           sequence.notes[i].end_time)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsets"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceWithOnsets</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceWithOnsets(self):
+  # 100 frames of notes and onsets.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+  # Activate key 39 for the middle 50 frames and last 10 frames.
+  frames[25:75, 39] = True
+  frames[90:100, 39] = True
+  # Add an onset for the first occurrence.
+  onsets[25, 39] = True
+  # Add an onset for a note that doesn&#39;t have an active frame.
+  onsets[80, 49] = True
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames,
+      frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+      min_duration_ms=0,
+      onset_predictions=onsets)
+  self.assertLen(sequence.notes, 2)
+
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[0].start_time)
+  self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+  self.assertEqual(49, sequence.notes[1].pitch)
+  self.assertEqual(80 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[1].start_time)
+  self.assertEqual(81 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity(self):
+  # 100 frames of notes and onsets.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+  velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+  # Activate key 39 for the middle 50 frames and last 10 frames.
+  frames[25:75, 39] = True
+  frames[90:100, 39] = True
+  onsets[25, 39] = True
+  velocity_values[25, 39] = 0.5
+  onsets[90, 39] = True
+  velocity_values[90, 39] = 1.0
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames,
+      frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+      min_duration_ms=0,
+      onset_predictions=onsets,
+      velocity_values=velocity_values,
+      velocity_scale=127,
+      velocity_bias=0)
+  self.assertLen(sequence.notes, 2)
+
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(63, sequence.notes[0].velocity)
+  self.assertEqual(39, sequence.notes[1].pitch)
+  self.assertEqual(127, sequence.notes[1].velocity)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndVelocity"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceWithOnsetsAndVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceWithOnsetsAndVelocity(self):
+  # 100 frames of notes and onsets.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+  velocity_values = np.zeros((100, MIDI_PITCHES), np.float32)
+  # Activate key 39 for the middle 50 frames and last 10 frames.
+  frames[25:75, 39] = True
+  frames[90:100, 39] = True
+  # Add an onset for the first occurrence with a valid velocity.
+  onsets[25, 39] = True
+  velocity_values[25, 39] = 0.5
+  # Add an onset for the second occurrence with a NaN velocity.
+  onsets[90, 39] = True
+  velocity_values[90, 39] = float(&#39;nan&#39;)
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames,
+      frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+      min_duration_ms=0,
+      onset_predictions=onsets,
+      velocity_values=velocity_values)
+  self.assertLen(sequence.notes, 2)
+
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(50, sequence.notes[0].velocity)
+  self.assertEqual(39, sequence.notes[1].pitch)
+  self.assertEqual(0, sequence.notes[1].velocity)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsDefaultVelocity"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceWithOnsetsDefaultVelocity</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceWithOnsetsDefaultVelocity(self):
+  # 100 frames of notes and onsets.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+  # Activate key 39 for the middle 50 frames and last 10 frames.
+  frames[25:75, 39] = True
+  frames[90:100, 39] = True
+  onsets[25, 39] = True
+  onsets[90, 39] = True
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames,
+      frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+      min_duration_ms=0,
+      onset_predictions=onsets,
+      velocity=100)
+  self.assertLen(sequence.notes, 2)
+
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(100, sequence.notes[0].velocity)
+  self.assertEqual(39, sequence.notes[1].pitch)
+  self.assertEqual(100, sequence.notes[1].velocity)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsOverlappingFrames"><code class="name flex">
+<span>def <span class="ident">testPianorollToNoteSequenceWithOnsetsOverlappingFrames</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testPianorollToNoteSequenceWithOnsetsOverlappingFrames(self):
+  # 100 frames of notes and onsets.
+  frames = np.zeros((100, MIDI_PITCHES), np.bool)
+  onsets = np.zeros((100, MIDI_PITCHES), np.bool)
+  # Activate key 39 for the middle 50 frames.
+  frames[25:75, 39] = True
+  # Add multiple onsets within those frames.
+  onsets[25, 39] = True
+  onsets[30, 39] = True
+  # If an onset lasts for multiple frames, it should create only 1 note.
+  onsets[35, 39] = True
+  onsets[36, 39] = True
+  sequence = sequences_lib.pianoroll_to_note_sequence(
+      frames,
+      frames_per_second=DEFAULT_FRAMES_PER_SECOND,
+      min_duration_ms=0,
+      onset_predictions=onsets)
+  self.assertLen(sequence.notes, 3)
+
+  self.assertEqual(39, sequence.notes[0].pitch)
+  self.assertEqual(25 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[0].start_time)
+  self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[0].end_time)
+
+  self.assertEqual(39, sequence.notes[1].pitch)
+  self.assertEqual(30 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[1].start_time)
+  self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[1].end_time)
+
+  self.assertEqual(39, sequence.notes[2].pitch)
+  self.assertEqual(35 / DEFAULT_FRAMES_PER_SECOND,
+                   sequence.notes[2].start_time)
+  self.assertEqual(75 / DEFAULT_FRAMES_PER_SECOND, sequence.notes[2].end_time)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence"><code class="name flex">
+<span>def <span class="ident">testQuantizeNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeNoteSequence(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence,
+      [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+  testing_lib.add_control_changes_to_sequence(
+      self.note_sequence, 0,
+      [(2.0, 64, 127), (4.0, 64, 0)])
+
+  expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+  expected_quantized_sequence.quantization_info.steps_per_quarter = (
+      self.steps_per_quarter)
+  testing_lib.add_quantized_steps_to_sequence(
+      expected_quantized_sequence,
+      [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+  testing_lib.add_quantized_chord_steps_to_sequence(
+      expected_quantized_sequence, [1, 16])
+  testing_lib.add_quantized_control_steps_to_sequence(
+      expected_quantized_sequence, [8, 16])
+
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, steps_per_quarter=self.steps_per_quarter)
+
+  self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequenceAbsolute"><code class="name flex">
+<span>def <span class="ident">testQuantizeNoteSequenceAbsolute</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeNoteSequenceAbsolute(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence,
+      [(&#39;B7&#39;, 0.22), (&#39;Em9&#39;, 4.0)])
+  testing_lib.add_control_changes_to_sequence(
+      self.note_sequence, 0,
+      [(2.0, 64, 127), (4.0, 64, 0)])
+
+  expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+  expected_quantized_sequence.quantization_info.steps_per_second = 4
+  testing_lib.add_quantized_steps_to_sequence(
+      expected_quantized_sequence,
+      [(0, 40), (1, 2), (10, 14), (16, 17), (19, 20)])
+  testing_lib.add_quantized_chord_steps_to_sequence(
+      expected_quantized_sequence, [1, 16])
+  testing_lib.add_quantized_control_steps_to_sequence(
+      expected_quantized_sequence, [8, 16])
+
+  quantized_sequence = sequences_lib.quantize_note_sequence_absolute(
+      self.note_sequence, steps_per_second=4)
+
+  self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_ImplicitTimeSignatureChange"><code class="name flex">
+<span>def <span class="ident">testQuantizeNoteSequence_ImplicitTimeSignatureChange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeNoteSequence_ImplicitTimeSignatureChange(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.time_signatures[:]
+
+  # No time signature.
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Implicit time signature change.
+  self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+  with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder"><code class="name flex">
+<span>def <span class="ident">testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.time_signatures[:]
+
+  # No time signature.
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # No implicit time signature change, but time signatures are added out of
+  # order.
+  self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+  self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=0)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_TimeSignatureChange"><code class="name flex">
+<span>def <span class="ident">testQuantizeNoteSequence_TimeSignatureChange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeNoteSequence_TimeSignatureChange(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  del self.note_sequence.time_signatures[:]
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Single time signature.
+  self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=0)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Multiple time signatures with no change.
+  self.note_sequence.time_signatures.add(numerator=4, denominator=4, time=1)
+  sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+
+  # Time signature change.
+  self.note_sequence.time_signatures.add(numerator=2, denominator=4, time=2)
+  with self.assertRaises(sequences_lib.MultipleTimeSignatureError):
+    sequences_lib.quantize_note_sequence(
+        self.note_sequence, self.steps_per_quarter)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeToStep"><code class="name flex">
+<span>def <span class="ident">testQuantizeToStep</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testQuantizeToStep(self):
+  self.assertEqual(
+      32, sequences_lib.quantize_to_step(8.0001, 4))
+  self.assertEqual(
+      34, sequences_lib.quantize_to_step(8.4999, 4))
+  self.assertEqual(
+      33, sequences_lib.quantize_to_step(8.4999, 4, quantize_cutoff=1.0))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRectifyBeats"><code class="name flex">
+<span>def <span class="ident">testRectifyBeats</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRectifyBeats(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.5),
+       (65, 100, 1.0, 1.5), (67, 100, 1.5, 2.0)])
+  testing_lib.add_beats_to_sequence(sequence, [0.5, 1.0, 2.0])
+
+  rectified_sequence, alignment = sequences_lib.rectify_beats(
+      sequence, 120)
+
+  expected_sequence = music_pb2.NoteSequence()
+  expected_sequence.tempos.add(qpm=120)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.25, 0.5), (62, 100, 0.5, 0.75), (64, 100, 0.75, 2.0),
+       (65, 100, 1.0, 1.25), (67, 100, 1.25, 1.5)])
+  testing_lib.add_beats_to_sequence(expected_sequence, [0.5, 1.0, 1.5])
+
+  self.assertEqual(expected_sequence, rectified_sequence)
+
+  expected_alignment = [
+      [0.0, 0.5, 1.0, 2.0, 2.5],
+      [0.0, 0.5, 1.0, 1.5, 2.0]
+  ]
+  self.assertEqual(expected_alignment, alignment.T.tolist())</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantData"><code class="name flex">
+<span>def <span class="ident">testRemoveRedundantData</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRemoveRedundantData(self):
+  sequence = copy.copy(self.note_sequence)
+  redundant_tempo = sequence.tempos.add()
+  redundant_tempo.CopyFrom(sequence.tempos[0])
+  redundant_tempo.time = 5.0
+  sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+  sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+  sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+  sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+  sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+  sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+  fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  expected_sequence.sequence_metadata.composers.append(&#39;Foo&#39;)
+  expected_sequence.sequence_metadata.composers.append(&#39;Bar&#39;)
+  expected_sequence.sequence_metadata.genre.append(&#39;Classical&#39;)
+
+  self.assertProtoEquals(expected_sequence, fixed_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantDataOutOfOrder"><code class="name flex">
+<span>def <span class="ident">testRemoveRedundantDataOutOfOrder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRemoveRedundantDataOutOfOrder(self):
+  sequence = copy.copy(self.note_sequence)
+  meaningful_tempo = sequence.tempos.add()
+  meaningful_tempo.time = 5.0
+  meaningful_tempo.qpm = 50
+  redundant_tempo = sequence.tempos.add()
+  redundant_tempo.CopyFrom(sequence.tempos[0])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  expected_meaningful_tempo = expected_sequence.tempos.add()
+  expected_meaningful_tempo.time = 5.0
+  expected_meaningful_tempo.qpm = 50
+
+  fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+  self.assertProtoEquals(expected_sequence, fixed_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDuration"><code class="name flex">
+<span>def <span class="ident">testRepeatSequenceToDuration</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRepeatSequenceToDuration(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+       (60, 100, 1.5, 2.5), (72, 100, 2.0, 3.0)])
+
+  repeated_seq = sequences_lib.repeat_sequence_to_duration(
+      sequence, duration=3)
+  self.assertProtoEquals(expected_sequence, repeated_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDurationProvidedDuration"><code class="name flex">
+<span>def <span class="ident">testRepeatSequenceToDurationProvidedDuration</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRepeatSequenceToDurationProvidedDuration(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5)])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(60, 100, 0.0, 1.0), (72, 100, 0.5, 1.5),
+       (60, 100, 2.0, 3.0), (72, 100, 2.5, 3.0)])
+
+  repeated_seq = sequences_lib.repeat_sequence_to_duration(
+      sequence, duration=3, sequence_duration=2)
+  self.assertProtoEquals(expected_sequence, repeated_seq)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testRounding"><code class="name flex">
+<span>def <span class="ident">testRounding</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testRounding(self):
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 1,
+      [(12, 100, 0.01, 0.24), (11, 100, 0.22, 0.55), (40, 100, 0.50, 0.75),
+       (41, 100, 0.689, 1.18), (44, 100, 1.19, 1.69), (55, 100, 4.0, 4.01)])
+
+  expected_quantized_sequence = copy.deepcopy(self.note_sequence)
+  expected_quantized_sequence.quantization_info.steps_per_quarter = (
+      self.steps_per_quarter)
+  testing_lib.add_quantized_steps_to_sequence(
+      expected_quantized_sequence,
+      [(0, 1), (1, 2), (2, 3), (3, 5), (5, 7), (16, 17)])
+  quantized_sequence = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  self.assertProtoEquals(expected_quantized_sequence, quantized_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianoroll"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianoroll</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianoroll(self):
+  sequence = music_pb2.NoteSequence(total_time=1.21)
+  testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.11, 1.01),
+                                                  (2, 55, 0.22, 0.50),
+                                                  (3, 100, 0.3, 0.8),
+                                                  (2, 45, 1.0, 1.21)])
+
+  pianoroll_tuple = sequences_lib.sequence_to_pianoroll(
+      sequence, frames_per_second=10, min_pitch=1, max_pitch=2)
+  output = pianoroll_tuple.active
+  offset = pianoroll_tuple.offsets
+
+  expected_pianoroll = [[0, 0],
+                        [1, 0],
+                        [1, 1],
+                        [1, 1],
+                        [1, 1],
+                        [1, 0],
+                        [1, 0],
+                        [1, 0],
+                        [1, 0],
+                        [1, 0],
+                        [1, 1],
+                        [0, 1],
+                        [0, 1]]
+
+  expected_offsets = [[0, 0],
+                      [0, 0],
+                      [0, 0],
+                      [0, 0],
+                      [0, 0],
+                      [0, 1],
+                      [0, 0],
+                      [0, 0],
+                      [0, 0],
+                      [0, 0],
+                      [1, 0],
+                      [0, 0],
+                      [0, 1]]
+
+  np.testing.assert_allclose(expected_pianoroll, output)
+  np.testing.assert_allclose(expected_offsets, offset)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollActiveVelocities"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollActiveVelocities</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollActiveVelocities(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+  sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+  sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+  sequence.total_time = 2.0
+
+  roll = sequences_lib.sequence_to_pianoroll(
+      sequence, 1, 60, 62, max_velocity=64)
+  active_velocities = roll.active_velocities
+
+  self.assertEqual(np.all(active_velocities[0:2, 0] == 0.25), True)
+  self.assertEqual(np.all(active_velocities[0:2, 1] == 0.5), True)
+  self.assertEqual(np.all(active_velocities[0:2, 2] == 1.), True)
+  self.assertEqual(np.all(active_velocities[2:] == 0), True)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollControlChanges"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollControlChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollControlChanges(self):
+  sequence = music_pb2.NoteSequence(total_time=2.0)
+  cc = music_pb2.NoteSequence.ControlChange
+  sequence.control_changes.extend([
+      cc(time=0.7, control_number=3, control_value=16),
+      cc(time=0.0, control_number=4, control_value=32),
+      cc(time=0.5, control_number=4, control_value=32),
+      cc(time=1.6, control_number=3, control_value=64),
+  ])
+
+  expected_cc_roll = np.zeros((5, 128), dtype=np.int32)
+  expected_cc_roll[0:2, 4] = 33
+  expected_cc_roll[1, 3] = 17
+  expected_cc_roll[3, 3] = 65
+
+  cc_roll = sequences_lib.sequence_to_pianoroll(
+      sequence, frames_per_second=2, min_pitch=1, max_pitch=4).control_changes
+
+  np.testing.assert_allclose(expected_cc_roll, cc_roll)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollFrameOccupancy"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollFrameOccupancy</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollFrameOccupancy(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=1.7)
+  sequence.notes.add(pitch=61, start_time=6.2, end_time=6.55)
+  sequence.notes.add(pitch=62, start_time=3.4, end_time=4.3)
+  sequence.total_time = 6.55
+
+  active = sequences_lib.sequence_to_pianoroll(
+      sequence, 2, 60, 62, min_frame_occupancy_for_label=0.5).active
+
+  expected_roll = np.zeros([14, 3])
+  expected_roll[2:3, 0] = 1.
+  expected_roll[12:13, 1] = 1.
+  expected_roll[7:9, 2] = 1.
+
+  np.testing.assert_equal(expected_roll, active)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsetVelocities"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollOnsetVelocities</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollOnsetVelocities(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=0.0, end_time=2.0, velocity=16)
+  sequence.notes.add(pitch=61, start_time=0.0, end_time=2.0, velocity=32)
+  sequence.notes.add(pitch=62, start_time=0.0, end_time=2.0, velocity=64)
+  sequence.total_time = 2.0
+
+  roll = sequences_lib.sequence_to_pianoroll(
+      sequence, 1, 60, 62, max_velocity=64, onset_window=0)
+  onset_velocities = roll.onset_velocities
+
+  self.assertEqual(onset_velocities[0, 0], 0.25)
+  self.assertEqual(onset_velocities[0, 1], 0.5)
+  self.assertEqual(onset_velocities[0, 2], 1.)
+  self.assertEqual(np.all(onset_velocities[1:] == 0), True)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsets"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollOnsets</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollOnsets(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=2.0, end_time=5.0)
+  sequence.notes.add(pitch=61, start_time=6.0, end_time=7.0)
+  sequence.notes.add(pitch=62, start_time=7.0, end_time=8.0)
+  sequence.total_time = 8.0
+
+  onsets = sequences_lib.sequence_to_pianoroll(
+      sequence,
+      100,
+      60,
+      62,
+      onset_mode=&#39;length_ms&#39;,
+      onset_length_ms=100.0,
+      onset_delay_ms=10.0,
+      min_frame_occupancy_for_label=.999).onsets
+
+  expected_roll = np.zeros([801, 3])
+  expected_roll[201:211, 0] = 1.
+  expected_roll[601:611, 1] = 1.
+  expected_roll[701:711, 2] = 1.
+
+  np.testing.assert_equal(expected_roll, onsets)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOverlappingNotes"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollOverlappingNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollOverlappingNotes(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=2.0)
+  sequence.notes.add(pitch=60, start_time=1.2, end_time=2.0)
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=2.5)
+  sequence.total_time = 2.5
+
+  rolls = sequences_lib.sequence_to_pianoroll(
+      sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+      onset_mode=&#39;length_ms&#39;, onset_length_ms=10)
+
+  expected_onsets = np.zeros([26, 1])
+  expected_onsets[10, 0] = 1
+  expected_onsets[12, 0] = 1
+  np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+  expected_offsets = np.zeros([26, 1])
+  expected_offsets[20, 0] = 1
+  expected_offsets[25, 0] = 1
+  np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+  expected_active = np.zeros([26, 1])
+  expected_active[10:25, 0] = 1
+  np.testing.assert_equal(expected_active, rolls.active)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollShortNotes"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollShortNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollShortNotes(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=60, start_time=1.0, end_time=1.0001)
+  sequence.notes.add(pitch=60, start_time=1.2, end_time=1.2001)
+  sequence.total_time = 2.5
+
+  rolls = sequences_lib.sequence_to_pianoroll(
+      sequence, frames_per_second=10, min_pitch=60, max_pitch=60,
+      onset_mode=&#39;length_ms&#39;, onset_length_ms=0)
+
+  expected_onsets = np.zeros([26, 1])
+  expected_onsets[10, 0] = 1
+  expected_onsets[12, 0] = 1
+  np.testing.assert_equal(expected_onsets, rolls.onsets)
+
+  expected_offsets = np.zeros([26, 1])
+  expected_offsets[10, 0] = 1
+  expected_offsets[12, 0] = 1
+  np.testing.assert_equal(expected_offsets, rolls.offsets)
+
+  expected_active = np.zeros([26, 1])
+  expected_active[10:11, 0] = 1
+  expected_active[12:13, 0] = 1
+  np.testing.assert_equal(expected_active, rolls.active)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWeightedRoll"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollWeightedRoll</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollWeightedRoll(self):
+  sequence = music_pb2.NoteSequence(total_time=2.0)
+  testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                  (2, 100, 0.20, 0.50),
+                                                  (3, 100, 1.20, 1.50),
+                                                  (4, 100, 0.40, 2.00),
+                                                  (6, 100, 0.10, 0.60)])
+
+  onset_upweight = 5.0
+  expected_roll_weights = [
+      [onset_upweight, onset_upweight, 1, onset_upweight],
+      [onset_upweight, onset_upweight, onset_upweight, onset_upweight],
+      [1, 1, onset_upweight, onset_upweight / 1],
+      [1, 1, onset_upweight, onset_upweight / 2],
+      [1, 1, 1, 1],
+  ]
+
+  expected_onsets = [
+      [1, 1, 0, 1],
+      [1, 1, 1, 1],
+      [0, 0, 1, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 0],
+  ]
+  roll = sequences_lib.sequence_to_pianoroll(
+      sequence,
+      frames_per_second=2,
+      min_pitch=1,
+      max_pitch=4,
+      onset_upweight=onset_upweight)
+
+  np.testing.assert_allclose(expected_roll_weights, roll.weights)
+  np.testing.assert_allclose(expected_onsets, roll.onsets)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffset"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollWithBlankFrameBeforeOffset</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollWithBlankFrameBeforeOffset(self):
+  sequence = music_pb2.NoteSequence(total_time=1.5)
+  testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.00, 1.00),
+                                                  (2, 100, 0.20, 0.50),
+                                                  (1, 100, 1.20, 1.50),
+                                                  (2, 100, 0.50, 1.50)])
+
+  expected_pianoroll = [
+      [1, 0],
+      [1, 0],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [0, 1],
+      [0, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [0, 0],
+  ]
+
+  output = sequences_lib.sequence_to_pianoroll(
+      sequence, frames_per_second=10, min_pitch=1, max_pitch=2).active
+
+  np.testing.assert_allclose(expected_pianoroll, output)
+
+  expected_pianoroll_with_blank_frame = [
+      [1, 0],
+      [1, 0],
+      [1, 1],
+      [1, 1],
+      [1, 0],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [0, 1],
+      [0, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [0, 0],
+  ]
+
+  output_with_blank_frame = sequences_lib.sequence_to_pianoroll(
+      sequence,
+      frames_per_second=10,
+      min_pitch=1,
+      max_pitch=2,
+      add_blank_frame_before_onset=True).active
+
+  np.testing.assert_allclose(expected_pianoroll_with_blank_frame,
+                             output_with_blank_frame)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder"><code class="name flex">
+<span>def <span class="ident">testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder(self):
+  sequence = music_pb2.NoteSequence(total_time=.5)
+  testing_lib.add_track_to_sequence(sequence, 0, [(1, 100, 0.20, 0.50),
+                                                  (1, 100, 0.00, 0.20)])
+
+  expected_pianoroll = [
+      [1],
+      [0],
+      [1],
+      [1],
+      [1],
+      [0],
+  ]
+
+  output = sequences_lib.sequence_to_pianoroll(
+      sequence,
+      frames_per_second=10,
+      min_pitch=1,
+      max_pitch=1,
+      add_blank_frame_before_onset=True).active
+
+  np.testing.assert_allclose(expected_pianoroll, output)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToValuedIntervals"><code class="name flex">
+<span>def <span class="ident">testSequenceToValuedIntervals</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSequenceToValuedIntervals(self):
+  sequence = music_pb2.NoteSequence()
+  sequence.notes.add(pitch=69, start_time=1.0, end_time=2.0, velocity=80)
+  # Should be dropped because it is 0 duration.
+  sequence.notes.add(pitch=60, start_time=3.0, end_time=3.0, velocity=90)
+
+  intervals, pitches, velocities = sequences_lib.sequence_to_valued_intervals(
+      sequence)
+  np.testing.assert_array_equal([[1., 2.]], intervals)
+  np.testing.assert_array_equal([440.0], pitches)
+  np.testing.assert_array_equal([80], velocities)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testShiftSequenceTimes"><code class="name flex">
+<span>def <span class="ident">testShiftSequenceTimes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testShiftSequenceTimes(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 0,
+      [(0.0, 64, 127), (2.0, 64, 0), (4.0, 64, 127), (5.0, 64, 0)])
+  testing_lib.add_control_changes_to_sequence(
+      sequence, 1, [(2.0, 64, 127)])
+  testing_lib.add_pitch_bends_to_sequence(
+      sequence, 1, 1, [(2.0, 100), (3.0, 0)])
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(12, 100, 1.01, 11.0), (11, 55, 1.22, 1.50), (40, 45, 3.50, 4.50),
+       (55, 120, 5.0, 5.01), (52, 99, 5.75, 6.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_sequence, [(&#39;C&#39;, 2.5), (&#39;G7&#39;, 4.0), (&#39;F&#39;, 5.8)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_sequence, 0,
+      [(1.0, 64, 127), (3.0, 64, 0), (5.0, 64, 127), (6.0, 64, 0)])
+  testing_lib.add_control_changes_to_sequence(
+      expected_sequence, 1, [(3.0, 64, 127)])
+  testing_lib.add_pitch_bends_to_sequence(
+      expected_sequence, 1, 1, [(3.0, 100), (4.0, 0)])
+
+  expected_sequence.time_signatures[0].time = 1
+  expected_sequence.tempos[0].time = 1
+
+  shifted_sequence = sequences_lib.shift_sequence_times(sequence, 1.0)
+  self.assertProtoEquals(expected_sequence, shifted_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceAtTimes"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceAtTimes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceAtTimes(self):
+  # Tests splitting a NoteSequence at specified times, truncating notes.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+  expected_subsequence_1.total_time = 3.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_2, [(&#39;G7&#39;, 0.0)])
+  expected_subsequence_2.total_time = 0.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+  expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+  expected_subsequence_3 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_3, 0,
+      [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+  expected_subsequence_3.total_time = 1.0
+  expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+  expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+  subsequences = sequences_lib.split_note_sequence(
+      sequence, hop_size_seconds=[3.0, 4.0])
+  self.assertLen(subsequences, 3)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+  self.assertProtoEquals(expected_subsequence_3, subsequences[2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceCoincidentTimeChanges"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceCoincidentTimeChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceCoincidentTimeChanges(self):
+  # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+  # two time changes occurring simultaneously.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      time_signatures: {
+        time: 2.0
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 60}
+      tempos: {
+        time: 2.0
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+  expected_subsequence_1.total_time = 2.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01), (52, 99, 2.75, 3.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0), (&#39;F&#39;, 2.8)])
+  expected_subsequence_2.total_time = 3.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+  expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+  subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+  self.assertLen(subsequences, 2)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceDuplicateTimeChanges"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceDuplicateTimeChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceDuplicateTimeChanges(self):
+  # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+  # duplicate time changes.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      time_signatures: {
+        time: 2.0
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+  expected_subsequence = music_pb2.NoteSequence()
+  expected_subsequence.CopyFrom(sequence)
+  expected_subsequence.subsequence_info.start_time_offset = 0.0
+  expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+  subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+  self.assertLen(subsequences, 1)
+  self.assertProtoEquals(expected_subsequence, subsequences[0])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChanges"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceMultipleTimeChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceMultipleTimeChanges(self):
+  # Tests splitting a NoteSequence on time changes, truncating notes on splits
+  # that occur inside notes.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      time_signatures: {
+        time: 2.0
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 60}
+      tempos: {
+        time: 4.25
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 2.0), (11, 55, 0.22, 0.50)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 1.5)])
+  expected_subsequence_1.total_time = 2.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 8.0
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(40, 45, 0.50, 1.50), (55, 120, 2.0, 2.01)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_2, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 1.0)])
+  expected_subsequence_2.total_time = 2.01
+  expected_subsequence_2.subsequence_info.start_time_offset = 2.0
+  expected_subsequence_2.subsequence_info.end_time_offset = 5.99
+
+  expected_subsequence_3 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_3, 0,
+      [(52, 99, 0.5, 0.75)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_3, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+  expected_subsequence_3.total_time = 0.75
+  expected_subsequence_3.subsequence_info.start_time_offset = 4.25
+  expected_subsequence_3.subsequence_info.end_time_offset = 5.0
+
+  subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+  self.assertLen(subsequences, 3)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+  self.assertProtoEquals(expected_subsequence_3, subsequences[2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes(self):
+  # Tests splitting a NoteSequence on time changes skipping splits that occur
+  # inside notes.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      time_signatures: {
+        time: 2.0
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 60}
+      tempos: {
+        time: 4.25
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      time_signatures: {
+        time: 2.0
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0)])
+  expected_subsequence_1.total_time = 4.01
+  expected_subsequence_1.subsequence_info.end_time_offset = 0.99
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 3
+        denominator: 4}
+      tempos: {
+        qpm: 80}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0, [(52, 99, 0.5, 0.75)])
+  testing_lib.add_chords_to_sequence(expected_subsequence_2, [
+      (&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.55)])
+  expected_subsequence_2.total_time = 0.75
+  expected_subsequence_2.subsequence_info.start_time_offset = 4.25
+
+  subsequences = sequences_lib.split_note_sequence_on_time_changes(
+      sequence, skip_splits_inside_notes=True)
+  self.assertLen(subsequences, 2)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceNoTimeChanges"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceNoTimeChanges</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceNoTimeChanges(self):
+  # Tests splitting a NoteSequence on time changes for a NoteSequence that has
+  # no time changes (time signature and tempo changes).
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.5), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.8)])
+
+  expected_subsequence = music_pb2.NoteSequence()
+  expected_subsequence.CopyFrom(sequence)
+  expected_subsequence.subsequence_info.start_time_offset = 0.0
+  expected_subsequence.subsequence_info.end_time_offset = 0.0
+
+  subsequences = sequences_lib.split_note_sequence_on_time_changes(sequence)
+  self.assertLen(subsequences, 1)
+  self.assertProtoEquals(expected_subsequence, subsequences[0])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilence"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceOnSilence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceOnSilence(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+
+  expected_subsequence_1 = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 1.0), (11, 55, 0.22, 0.50)])
+  expected_subsequence_1.total_time = 1.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 4.0
+
+  expected_subsequence_2 = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(40, 45, 0.0, 1.0), (55, 120, 1.50, 1.51)])
+  expected_subsequence_2.total_time = 1.51
+  expected_subsequence_2.subsequence_info.start_time_offset = 2.50
+  expected_subsequence_2.subsequence_info.end_time_offset = 0.99
+
+  expected_subsequence_3 = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_3, 0,
+      [(52, 99, 0.0, 0.25)])
+  expected_subsequence_3.total_time = 0.25
+  expected_subsequence_3.subsequence_info.start_time_offset = 4.75
+
+  subsequences = sequences_lib.split_note_sequence_on_silence(
+      sequence, gap_seconds=0.5)
+  self.assertLen(subsequences, 3)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+  self.assertProtoEquals(expected_subsequence_3, subsequences[2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilenceInitialGap"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceOnSilenceInitialGap</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceOnSilenceInitialGap(self):
+  sequence = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 1.5, 2.0), (11, 55, 1.5, 3.0), (40, 45, 2.5, 3.5)])
+
+  expected_subsequence_1 = music_pb2.NoteSequence()
+  expected_subsequence_1.total_time = 0.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 3.5
+
+  expected_subsequence_2 = music_pb2.NoteSequence()
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(12, 100, 0.0, 0.5), (11, 55, 0.0, 1.5), (40, 45, 1.0, 2.0)])
+  expected_subsequence_2.total_time = 2.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 1.5
+
+  subsequences = sequences_lib.split_note_sequence_on_silence(
+      sequence, gap_seconds=1.0)
+  self.assertLen(subsequences, 2)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceSkipSplitsInsideNotes"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceSkipSplitsInsideNotes</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceSkipSplitsInsideNotes(self):
+  # Tests splitting a NoteSequence at regular hop size, skipping splits that
+  # would have occurred inside a note.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0), (&#39;F&#39;, 4.5)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 0.0), (&#39;G7&#39;, 3.0)])
+  expected_subsequence_1.total_time = 3.50
+  expected_subsequence_1.subsequence_info.end_time_offset = 1.5
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 0.5)])
+  expected_subsequence_2.total_time = 1.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 4.0
+
+  subsequences = sequences_lib.split_note_sequence(
+      sequence, hop_size_seconds=2.0, skip_splits_inside_notes=True)
+  self.assertLen(subsequences, 2)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithHopSize"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceWithHopSize</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceWithHopSize(self):
+  # Tests splitting a NoteSequence at regular hop size, truncating notes.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_chords_to_sequence(
+      sequence, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0), (&#39;F&#39;, 4.0)])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_1, [(&#39;C&#39;, 1.0), (&#39;G7&#39;, 2.0)])
+  expected_subsequence_1.total_time = 3.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_2, 0,
+      [(55, 120, 1.0, 1.01), (52, 99, 1.75, 2.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_2, [(&#39;G7&#39;, 0.0), (&#39;F&#39;, 1.0)])
+  expected_subsequence_2.total_time = 2.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+  expected_subsequence_2.subsequence_info.end_time_offset = 3.0
+
+  expected_subsequence_3 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_chords_to_sequence(
+      expected_subsequence_3, [(&#39;F&#39;, 0.0)])
+  expected_subsequence_3.total_time = 0.0
+  expected_subsequence_3.subsequence_info.start_time_offset = 6.0
+  expected_subsequence_3.subsequence_info.end_time_offset = 2.0
+
+  subsequences = sequences_lib.split_note_sequence(
+      sequence, hop_size_seconds=3.0)
+  self.assertLen(subsequences, 3)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+  self.assertProtoEquals(expected_subsequence_3, subsequences[2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithStatelessEvents"><code class="name flex">
+<span>def <span class="ident">testSplitNoteSequenceWithStatelessEvents</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testSplitNoteSequenceWithStatelessEvents(self):
+  # Tests splitting a NoteSequence at specified times with stateless events.
+  sequence = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 8.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  testing_lib.add_beats_to_sequence(sequence, [1.0, 2.0, 4.0])
+
+  expected_subsequence_1 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_1, 0,
+      [(12, 100, 0.01, 3.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.0)])
+  testing_lib.add_beats_to_sequence(expected_subsequence_1, [1.0, 2.0])
+  expected_subsequence_1.total_time = 3.0
+  expected_subsequence_1.subsequence_info.end_time_offset = 5.0
+
+  expected_subsequence_2 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  expected_subsequence_2.total_time = 0.0
+  expected_subsequence_2.subsequence_info.start_time_offset = 3.0
+  expected_subsequence_2.subsequence_info.end_time_offset = 5.0
+
+  expected_subsequence_3 = testing_lib.parse_test_proto(
+      music_pb2.NoteSequence,
+      &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4}
+      tempos: {
+        qpm: 60}&#34;&#34;&#34;)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence_3, 0,
+      [(55, 120, 0.0, 0.01), (52, 99, 0.75, 1.0)])
+  testing_lib.add_beats_to_sequence(expected_subsequence_3, [0.0])
+  expected_subsequence_3.total_time = 1.0
+  expected_subsequence_3.subsequence_info.start_time_offset = 4.0
+  expected_subsequence_3.subsequence_info.end_time_offset = 3.0
+
+  subsequences = sequences_lib.split_note_sequence(
+      sequence, hop_size_seconds=[3.0, 4.0])
+  self.assertLen(subsequences, 3)
+  self.assertProtoEquals(expected_subsequence_1, subsequences[0])
+  self.assertProtoEquals(expected_subsequence_2, subsequences[1])
+  self.assertProtoEquals(expected_subsequence_3, subsequences[2])</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testStepsPerBar"><code class="name flex">
+<span>def <span class="ident">testStepsPerBar</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testStepsPerBar(self):
+  qns = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  self.assertEqual(16, sequences_lib.steps_per_bar_in_quantized_sequence(qns))
+
+  self.note_sequence.time_signatures[0].numerator = 6
+  self.note_sequence.time_signatures[0].denominator = 8
+  qns = sequences_lib.quantize_note_sequence(
+      self.note_sequence, self.steps_per_quarter)
+  self.assertEqual(12.0,
+                   sequences_lib.steps_per_bar_in_quantized_sequence(qns))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testStepsPerQuarterToStepsPerSecond"><code class="name flex">
+<span>def <span class="ident">testStepsPerQuarterToStepsPerSecond</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testStepsPerQuarterToStepsPerSecond(self):
+  self.assertEqual(
+      4.0, sequences_lib.steps_per_quarter_to_steps_per_second(4, 60.0))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testStretchNoteSequence"><code class="name flex">
+<span>def <span class="ident">testStretchNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testStretchNoteSequence(self):
+  expected_stretched_sequence = copy.deepcopy(self.note_sequence)
+  expected_stretched_sequence.tempos[0].qpm = 40
+
+  testing_lib.add_track_to_sequence(
+      self.note_sequence, 0,
+      [(12, 100, 0.0, 10.0), (11, 55, 0.2, 0.5), (40, 45, 2.5, 3.5)])
+  testing_lib.add_track_to_sequence(
+      expected_stretched_sequence, 0,
+      [(12, 100, 0.0, 15.0), (11, 55, 0.3, 0.75), (40, 45, 3.75, 5.25)])
+
+  testing_lib.add_chords_to_sequence(
+      self.note_sequence, [(&#39;B7&#39;, 0.5), (&#39;Em9&#39;, 2.0)])
+  testing_lib.add_chords_to_sequence(
+      expected_stretched_sequence, [(&#39;B7&#39;, 0.75), (&#39;Em9&#39;, 3.0)])
+
+  prestretched_sequence = copy.deepcopy(self.note_sequence)
+
+  stretched_sequence = sequences_lib.stretch_note_sequence(
+      self.note_sequence, stretch_factor=1.5, in_place=False)
+  self.assertProtoEquals(expected_stretched_sequence, stretched_sequence)
+
+  # Make sure the proto was not modified
+  self.assertProtoEquals(prestretched_sequence, self.note_sequence)
+
+  sequences_lib.stretch_note_sequence(
+      self.note_sequence, stretch_factor=1.5, in_place=True)
+  self.assertProtoEquals(stretched_sequence, self.note_sequence)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequence"><code class="name flex">
+<span>def <span class="ident">testTransposeNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTransposeNoteSequence(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  sequence.text_annotations.add(
+      time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+  sequence.text_annotations.add(
+      time=2, annotation_type=CHORD_SYMBOL, text=&#39;E7&#39;)
+  sequence.key_signatures.add(
+      time=0, key=music_pb2.NoteSequence.KeySignature.E,
+      mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+  expected_sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence, 0,
+      [(13, 100, 0.01, 10.0), (12, 55, 0.22, 0.50), (41, 45, 2.50, 3.50),
+       (56, 120, 4.0, 4.01), (53, 99, 4.75, 5.0)])
+  expected_sequence.text_annotations.add(
+      time=1, annotation_type=CHORD_SYMBOL, text=&#39;N.C.&#39;)
+  expected_sequence.text_annotations.add(
+      time=2, annotation_type=CHORD_SYMBOL, text=&#39;F7&#39;)
+  expected_sequence.key_signatures.add(
+      time=0, key=music_pb2.NoteSequence.KeySignature.F,
+      mode=music_pb2.NoteSequence.KeySignature.MIXOLYDIAN)
+
+  transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+      sequence, 1)
+  self.assertProtoEquals(expected_sequence, transposed_sequence)
+  self.assertEqual(delete_count, 0)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequenceOutOfRange"><code class="name flex">
+<span>def <span class="ident">testTransposeNoteSequenceOutOfRange</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTransposeNoteSequenceOutOfRange(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(35, 100, 0.01, 10.0), (36, 55, 0.22, 0.50), (37, 45, 2.50, 3.50),
+       (38, 120, 4.0, 4.01), (39, 99, 4.75, 5.0)])
+
+  expected_sequence_1 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence_1, 0,
+      [(39, 100, 0.01, 10.0), (40, 55, 0.22, 0.50)])
+
+  expected_sequence_2 = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_sequence_2, 0,
+      [(30, 120, 4.0, 4.01), (31, 99, 4.75, 5.0)])
+
+  sequence_copy = copy.copy(sequence)
+  transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+      sequence_copy, 4, 30, 40)
+  self.assertProtoEquals(expected_sequence_1, transposed_sequence)
+  self.assertEqual(delete_count, 3)
+
+  sequence_copy = copy.copy(sequence)
+  transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+      sequence_copy, -8, 30, 40)
+  self.assertProtoEquals(expected_sequence_2, transposed_sequence)
+  self.assertEqual(delete_count, 3)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.sequences_lib_test.SequencesLibTest.testTrimNoteSequence"><code class="name flex">
+<span>def <span class="ident">testTrimNoteSequence</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def testTrimNoteSequence(self):
+  sequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      sequence, 0,
+      [(12, 100, 0.01, 10.0), (11, 55, 0.22, 0.50), (40, 45, 2.50, 3.50),
+       (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
+  expected_subsequence = copy.copy(self.note_sequence)
+  testing_lib.add_track_to_sequence(
+      expected_subsequence, 0,
+      [(40, 45, 2.50, 3.50), (55, 120, 4.0, 4.01)])
+  expected_subsequence.total_time = 4.75
+
+  subsequence = sequences_lib.trim_note_sequence(sequence, 2.5, 4.75)
+  self.assertProtoEquals(expected_subsequence, subsequence)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.testing_lib.ProtoTestCase" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="testing_lib.html#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.sequences_lib_test.SequencesLibTest" href="#note_seq.sequences_lib_test.SequencesLibTest">SequencesLibTest</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimes" href="#note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimes">testAdjustNoteSequenceTimes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesEndBeforeStart" href="#note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesEndBeforeStart">testAdjustNoteSequenceTimesEndBeforeStart</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithNotesBeforeTimeZero" href="#note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithNotesBeforeTimeZero">testAdjustNoteSequenceTimesWithNotesBeforeTimeZero</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithSkippedNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithSkippedNotes">testAdjustNoteSequenceTimesWithSkippedNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithZeroDurations" href="#note_seq.sequences_lib_test.SequencesLibTest.testAdjustNoteSequenceTimesWithZeroDurations">testAdjustNoteSequenceTimesWithZeroDurations</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChanges">testApplySustainControlChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtendNotesToEnd" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtendNotesToEnd">testApplySustainControlChangesExtendNotesToEnd</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtraneousSustain" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesExtraneousSustain">testApplySustainControlChangesExtraneousSustain</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesProcessSustainBeforeNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesProcessSustainBeforeNotes">testApplySustainControlChangesProcessSustainBeforeNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesSimultaneousOnOff" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesSimultaneousOnOff">testApplySustainControlChangesSimultaneousOnOff</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithDrumNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithDrumNotes">testApplySustainControlChangesWithDrumNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithIdenticalNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithIdenticalNotes">testApplySustainControlChangesWithIdenticalNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotes">testApplySustainControlChangesWithRepeatedNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotesBeforeSustain" href="#note_seq.sequences_lib_test.SequencesLibTest.testApplySustainControlChangesWithRepeatedNotesBeforeSustain">testApplySustainControlChangesWithRepeatedNotesBeforeSustain</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAssertIsQuantizedNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testAssertIsQuantizedNoteSequence">testAssertIsQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAssertIsRelativeQuantizedNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testAssertIsRelativeQuantizedNoteSequence">testAssertIsRelativeQuantizedNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteFalse" href="#note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteFalse">testAugmentNoteSequenceDeleteFalse</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteTrue" href="#note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceDeleteTrue">testAugmentNoteSequenceDeleteTrue</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoStretch" href="#note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoStretch">testAugmentNoteSequenceNoStretch</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoTranspose" href="#note_seq.sequences_lib_test.SequencesLibTest.testAugmentNoteSequenceNoTranspose">testAugmentNoteSequenceNoTranspose</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testClampTranspose" href="#note_seq.sequences_lib_test.SequencesLibTest.testClampTranspose">testClampTranspose</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequences" href="#note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequences">testConcatenateSequences</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequencesWithSpecifiedDurations" href="#note_seq.sequences_lib_test.SequencesLibTest.testConcatenateSequencesWithSpecifiedDurations">testConcatenateSequencesWithSpecifiedDurations</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testExpandSectionGroups" href="#note_seq.sequences_lib_test.SequencesLibTest.testExpandSectionGroups">testExpandSectionGroups</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testExpandWithoutSectionGroups" href="#note_seq.sequences_lib_test.SequencesLibTest.testExpandWithoutSectionGroups">testExpandWithoutSectionGroups</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequence">testExtractSubsequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePastEnd" href="#note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePastEnd">testExtractSubsequencePastEnd</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePedalEvents" href="#note_seq.sequences_lib_test.SequencesLibTest.testExtractSubsequencePedalEvents">testExtractSubsequencePedalEvents</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_ImplicitTempoChange" href="#note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_ImplicitTempoChange">testFromNoteSequence_ImplicitTempoChange</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_NoImplicitTempoChangeOutOfOrder" href="#note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_NoImplicitTempoChangeOutOfOrder">testFromNoteSequence_NoImplicitTempoChangeOutOfOrder</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_TempoChange" href="#note_seq.sequences_lib_test.SequencesLibTest.testFromNoteSequence_TempoChange">testFromNoteSequence_TempoChange</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testInferDenseChordsForSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testInferDenseChordsForSequence">testInferDenseChordsForSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testMultiTrack" href="#note_seq.sequences_lib_test.SequencesLibTest.testMultiTrack">testMultiTrack</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequence">testPianorollOnsetsToNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequenceFullVelocityScale" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollOnsetsToNoteSequenceFullVelocityScale">testPianorollOnsetsToNoteSequenceFullVelocityScale</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequence">testPianorollToNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceAllNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceAllNotes">testPianorollToNoteSequenceAllNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsets" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsets">testPianorollToNoteSequenceWithOnsets</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity">testPianorollToNoteSequenceWithOnsetsAndFullScaleVelocity</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndVelocity" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsAndVelocity">testPianorollToNoteSequenceWithOnsetsAndVelocity</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsDefaultVelocity" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsDefaultVelocity">testPianorollToNoteSequenceWithOnsetsDefaultVelocity</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsOverlappingFrames" href="#note_seq.sequences_lib_test.SequencesLibTest.testPianorollToNoteSequenceWithOnsetsOverlappingFrames">testPianorollToNoteSequenceWithOnsetsOverlappingFrames</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence">testQuantizeNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequenceAbsolute" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequenceAbsolute">testQuantizeNoteSequenceAbsolute</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_ImplicitTimeSignatureChange" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_ImplicitTimeSignatureChange">testQuantizeNoteSequence_ImplicitTimeSignatureChange</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder">testQuantizeNoteSequence_NoImplicitTimeSignatureChangeOutOfOrder</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_TimeSignatureChange" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeNoteSequence_TimeSignatureChange">testQuantizeNoteSequence_TimeSignatureChange</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testQuantizeToStep" href="#note_seq.sequences_lib_test.SequencesLibTest.testQuantizeToStep">testQuantizeToStep</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRectifyBeats" href="#note_seq.sequences_lib_test.SequencesLibTest.testRectifyBeats">testRectifyBeats</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantData" href="#note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantData">testRemoveRedundantData</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantDataOutOfOrder" href="#note_seq.sequences_lib_test.SequencesLibTest.testRemoveRedundantDataOutOfOrder">testRemoveRedundantDataOutOfOrder</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDuration" href="#note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDuration">testRepeatSequenceToDuration</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDurationProvidedDuration" href="#note_seq.sequences_lib_test.SequencesLibTest.testRepeatSequenceToDurationProvidedDuration">testRepeatSequenceToDurationProvidedDuration</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testRounding" href="#note_seq.sequences_lib_test.SequencesLibTest.testRounding">testRounding</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianoroll" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianoroll">testSequenceToPianoroll</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollActiveVelocities" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollActiveVelocities">testSequenceToPianorollActiveVelocities</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollControlChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollControlChanges">testSequenceToPianorollControlChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollFrameOccupancy" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollFrameOccupancy">testSequenceToPianorollFrameOccupancy</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsetVelocities" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsetVelocities">testSequenceToPianorollOnsetVelocities</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsets" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOnsets">testSequenceToPianorollOnsets</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOverlappingNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollOverlappingNotes">testSequenceToPianorollOverlappingNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollShortNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollShortNotes">testSequenceToPianorollShortNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWeightedRoll" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWeightedRoll">testSequenceToPianorollWeightedRoll</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffset" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffset">testSequenceToPianorollWithBlankFrameBeforeOffset</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder">testSequenceToPianorollWithBlankFrameBeforeOffsetOutOfOrder</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSequenceToValuedIntervals" href="#note_seq.sequences_lib_test.SequencesLibTest.testSequenceToValuedIntervals">testSequenceToValuedIntervals</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testShiftSequenceTimes" href="#note_seq.sequences_lib_test.SequencesLibTest.testShiftSequenceTimes">testShiftSequenceTimes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceAtTimes" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceAtTimes">testSplitNoteSequenceAtTimes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceCoincidentTimeChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceCoincidentTimeChanges">testSplitNoteSequenceCoincidentTimeChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceDuplicateTimeChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceDuplicateTimeChanges">testSplitNoteSequenceDuplicateTimeChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChanges">testSplitNoteSequenceMultipleTimeChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes">testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceNoTimeChanges" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceNoTimeChanges">testSplitNoteSequenceNoTimeChanges</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilence" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilence">testSplitNoteSequenceOnSilence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilenceInitialGap" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceOnSilenceInitialGap">testSplitNoteSequenceOnSilenceInitialGap</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceSkipSplitsInsideNotes" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceSkipSplitsInsideNotes">testSplitNoteSequenceSkipSplitsInsideNotes</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithHopSize" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithHopSize">testSplitNoteSequenceWithHopSize</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithStatelessEvents" href="#note_seq.sequences_lib_test.SequencesLibTest.testSplitNoteSequenceWithStatelessEvents">testSplitNoteSequenceWithStatelessEvents</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testStepsPerBar" href="#note_seq.sequences_lib_test.SequencesLibTest.testStepsPerBar">testStepsPerBar</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testStepsPerQuarterToStepsPerSecond" href="#note_seq.sequences_lib_test.SequencesLibTest.testStepsPerQuarterToStepsPerSecond">testStepsPerQuarterToStepsPerSecond</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testStretchNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testStretchNoteSequence">testStretchNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequence">testTransposeNoteSequence</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequenceOutOfRange" href="#note_seq.sequences_lib_test.SequencesLibTest.testTransposeNoteSequenceOutOfRange">testTransposeNoteSequenceOutOfRange</a></code></li>
+<li><code><a title="note_seq.sequences_lib_test.SequencesLibTest.testTrimNoteSequence" href="#note_seq.sequences_lib_test.SequencesLibTest.testTrimNoteSequence">testTrimNoteSequence</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/testing_lib.html
+++ b/docs/testing_lib.html
@@ -1,0 +1,735 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.testing_lib API documentation</title>
+<meta name="description" content="Testing support code." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.testing_lib</code></h1>
+</header>
+<section id="section-intro">
+<p>Testing support code.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+&#34;&#34;&#34;Testing support code.&#34;&#34;&#34;
+
+import os
+
+from absl.testing import absltest
+
+from note_seq import encoder_decoder
+from note_seq.protobuf import compare
+from note_seq.protobuf import music_pb2
+
+from google.protobuf import descriptor_pool
+from google.protobuf import text_format
+
+# Shortcut to text annotation types.
+BEAT = music_pb2.NoteSequence.TextAnnotation.BEAT
+CHORD_SYMBOL = music_pb2.NoteSequence.TextAnnotation.CHORD_SYMBOL
+
+
+def add_track_to_sequence(note_sequence,
+                          instrument,
+                          notes,
+                          is_drum=False,
+                          program=0):
+  &#34;&#34;&#34;Adds instrument track to NoteSequence.&#34;&#34;&#34;
+  for pitch, velocity, start_time, end_time in notes:
+    note = note_sequence.notes.add()
+    note.pitch = pitch
+    note.velocity = velocity
+    note.start_time = start_time
+    note.end_time = end_time
+    note.instrument = instrument
+    note.is_drum = is_drum
+    note.program = program
+    if end_time &gt; note_sequence.total_time:
+      note_sequence.total_time = end_time
+
+
+def add_chords_to_sequence(note_sequence, chords):
+  for figure, time in chords:
+    annotation = note_sequence.text_annotations.add()
+    annotation.time = time
+    annotation.text = figure
+    annotation.annotation_type = CHORD_SYMBOL
+
+
+def add_key_signatures_to_sequence(note_sequence, keys):
+  for key, time in keys:
+    ks = note_sequence.key_signatures.add()
+    ks.time = time
+    ks.key = key
+
+
+def add_beats_to_sequence(note_sequence, beats, beats_per_bar=None):
+  for i, time in enumerate(beats):
+    annotation = note_sequence.text_annotations.add()
+    annotation.time = time
+    annotation.annotation_type = BEAT
+    if beats_per_bar:
+      annotation.text = str((i % beats_per_bar) + 1)
+
+
+def add_control_changes_to_sequence(note_sequence, instrument, control_changes):
+  for time, control_number, control_value in control_changes:
+    control_change = note_sequence.control_changes.add()
+    control_change.time = time
+    control_change.control_number = control_number
+    control_change.control_value = control_value
+    control_change.instrument = instrument
+
+
+def add_pitch_bends_to_sequence(
+    note_sequence, instrument, program, pitch_bends):
+  for time, bend in pitch_bends:
+    pitch_bend = note_sequence.pitch_bends.add()
+    pitch_bend.time = time
+    pitch_bend.bend = bend
+    pitch_bend.program = program
+    pitch_bend.instrument = instrument
+    pitch_bend.is_drum = False  # Assume false for this test method.
+
+
+def add_quantized_steps_to_sequence(sequence, quantized_steps):
+  assert len(sequence.notes) == len(quantized_steps)
+
+  for note, quantized_step in zip(sequence.notes, quantized_steps):
+    note.quantized_start_step = quantized_step[0]
+    note.quantized_end_step = quantized_step[1]
+
+    if quantized_step[1] &gt; sequence.total_quantized_steps:
+      sequence.total_quantized_steps = quantized_step[1]
+
+
+def add_quantized_chord_steps_to_sequence(sequence, quantized_steps):
+  chord_annotations = [a for a in sequence.text_annotations
+                       if a.annotation_type == CHORD_SYMBOL]
+  assert len(chord_annotations) == len(quantized_steps)
+  for chord, quantized_step in zip(chord_annotations, quantized_steps):
+    chord.quantized_step = quantized_step
+
+
+def add_quantized_control_steps_to_sequence(sequence, quantized_steps):
+  assert len(sequence.control_changes) == len(quantized_steps)
+
+  for cc, quantized_step in zip(sequence.control_changes, quantized_steps):
+    cc.quantized_step = quantized_step
+
+
+class TrivialOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;One-hot encoding that uses the identity encoding.&#34;&#34;&#34;
+
+  def __init__(self, num_classes, num_steps=None):
+    if num_steps is not None and len(num_steps) != num_classes:
+      raise ValueError(&#39;num_steps must have length num_classes&#39;)
+    self._num_classes = num_classes
+    self._num_steps = num_steps
+
+  @property
+  def num_classes(self):
+    return self._num_classes
+
+  @property
+  def default_event(self):
+    return 0
+
+  def encode_event(self, event):
+    return event
+
+  def decode_event(self, index):
+    event = index
+    return event
+
+  def event_to_num_steps(self, event):
+    if self._num_steps is not None:
+      return self._num_steps[event]
+    else:
+      return 1
+
+
+def parse_test_proto(proto_type, proto_string):
+  instance = proto_type()
+  text_format.Parse(proto_string, instance)
+  return instance
+
+
+def get_testdata_dir():
+  dir_path = &#39;note_seq/testdata&#39;
+  return os.path.join(absltest.get_default_test_srcdir(), dir_path)
+
+
+class ProtoTestCase(absltest.TestCase):
+  &#34;&#34;&#34;Adds assertProtoEquals from tf.test.TestCase.&#34;&#34;&#34;
+
+  def setUp(self):
+    self.maxDiff = None  # pylint:disable=invalid-name
+    self.steps_per_quarter = 4
+    self.note_sequence = parse_test_proto(
+        music_pb2.NoteSequence, &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 60
+        }
+        &#34;&#34;&#34;)
+    super().setUp()
+
+  def _AssertProtoEquals(self, a, b, msg=None):  # pylint:disable=invalid-name
+    &#34;&#34;&#34;Asserts that a and b are the same proto.
+
+    Uses ProtoEq() first, as it returns correct results
+    for floating point attributes, and then use assertProtoEqual()
+    in case of failure as it provides good error messages.
+
+    Args:
+      a: a proto.
+      b: another proto.
+      msg: Optional message to report on failure.
+    &#34;&#34;&#34;
+    if not compare.ProtoEq(a, b):
+      compare.assertProtoEqual(self, a, b, normalize_numbers=True, msg=msg)
+
+  def assertProtoEquals(self, expected_message_maybe_ascii, message, msg=None):
+    &#34;&#34;&#34;Asserts that message is same as parsed expected_message_ascii.
+
+    Creates another prototype of message, reads the ascii message into it and
+    then compares them using self._AssertProtoEqual().
+
+    Args:
+      expected_message_maybe_ascii: proto message in original or ascii form.
+      message: the message to validate.
+      msg: Optional message to report on failure.
+    &#34;&#34;&#34;
+    msg = msg if msg else &#39;&#39;
+    if isinstance(expected_message_maybe_ascii, type(message)):
+      expected_message = expected_message_maybe_ascii
+      self._AssertProtoEquals(expected_message, message)
+    elif isinstance(expected_message_maybe_ascii, str):
+      expected_message = type(message)()
+      text_format.Parse(
+          expected_message_maybe_ascii,
+          expected_message,
+          descriptor_pool=descriptor_pool.Default())
+      self._AssertProtoEquals(expected_message, message, msg=msg)
+    else:
+      assert False, (&#34;Can&#39;t compare protos of type %s and %s. %s&#34; %
+                     (type(expected_message_maybe_ascii), type(message), msg))</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="note_seq.testing_lib.add_beats_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_beats_to_sequence</span></span>(<span>note_sequence, beats, beats_per_bar=None)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_beats_to_sequence(note_sequence, beats, beats_per_bar=None):
+  for i, time in enumerate(beats):
+    annotation = note_sequence.text_annotations.add()
+    annotation.time = time
+    annotation.annotation_type = BEAT
+    if beats_per_bar:
+      annotation.text = str((i % beats_per_bar) + 1)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_chords_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_chords_to_sequence</span></span>(<span>note_sequence, chords)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_chords_to_sequence(note_sequence, chords):
+  for figure, time in chords:
+    annotation = note_sequence.text_annotations.add()
+    annotation.time = time
+    annotation.text = figure
+    annotation.annotation_type = CHORD_SYMBOL</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_control_changes_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_control_changes_to_sequence</span></span>(<span>note_sequence, instrument, control_changes)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_control_changes_to_sequence(note_sequence, instrument, control_changes):
+  for time, control_number, control_value in control_changes:
+    control_change = note_sequence.control_changes.add()
+    control_change.time = time
+    control_change.control_number = control_number
+    control_change.control_value = control_value
+    control_change.instrument = instrument</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_key_signatures_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_key_signatures_to_sequence</span></span>(<span>note_sequence, keys)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_key_signatures_to_sequence(note_sequence, keys):
+  for key, time in keys:
+    ks = note_sequence.key_signatures.add()
+    ks.time = time
+    ks.key = key</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_pitch_bends_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_pitch_bends_to_sequence</span></span>(<span>note_sequence, instrument, program, pitch_bends)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_pitch_bends_to_sequence(
+    note_sequence, instrument, program, pitch_bends):
+  for time, bend in pitch_bends:
+    pitch_bend = note_sequence.pitch_bends.add()
+    pitch_bend.time = time
+    pitch_bend.bend = bend
+    pitch_bend.program = program
+    pitch_bend.instrument = instrument
+    pitch_bend.is_drum = False  # Assume false for this test method.</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_quantized_chord_steps_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_quantized_chord_steps_to_sequence</span></span>(<span>sequence, quantized_steps)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_quantized_chord_steps_to_sequence(sequence, quantized_steps):
+  chord_annotations = [a for a in sequence.text_annotations
+                       if a.annotation_type == CHORD_SYMBOL]
+  assert len(chord_annotations) == len(quantized_steps)
+  for chord, quantized_step in zip(chord_annotations, quantized_steps):
+    chord.quantized_step = quantized_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_quantized_control_steps_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_quantized_control_steps_to_sequence</span></span>(<span>sequence, quantized_steps)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_quantized_control_steps_to_sequence(sequence, quantized_steps):
+  assert len(sequence.control_changes) == len(quantized_steps)
+
+  for cc, quantized_step in zip(sequence.control_changes, quantized_steps):
+    cc.quantized_step = quantized_step</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_quantized_steps_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_quantized_steps_to_sequence</span></span>(<span>sequence, quantized_steps)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_quantized_steps_to_sequence(sequence, quantized_steps):
+  assert len(sequence.notes) == len(quantized_steps)
+
+  for note, quantized_step in zip(sequence.notes, quantized_steps):
+    note.quantized_start_step = quantized_step[0]
+    note.quantized_end_step = quantized_step[1]
+
+    if quantized_step[1] &gt; sequence.total_quantized_steps:
+      sequence.total_quantized_steps = quantized_step[1]</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.add_track_to_sequence"><code class="name flex">
+<span>def <span class="ident">add_track_to_sequence</span></span>(<span>note_sequence, instrument, notes, is_drum=False, program=0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds instrument track to NoteSequence.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_track_to_sequence(note_sequence,
+                          instrument,
+                          notes,
+                          is_drum=False,
+                          program=0):
+  &#34;&#34;&#34;Adds instrument track to NoteSequence.&#34;&#34;&#34;
+  for pitch, velocity, start_time, end_time in notes:
+    note = note_sequence.notes.add()
+    note.pitch = pitch
+    note.velocity = velocity
+    note.start_time = start_time
+    note.end_time = end_time
+    note.instrument = instrument
+    note.is_drum = is_drum
+    note.program = program
+    if end_time &gt; note_sequence.total_time:
+      note_sequence.total_time = end_time</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.get_testdata_dir"><code class="name flex">
+<span>def <span class="ident">get_testdata_dir</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_testdata_dir():
+  dir_path = &#39;note_seq/testdata&#39;
+  return os.path.join(absltest.get_default_test_srcdir(), dir_path)</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.parse_test_proto"><code class="name flex">
+<span>def <span class="ident">parse_test_proto</span></span>(<span>proto_type, proto_string)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def parse_test_proto(proto_type, proto_string):
+  instance = proto_type()
+  text_format.Parse(proto_string, instance)
+  return instance</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="note_seq.testing_lib.ProtoTestCase"><code class="flex name class">
+<span>class <span class="ident">ProtoTestCase</span></span>
+<span>(</span><span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Adds assertProtoEquals from tf.test.TestCase.</p>
+<p>Create an instance of the class that will use the named test
+method when executed. Raises a ValueError if the instance does
+not have a method with the specified name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ProtoTestCase(absltest.TestCase):
+  &#34;&#34;&#34;Adds assertProtoEquals from tf.test.TestCase.&#34;&#34;&#34;
+
+  def setUp(self):
+    self.maxDiff = None  # pylint:disable=invalid-name
+    self.steps_per_quarter = 4
+    self.note_sequence = parse_test_proto(
+        music_pb2.NoteSequence, &#34;&#34;&#34;
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 60
+        }
+        &#34;&#34;&#34;)
+    super().setUp()
+
+  def _AssertProtoEquals(self, a, b, msg=None):  # pylint:disable=invalid-name
+    &#34;&#34;&#34;Asserts that a and b are the same proto.
+
+    Uses ProtoEq() first, as it returns correct results
+    for floating point attributes, and then use assertProtoEqual()
+    in case of failure as it provides good error messages.
+
+    Args:
+      a: a proto.
+      b: another proto.
+      msg: Optional message to report on failure.
+    &#34;&#34;&#34;
+    if not compare.ProtoEq(a, b):
+      compare.assertProtoEqual(self, a, b, normalize_numbers=True, msg=msg)
+
+  def assertProtoEquals(self, expected_message_maybe_ascii, message, msg=None):
+    &#34;&#34;&#34;Asserts that message is same as parsed expected_message_ascii.
+
+    Creates another prototype of message, reads the ascii message into it and
+    then compares them using self._AssertProtoEqual().
+
+    Args:
+      expected_message_maybe_ascii: proto message in original or ascii form.
+      message: the message to validate.
+      msg: Optional message to report on failure.
+    &#34;&#34;&#34;
+    msg = msg if msg else &#39;&#39;
+    if isinstance(expected_message_maybe_ascii, type(message)):
+      expected_message = expected_message_maybe_ascii
+      self._AssertProtoEquals(expected_message, message)
+    elif isinstance(expected_message_maybe_ascii, str):
+      expected_message = type(message)()
+      text_format.Parse(
+          expected_message_maybe_ascii,
+          expected_message,
+          descriptor_pool=descriptor_pool.Default())
+      self._AssertProtoEquals(expected_message, message, msg=msg)
+    else:
+      assert False, (&#34;Can&#39;t compare protos of type %s and %s. %s&#34; %
+                     (type(expected_message_maybe_ascii), type(message), msg))</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>absl.testing.absltest.TestCase</li>
+<li>absl.third_party.unittest3_backport.case.TestCase</li>
+<li>unittest.case.TestCase</li>
+</ul>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="note_seq.abc_parser_test.AbcParserTest" href="abc_parser_test.html#note_seq.abc_parser_test.AbcParserTest">AbcParserTest</a></li>
+<li><a title="note_seq.chords_lib_test.ChordsLibTest" href="chords_lib_test.html#note_seq.chords_lib_test.ChordsLibTest">ChordsLibTest</a></li>
+<li><a title="note_seq.drums_lib_test.DrumsLibTest" href="drums_lib_test.html#note_seq.drums_lib_test.DrumsLibTest">DrumsLibTest</a></li>
+<li><a title="note_seq.lead_sheets_lib_test.LeadSheetsLibTest" href="lead_sheets_lib_test.html#note_seq.lead_sheets_lib_test.LeadSheetsLibTest">LeadSheetsLibTest</a></li>
+<li><a title="note_seq.melodies_lib_test.MelodiesLibTest" href="melodies_lib_test.html#note_seq.melodies_lib_test.MelodiesLibTest">MelodiesLibTest</a></li>
+<li><a title="note_seq.musicxml_parser_test.MusicXMLParserTest" href="musicxml_parser_test.html#note_seq.musicxml_parser_test.MusicXMLParserTest">MusicXMLParserTest</a></li>
+<li><a title="note_seq.sequences_lib_test.SequencesLibTest" href="sequences_lib_test.html#note_seq.sequences_lib_test.SequencesLibTest">SequencesLibTest</a></li>
+</ul>
+<h3>Methods</h3>
+<dl>
+<dt id="note_seq.testing_lib.ProtoTestCase.assertProtoEquals"><code class="name flex">
+<span>def <span class="ident">assertProtoEquals</span></span>(<span>self, expected_message_maybe_ascii, message, msg=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Asserts that message is same as parsed expected_message_ascii.</p>
+<p>Creates another prototype of message, reads the ascii message into it and
+then compares them using self._AssertProtoEqual().</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>expected_message_maybe_ascii</code></strong></dt>
+<dd>proto message in original or ascii form.</dd>
+<dt><strong><code>message</code></strong></dt>
+<dd>the message to validate.</dd>
+<dt><strong><code>msg</code></strong></dt>
+<dd>Optional message to report on failure.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def assertProtoEquals(self, expected_message_maybe_ascii, message, msg=None):
+  &#34;&#34;&#34;Asserts that message is same as parsed expected_message_ascii.
+
+  Creates another prototype of message, reads the ascii message into it and
+  then compares them using self._AssertProtoEqual().
+
+  Args:
+    expected_message_maybe_ascii: proto message in original or ascii form.
+    message: the message to validate.
+    msg: Optional message to report on failure.
+  &#34;&#34;&#34;
+  msg = msg if msg else &#39;&#39;
+  if isinstance(expected_message_maybe_ascii, type(message)):
+    expected_message = expected_message_maybe_ascii
+    self._AssertProtoEquals(expected_message, message)
+  elif isinstance(expected_message_maybe_ascii, str):
+    expected_message = type(message)()
+    text_format.Parse(
+        expected_message_maybe_ascii,
+        expected_message,
+        descriptor_pool=descriptor_pool.Default())
+    self._AssertProtoEquals(expected_message, message, msg=msg)
+  else:
+    assert False, (&#34;Can&#39;t compare protos of type %s and %s. %s&#34; %
+                   (type(expected_message_maybe_ascii), type(message), msg))</code></pre>
+</details>
+</dd>
+<dt id="note_seq.testing_lib.ProtoTestCase.setUp"><code class="name flex">
+<span>def <span class="ident">setUp</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Hook method for setting up the test fixture before exercising it.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setUp(self):
+  self.maxDiff = None  # pylint:disable=invalid-name
+  self.steps_per_quarter = 4
+  self.note_sequence = parse_test_proto(
+      music_pb2.NoteSequence, &#34;&#34;&#34;
+      time_signatures: {
+        numerator: 4
+        denominator: 4
+      }
+      tempos: {
+        qpm: 60
+      }
+      &#34;&#34;&#34;)
+  super().setUp()</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="note_seq.testing_lib.TrivialOneHotEncoding"><code class="flex name class">
+<span>class <span class="ident">TrivialOneHotEncoding</span></span>
+<span>(</span><span>num_classes, num_steps=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>One-hot encoding that uses the identity encoding.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TrivialOneHotEncoding(encoder_decoder.OneHotEncoding):
+  &#34;&#34;&#34;One-hot encoding that uses the identity encoding.&#34;&#34;&#34;
+
+  def __init__(self, num_classes, num_steps=None):
+    if num_steps is not None and len(num_steps) != num_classes:
+      raise ValueError(&#39;num_steps must have length num_classes&#39;)
+    self._num_classes = num_classes
+    self._num_steps = num_steps
+
+  @property
+  def num_classes(self):
+    return self._num_classes
+
+  @property
+  def default_event(self):
+    return 0
+
+  def encode_event(self, event):
+    return event
+
+  def decode_event(self, index):
+    event = index
+    return event
+
+  def event_to_num_steps(self, event):
+    if self._num_steps is not None:
+      return self._num_steps[event]
+    else:
+      return 1</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="note_seq.encoder_decoder.OneHotEncoding" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding">OneHotEncoding</a></b></code>:
+<ul class="hlist">
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.decode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.decode_event">decode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.default_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.default_event">default_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.encode_event" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.encode_event">encode_event</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.event_to_num_steps">event_to_num_steps</a></code></li>
+<li><code><a title="note_seq.encoder_decoder.OneHotEncoding.num_classes" href="encoder_decoder.html#note_seq.encoder_decoder.OneHotEncoding.num_classes">num_classes</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="note_seq.testing_lib.add_beats_to_sequence" href="#note_seq.testing_lib.add_beats_to_sequence">add_beats_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_chords_to_sequence" href="#note_seq.testing_lib.add_chords_to_sequence">add_chords_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_control_changes_to_sequence" href="#note_seq.testing_lib.add_control_changes_to_sequence">add_control_changes_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_key_signatures_to_sequence" href="#note_seq.testing_lib.add_key_signatures_to_sequence">add_key_signatures_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_pitch_bends_to_sequence" href="#note_seq.testing_lib.add_pitch_bends_to_sequence">add_pitch_bends_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_quantized_chord_steps_to_sequence" href="#note_seq.testing_lib.add_quantized_chord_steps_to_sequence">add_quantized_chord_steps_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_quantized_control_steps_to_sequence" href="#note_seq.testing_lib.add_quantized_control_steps_to_sequence">add_quantized_control_steps_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_quantized_steps_to_sequence" href="#note_seq.testing_lib.add_quantized_steps_to_sequence">add_quantized_steps_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.add_track_to_sequence" href="#note_seq.testing_lib.add_track_to_sequence">add_track_to_sequence</a></code></li>
+<li><code><a title="note_seq.testing_lib.get_testdata_dir" href="#note_seq.testing_lib.get_testdata_dir">get_testdata_dir</a></code></li>
+<li><code><a title="note_seq.testing_lib.parse_test_proto" href="#note_seq.testing_lib.parse_test_proto">parse_test_proto</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="note_seq.testing_lib.ProtoTestCase" href="#note_seq.testing_lib.ProtoTestCase">ProtoTestCase</a></code></h4>
+<ul class="">
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.assertProtoEquals" href="#note_seq.testing_lib.ProtoTestCase.assertProtoEquals">assertProtoEquals</a></code></li>
+<li><code><a title="note_seq.testing_lib.ProtoTestCase.setUp" href="#note_seq.testing_lib.ProtoTestCase.setUp">setUp</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="note_seq.testing_lib.TrivialOneHotEncoding" href="#note_seq.testing_lib.TrivialOneHotEncoding">TrivialOneHotEncoding</a></code></h4>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/version.html
+++ b/docs/version.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>note_seq.version API documentation</title>
+<meta name="description" content="Separate file for storing the current version of note-seq …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>note_seq.version</code></h1>
+</header>
+<section id="section-intro">
+<p>Separate file for storing the current version of note-seq.</p>
+<p>Stored in a separate file so that setup.py can reference the version without
+pulling in all the dependencies in <strong>init</strong>.py.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python"># Copyright 2021 The Magenta Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+r&#34;&#34;&#34;Separate file for storing the current version of note-seq.
+
+Stored in a separate file so that setup.py can reference the version without
+pulling in all the dependencies in __init__.py.
+&#34;&#34;&#34;
+
+__version__ = &#34;0.0.3&#34;</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="note_seq" href="index.html">note_seq</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Some quick-n-dirty documentation addressing #15 

These doc files were generated automatically from existing docstrings using [pdoc3](https://pdoc3.github.io/pdoc/). It does a pretty good job of parsing most things, and huge shoutout to the maintainers for keeping crisp, clean docstrings, but it cannot catch everything. In particular, I've omitted everything under `note_seq/alignment`. These files are not generated automatically, but if you'd like, we can discuss additional infrastructure to do so.

This is certainly not a long-term solution, but a quick fix so users don't have to go digging in source to read the docs. For convenience, I've also tossed the files here, where they can be browsed: https://wlt.coffee/cream/docs/note_seq/

Ideally, we would have a proper readthedocs site, but that would be a much longer, time-consuming project. In the meanwhile, I hope people find this useful!