### PR TITLE
bokeh compatibility fix

### DIFF
--- a/note_seq/notebook_utils.py
+++ b/note_seq/notebook_utils.py
@@ -143,8 +143,8 @@ def plot_sequence(sequence, show_figure=True):
   # by updating the figure if need be.
   fig = bokeh.plotting.figure(
       tools='hover,pan,box_zoom,reset,save')
-  fig.plot_width = 500
-  fig.plot_height = 200
+  fig.width = 500
+  fig.height = 200
   fig.xaxis.axis_label = 'time (sec)'
   fig.yaxis.axis_label = 'pitch (MIDI)'
   fig.yaxis.ticker = bokeh.models.SingleIntervalTicker(interval=12)


### PR DESCRIPTION
Current implementation gives error `AttributeError: unexpected attribute 'plot_width' to figure, similar attributes are outer_width, width or min_width` when calling `notebook_utils.plot_sequence`.

 As described in [this stackoverflow question](https://stackoverflow.com/a/74341247): 

> In the 3.0.0 bokeh release, the `plot_width` attribute of a figure was replaced with `width`. Similarly, `plot_height` was replaced with `height`. Even in the last [2.x.x release docs](https://docs.bokeh.org/en/2.4.3/docs/reference/plotting/figure.html?highlight=plot_width), they are described as "compatibility aliases" for `width` and `height`.

This pull request fixes this issue by following the stackover flow answer mentioned above. Specifically, it

- changed `plot_width` to `width`
- changed `plot_height` to `height`